### PR TITLE
l10n: Set the description to "System Restore Utility"

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,7 @@ Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, rsync
 #Recommends:
 Replaces: timeshift-btrfs
-Description: System restore utility for Linux
+Description: System restore utility
  Timeshift is a system restore utility which takes snapshots
  of the system at regular intervals. These snapshots can be restored
  at a later date to undo system changes. Creates incremental snapshots

--- a/src/Gtk/MainWindow.vala
+++ b/src/Gtk/MainWindow.vala
@@ -991,7 +991,7 @@ class MainWindow : Gtk.Window{
 		};
 
 		dialog.program_name = AppName;
-		dialog.comments = _("System Restore Utility for Linux");
+		dialog.comments = _("System Restore Utility");
 		dialog.copyright = "Copyright © 2016 Tony George (%s)".printf(AppAuthorEmail);
 		dialog.version = AppVersion;
 		dialog.logo = get_app_icon(128);

--- a/timeshift.pot
+++ b/timeshift.pot
@@ -2172,7 +2172,7 @@ msgid "System"
 msgstr ""
 
 #: Gtk/MainWindow.vala:994
-msgid "System Restore Utility for Linux"
+msgid "System Restore Utility"
 msgstr ""
 
 #: Gtk/FinishBox.vala:81


### PR DESCRIPTION
The first reason for this change is to make the description in the about dialog
match the GenericName and comment string in the /usr/share/applications/.desktop
file. We want these to match because we'll need that string in the POT file
to have it translated in Launchpad. This will ensure we'll be able to generate
a fully translated .desktop file in the near future.

The second reason for the change is that "for Linux" is redundant and not
relevant to users. Timeshift is a great app name, "System Restore Utility" a great
comment, it's explicit and clear in the app menu, but "for Linux" brings nothing
extra.