### PR TITLE
Fix typo in BTRFS radio tooltip

### DIFF
--- a/src/Gtk/SnapshotBackendBox.vala
+++ b/src/Gtk/SnapshotBackendBox.vala
@@ -92,7 +92,7 @@ class SnapshotBackendBox : Gtk.Box{
 	private void add_opt_btrfs(Gtk.Box hbox){
 
 		var opt = new RadioButton.with_label_from_widget(opt_rsync, _("BTRFS"));
-		opt.set_tooltip_markup(_("Create snapshots using RSYNC"));
+		opt.set_tooltip_markup(_("Create snapshots using BTRFS"));
 		hbox.add (opt);
 		opt_btrfs = opt;
 


### PR DESCRIPTION
It might be wrong, please close the PR if this is the case.

This looked like a typo. When choosing the backend between RSYNC and BTRFS in the first step of the wizard, hovering BTRFS said "Create snapshots using RSYNC".