### PR TITLE
Exclude /swapfile by default

### DIFF
--- a/src/Core/Main.vala
+++ b/src/Core/Main.vala
@@ -554,6 +554,7 @@ public class Main : GLib.Object{
 		exclude_list_default.add("/etc/timeshift.json");
 		exclude_list_default.add("/var/log/timeshift/*");
 		exclude_list_default.add("/var/log/timeshift-btrfs/*");
+		exclude_list_default.add("/swapfile");
 		
 		exclude_list_default.add("/root/.thumbnails");
 		exclude_list_default.add("/root/.cache");


### PR DESCRIPTION
Ubuntu 18.04 and Mint 19.x now default to using SWAP files
as opposed to SWAP partitions by default.

The swap file can be very large and doesn't need to be included
in snapshots by default.