### PR TITLE
Fix typo in en_GB translation

### DIFF
--- a/po/timeshift-en_GB.po
+++ b/po/timeshift-en_GB.po
@@ -850,7 +850,7 @@ msgstr "Examples"
 
 #: Gtk/UsersBox.vala:136
 msgid "Exclude All"
-msgstr "Exclude Apps"
+msgstr "Exclude All"
 
 #: Gtk/RestoreExcludeBox.vala:55 Gtk/ExcludeAppsBox.vala:51
 msgid "Exclude Application Settings"


### PR DESCRIPTION
This fixes a typo in the translation.