### PR TITLE
Use /usr/share/metainfo for AppData file

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -61,7 +61,7 @@ install:
 	mkdir -p "$(DESTDIR)$(sysconfdir)/default"
 	mkdir -p "$(DESTDIR)$(sharedir)/${app_name}"
 	mkdir -p "$(DESTDIR)$(sharedir)/icons"
-	mkdir -p "$(DESTDIR)$(sharedir)/appdata"
+	mkdir -p "$(DESTDIR)$(sharedir)/metainfo"
 
 	# binary
 	install -m 0755 ${app_name} "$(DESTDIR)$(bindir)"
@@ -88,7 +88,7 @@ install:
 	chmod --recursive 0644 $(DESTDIR)$(sharedir)/icons/hicolor/*/apps/${app_name}.png
 
 	# appdata
-	install -m 0644 ../debian/${app_name}.appdata.xml "$(DESTDIR)$(sharedir)/appdata"
+	install -m 0644 ../debian/${app_name}.appdata.xml "$(DESTDIR)$(sharedir)/metainfo"
 
 	# translations
 	for lang in am ar az bg ca cs da de el en_GB es et eu fr he hi hr hu ia id is it ko lt nb ne nl pl pt pt_BR ro ru sk sr sv tr uk vi zh_CN; do \
@@ -120,4 +120,4 @@ uninstall:
 	rm -f $(DESTDIR)$(localedir)/*/LC_MESSAGES/${app_name}.mo
 
 	# appdata
-	rm -f "$(DESTDIR)$(sharedir)/appdata/${app_name}.appdata.xml"
+	rm -f "$(DESTDIR)$(sharedir)/metainfo/${app_name}.appdata.xml"


### PR DESCRIPTION
/usr/share/appdata is deprecated by the freedesktop.org specifications.

https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#sect-Metadata-GenericComponent