### PR TITLE
Titlebar: Don't specify the version number

### DIFF
--- a/src/Gtk/MainWindow.vala
+++ b/src/Gtk/MainWindow.vala
@@ -70,7 +70,7 @@ class MainWindow : Gtk.Window{
 
 		log_debug("MainWindow: MainWindow()");
 		
-		this.title = AppName + " v" + AppVersion;
+		this.title = AppName;
         this.window_position = WindowPosition.CENTER;
         this.modal = true;
         this.set_default_size (def_width, def_height);


### PR DESCRIPTION
Keep the titlebar clean.

Users look for version numbers when troubleshooting. As such it is important
for them to be able to find that version number in About dialogs or from
the command line. Timeshift honors both scenarii already.