### PR TITLE
Remove gksu from timeshift-launcher

### DIFF
--- a/src/timeshift-launcher
+++ b/src/timeshift-launcher
@@ -17,8 +17,6 @@ else
 			sudo ${app_command}
 			xhost -SI:localuser:root
 			xhost
-		elif command -v gksu >/dev/null 2>&1; then
-			gksu ${app_command}
 		elif command -v pkexec >/dev/null 2>&1; then
 			pkexec env DISPLAY=$DISPLAY XAUTHORITY=$XAUTHORITY ${app_command}
 		elif command -v sudo >/dev/null 2>&1; then


### PR DESCRIPTION
Because gksu is obsolete and is not recommended for security reasons, it's better to run the program with pkexec