### PR TITLE
Merge and update translations from Launchpad

### DIFF
--- a/merge-launchpad-translations.sh
+++ b/merge-launchpad-translations.sh
@@ -6,7 +6,7 @@ cd "$DIR"
 
 . ./BUILD_CONFIG
 
-languages="am ar az bg ca cs da de el en_GB es et eu fi fr he hi hr hu ia id is it ko lt nb ne nl pl pt pt_BR ro ru sk sr sv tr uk vi zh_CN"
+languages="am ar az bg ca ca@valencia cs da de el en_GB es et eu fi fr he hi hr hu ia id is it ko lt nb ne nl pl pt pt_BR ro ru sk sr sv tr uk vi zh_CN zh_TW"
 
 echo ""
 echo "=========================================================================="
@@ -17,9 +17,7 @@ echo ""
 for lang in $languages; do
 	# remove headers in po-lp/*.po so that msgcat does not create malformed headers
 	sed -i '/^#/d' po-lp/${app_name}-$lang.po
-	msgcat -o po/${app_name}-$lang.po po-lp/${app_name}-$lang.po po/${app_name}-$lang.po
-	sed -i '/#-#-#-#-#/d' po/${app_name}-$lang.po
-	sed -i '/#, fuzzy/d' po/${app_name}-$lang.po
+	msgcat -o po/${app_name}-$lang.po po-lp/${app_name}-$lang.po po/${app_name}-$lang.po --use-first
 done
 
 echo ""

--- a/po/timeshift-am.po
+++ b/po/timeshift-am.po
@@ -1,24 +1,17 @@
-# Amharic translation for linuxmint
-# Copyright (c) 2017 Rosetta Contributors and Canonical Ltd 2017
-# This file is distributed under the same license as the linuxmint package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
-"PO-Revision-Date: 2017-11-22 15:09+0000\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
+"PO-Revision-Date: 2018-02-05 15:44+0000\n"
 "Last-Translator: samson <Unknown>\n"
 "Language-Team: Amharic <am@li.org>\n"
 "Language: am\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:01+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -212,12 +205,6 @@ msgstr "ደራሲዎች"
 msgid "Available"
 msgstr "ዝግጁ"
 
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
-
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr "BTRFS"
@@ -233,6 +220,13 @@ msgstr "የ BTRFS መሳሪያዎች አልተገኙም"
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
 msgstr "የ BTRFS አካሎች አልተጫኑም"
+
+#: Gtk/BackupDeviceBox.vala:98
+#, fuzzy
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
+msgstr "ሌሎች መተግበሪያዎች (የሚቀጥለው ገጽ)"
 
 #: Gtk/FinishBox.vala:92
 msgid ""
@@ -1230,11 +1224,11 @@ msgstr ""
 
 #: Gtk/RestoreDeviceBox.vala:244
 msgid "Keep on Root Device"
-msgstr ""
+msgstr "በ Root አካል ላይ ማስቀመጫ"
 
 #: Gtk/RestoreDeviceBox.vala:229
 msgid "Keep this mount path on the root filesystem"
-msgstr ""
+msgstr "ይህን የ መጫኛ መንገድ በ root ፋይል ስርአት ላይ ማስቀመጫ"
 
 #: Gtk/SnapshotListBox.vala:519
 msgid "LIVE"
@@ -2674,35 +2668,6 @@ msgstr "rsync ስህተት መልሷል"
 msgid "un-tagged"
 msgstr "ምልክት-ያልተደረገበት"
 
-#, fuzzy
-#~ msgid "Click to edit and drag-drop to re-order"
-#~ msgstr "ይጫኑ ለ ማረም: ይጎትቱ እና ይጣሉ እንደገና-ለማሰናዳት"
-
-#~ msgid ""
-#~ "Click an item to edit the pattern.\n"
-#~ "Drag and drop items with mouse to re-order."
-#~ msgstr ""
-#~ "ይጫኑ እቃ ላይ ለ ማረም አቀራረቡን\n"
-#~ "እቃዎችን ይጎትቱ እና ይጣሉ በ አይጥ እንደገና-ለማዘጋጀት"
-
-#~ msgid "Editing and Re-Ordering"
-#~ msgstr "ማረሚያ እና እንደገና-ማዘጋጃ"
-
-#~ msgid "Info"
-#~ msgstr "መረጃ"
-
-#~ msgid "Deleted system subvolumes"
-#~ msgstr "የ ስርአት ንዑስ መጠን ማጥፊያ"
-
-#~ msgid "<b>System:</b> Installed Linux distribution"
-#~ msgstr "<b>ስርአት:</b> የ ሊነክስ ስርጭት ተገጥሟል"
-
-#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
-#~ msgstr "<b>መመልከቻ ፎቶ የተነሳበት ቀን:</b> የ መመልከቻ ፎቶ የ ተፈጠረበት ቀን"
-
-#~ msgid "Selected snapshot path"
-#~ msgstr "የ ተመረጠው የ መመልከቻ ፎቶ መንገድ"
-
 #~ msgid ""
 #~ "<b>Backup Levels</b>\n"
 #~ "\n"
@@ -2722,6 +2687,19 @@ msgstr "ምልክት-ያልተደረገበት"
 #~ "W\tበየ ሳምንቱ\n"
 #~ "M\tበየ ወሩ"
 
+#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
+#~ msgstr "<b>መመልከቻ ፎቶ የተነሳበት ቀን:</b> የ መመልከቻ ፎቶ የ ተፈጠረበት ቀን"
+
+#~ msgid "<b>System:</b> Installed Linux distribution"
+#~ msgstr "<b>ስርአት:</b> የ ሊነክስ ስርጭት ተገጥሟል"
+
+#~ msgid ""
+#~ "Click an item to edit the pattern.\n"
+#~ "Drag and drop items with mouse to re-order."
+#~ msgstr ""
+#~ "ይጫኑ እቃ ላይ ለ ማረም አቀራረቡን\n"
+#~ "እቃዎችን ይጎትቱ እና ይጣሉ በ አይጥ እንደገና-ለማዘጋጀት"
+
 #~ msgid "Cloning System..."
 #~ msgstr "ስርአቱን በ ማባዛት ላይ..."
 
@@ -2731,14 +2709,26 @@ msgstr "ምልክት-ያልተደረገበት"
 #~ msgid "Contributions"
 #~ msgstr "አበርካቾች"
 
+#~ msgid "Create snapshots using RSYNC"
+#~ msgstr "የ መመልከቻ ፎቶ መፍጠሪያ RSYNC በ መጠቀም"
+
+#~ msgid "Deleted system subvolumes"
+#~ msgstr "የ ስርአት ንዑስ መጠን ማጥፊያ"
+
 #~ msgid "Documenters"
 #~ msgstr "አዘጋጆች"
+
+#~ msgid "Editing and Re-Ordering"
+#~ msgstr "ማረሚያ እና እንደገና-ማዘጋጃ"
 
 #~ msgid "Include everything"
 #~ msgstr "ሁሉንም ማካተቻ"
 
 #~ msgid "Include hidden items"
 #~ msgstr "የ ተደበቁ አካሎችን ማካተቻ"
+
+#~ msgid "Info"
+#~ msgstr "መረጃ"
 
 #~ msgid "Log Viewer"
 #~ msgstr "መግቢያ መመልከቻ"
@@ -2748,6 +2738,9 @@ msgstr "ምልክት-ያልተደረገበት"
 
 #~ msgid "Scheduled task runs once every hour"
 #~ msgstr "የታቀደው ስራ በየ ሰአቱ እየሄደ ነው"
+
+#~ msgid "Selected snapshot path"
+#~ msgstr "የ ተመረጠው የ መመልከቻ ፎቶ መንገድ"
 
 #~ msgid "Third Party Tools"
 #~ msgstr "የ ሶስተኛ አካል መሳሪያዎች"
@@ -2763,6 +2756,10 @@ msgstr "ምልክት-ያልተደረገበት"
 
 #~ msgid "View:"
 #~ msgstr "መመልከቻ:"
+
+#, fuzzy
+#~ msgid "Click to edit and drag-drop to re-order"
+#~ msgstr "ይጫኑ ለ ማረም: ይጎትቱ እና ይጣሉ እንደገና-ለማሰናዳት"
 
 #~ msgid "Change"
 #~ msgstr "ተቀይሯል"

--- a/po/timeshift-ar.po
+++ b/po/timeshift-ar.po
@@ -1,24 +1,17 @@
-# Arabic translation for linuxmint
-# Copyright (c) 2017 Rosetta Contributors and Canonical Ltd 2017
-# This file is distributed under the same license as the linuxmint package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-#
 msgid ""
 msgstr ""
-"Project-Id-Version: linuxmint\n"
+"Project-Id-Version: timeshift 1.6\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
-"PO-Revision-Date: 2017-10-06 14:06+0000\n"
-"Last-Translator: ismail belli <Unknown>\n"
-"Language-Team: Arabic <ar@li.org>\n"
-"Language: ar\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
+"PO-Revision-Date: 2018-04-10 15:34+0000\n"
+"Last-Translator: انور الاسكندرانى <Unknown>\n"
+"Language-Team: anwar AL_iskandrany <anwareleskndrany13@gmail.com>\n"
+"Language: ar_EG\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:01+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -26,49 +19,51 @@ msgid ""
 "\n"
 "Press ENTER to continue..."
 msgstr ""
+"\n"
+"إضغط مفتاح ENTER للمتابعة..."
 
 #: Core/SnapshotRepo.vala:641
 #, c-format
 msgid "%d snapshots, %s free"
-msgstr ""
+msgstr "اللقطات %d، الحرة %s"
 
 #: Console/AppConsole.vala:914
 #, c-format
 msgid "'%s' will be on '%s'"
-msgstr ""
+msgstr "سيكون '%s' على '%s'"
 
 #: Console/AppConsole.vala:911
 #, c-format
 msgid "'%s' will be on root device"
-msgstr ""
+msgstr "سيكون '%s' على جهاز الجذر"
 
 #: Gtk/BootOptionsBox.vala:118
 msgid "(Re)install GRUB2 on:"
-msgstr ""
+msgstr "(إعادة)تثبيت GRUB2 على:"
 
 #: Core/Main.vala:362
 msgid "** Uninstalled Timeshift BTRFS **"
-msgstr ""
+msgstr "** إلغاء تثبيت Timeshift BTRFS **"
 
 #: Core/Main.vala:3342
 msgid "/ is mapped to device"
-msgstr ""
+msgstr "/ تم تعيينه على الجهاز"
 
 #: Core/Main.vala:3364
 msgid "/boot is mapped to device"
-msgstr ""
+msgstr "/يتم تعيين التمهيد إلى الجهاز"
 
 #: Core/Main.vala:3375
 msgid "/boot/efi is mapped to device"
-msgstr ""
+msgstr "/التمهيد/efi يتم تعيينه إلى جهاز"
 
 #: Core/Main.vala:3353
 msgid "/home is mapped to device"
-msgstr ""
+msgstr "/يتم تعيين المجلد الرئيسي إلى الجهاز"
 
 #: Gtk/SnapshotListBox.vala:290
 msgid "<b>Comments</b> (double-click to edit)"
-msgstr ""
+msgstr "<b>التعليقات</b> (انقر نقراً مزدوجاً للتحرير)"
 
 #: Gtk/ScheduleBox.vala:168
 msgid ""
@@ -80,11 +75,11 @@ msgstr ""
 #: Console/AppConsole.vala:1034 Console/AppConsole.vala:1075
 #: Console/AppConsole.vala:1093
 msgid "Aborted."
-msgstr "تم اجهاضه"
+msgstr "إجهاض"
 
 #: Gtk/MainWindow.vala:393
 msgid "About"
-msgstr "حول البرنامج"
+msgstr "حول"
 
 #: Gtk/RsyncLogBox.vala:472
 msgid "Action"
@@ -108,7 +103,7 @@ msgstr "إضافة نمط مخصص"
 
 #: Gtk/ExcludeBox.vala:239
 msgid "Add directories"
-msgstr ""
+msgstr "إضافة دلائل"
 
 #: Gtk/ExcludeBox.vala:233
 msgid "Add files"
@@ -116,19 +111,19 @@ msgstr "إضافة ملفات"
 
 #: Console/AppConsole.vala:360
 msgid "Add tags to snapshot (default: O)"
-msgstr ""
+msgstr "إضافة علامات إلى اللقطة (افتراضي: O)"
 
 #: Utility/CronTab.vala:312
 msgid "Added cron task"
-msgstr ""
+msgstr "مهمة cron المضافة"
 
 #: Gtk/AppGtk.vala:131
 msgid "Admin Access Required"
-msgstr ""
+msgstr "مطلوب وصول مسؤول"
 
 #: Gtk/AppGtk.vala:126
 msgid "Admin access is required to backup and restore system files."
-msgstr ""
+msgstr "مطلوب وصول المسئول للنسخ الاحتياطي واستعادة ملفات النظام."
 
 #: Gtk/RsyncLogBox.vala:363
 msgid "All Files"
@@ -140,10 +135,13 @@ msgid ""
 "are incremental. Unchanged files will be hard-linked from the previous "
 "snapshot if available."
 msgstr ""
+"يتم نسخ كافة الملفات عند إنشاء اللقطة الاولي. اللقطات اللاحقة تزايديه. ستكون "
+"الملفات التي لم يتم تغييرها مرتبطة بشكل ثابت من اللقطة السابقة إذا كانت "
+"متوفرة."
 
 #: Gtk/ExcludeMessageWindow.vala:130
 msgid "All other files and folders are excluded."
-msgstr ""
+msgstr "يتم استبعاد كل الملفات والمجلدات الأخرى."
 
 #: Gtk/RestoreDeviceBox.vala:500
 msgid ""
@@ -154,75 +152,80 @@ msgid ""
 "Either select a non-encrypted device for boot directory or select a non-"
 "encrypted device for root filesystem."
 msgstr ""
+"يتم تحديد جهاز مشفر لنظام الملفات الجذر (/). يجب أن يتم تحميل دليل التمهيد (/"
+"boot) على جهاز غير مشفر ليتمكن النظام من التمهيد بنجاح.\n"
+"\n"
+"إما تحديد جهاز غير مشفرة لدليل التمهيد أو تحديد جهاز غير مشفرة لنظام ملفات "
+"الجذر."
 
 #: Core/Main.vala:249
 msgid "Another instance of Timeshift is creating a snapshot."
-msgstr ""
+msgstr "مثيل آخر من Timeshift هو إنشاء لقطة."
 
 #: Utility/AppLock.vala:49
 msgid "Another instance of this application is running"
-msgstr ""
+msgstr "يتم تشغيل مثيل آخر من هذا التطبيق"
 
 #: Core/Main.vala:253
 msgid "Another instance of timeshift is currently running!"
-msgstr ""
+msgstr "مثيل آخر من timeshift يتم تشغيله حاليا!"
 
 #: Console/AppConsole.vala:376
 msgid "Answer YES to all confirmation prompts"
-msgstr ""
+msgstr "أجب بـ نعم على كافة رسائل التأكيد"
 
 #: Core/Main.vala:3179
 msgid "App config loaded"
-msgstr ""
+msgstr "تم تحميل تكوين التطبيق"
 
 #: Core/Main.vala:3076
 msgid "App config saved"
-msgstr ""
+msgstr "تم حفظ تكوين التطبيق"
 
 #: Console/AppConsole.vala:102
 msgid "Application needs admin access."
-msgstr ""
+msgstr "يحتاج التطبيق وصول المسئول."
 
 #: Core/Main.vala:3519
 msgid "Application will exit"
-msgstr ""
+msgstr "سيتم إنهاء التطبيق"
 
 #: Core/Main.vala:378
 msgid "Application will exit."
-msgstr ""
+msgstr "سيتم إنهاء التطبيق."
 
 #: Utility/Gtk/AboutWindow.vala:433
 msgid "Artists"
-msgstr ""
+msgstr "الفنانين"
 
 #: Utility/Gtk/AboutWindow.vala:417
 msgid "Authors"
-msgstr ""
+msgstr "المؤلفون"
 
 #: Gtk/MainWindow.vala:346
 msgid "Available"
-msgstr ""
-
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
+msgstr "متاح"
 
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
-msgstr ""
+msgstr "BTRFS"
 
 #: Gtk/SnapshotBackendBox.vala:165
 msgid "BTRFS Snapshots"
-msgstr ""
+msgstr "لقطات BTRFS"
 
 #: Gtk/SnapshotBackendBox.vala:119
 msgid "BTRFS Tools Not Found"
-msgstr ""
+msgstr "أدوات BTRFS غير موجودة"
 
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
+msgstr "لم يتم تحميل جهاز BTRFS"
+
+#: Gtk/BackupDeviceBox.vala:98
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
 msgstr ""
 
 #: Gtk/FinishBox.vala:92
@@ -232,46 +235,49 @@ msgid ""
 "snapshots to an external non-system disk in RSYNC mode to guard against disk "
 "failures."
 msgstr ""
+"يتم حفظ لقطات BTRFS على نفس القرص الذي تم إنشاؤه منه. في حالة فشل قرص "
+"النظام، سيتم فقدان اللقطات مع النظام. حفظ اللقطات على قرص خارجي غير النظام "
+"في وضع RSYNC للحماية من فشل القرص."
 
 #: Utility/Gtk/AboutWindow.vala:349 Utility/Gtk/AboutWindow.vala:381
 msgid "Back"
-msgstr ""
+msgstr "عودة"
 
 #: Gtk/SetupWizardWindow.vala:94
 msgid "Backend"
-msgstr ""
+msgstr "الخلفية"
 
 #: Console/AppConsole.vala:356 Gtk/BackupWindow.vala:91
 msgid "Backup"
-msgstr ""
+msgstr "النسخ الاحتياطي"
 
 #: Core/Main.vala:2017
 msgid "Backup Device"
-msgstr ""
+msgstr "جهاز النسخ الاحتياطي"
 
 #: Core/Main.vala:2012
 msgid "Backup device not specified!"
-msgstr ""
+msgstr "لم يتم تحديد جهاز النسخ الاحتياطي!"
 
 #: Utility/Gtk/DonationWindow.vala:89
 msgid "Become a Patron"
-msgstr ""
+msgstr "كن راعياً"
 
 #: Gtk/RestoreExcludeBox.vala:91
 msgid "Bittorrent Clients"
-msgstr ""
+msgstr "عملاء تورنت"
 
 #: Gtk/ScheduleBox.vala:136 Gtk/SnapshotListBox.vala:298
 msgid "Boot"
-msgstr ""
+msgstr "التمهيد"
 
 #: Gtk/RestoreDeviceBox.vala:499
 msgid "Boot device not selected"
-msgstr ""
+msgstr "لم يتم تحديد جهاز التمهيد"
 
 #: Core/Main.vala:1017
 msgid "Boot snapshot failed!"
-msgstr ""
+msgstr "لقطة التمهيد فشلت!"
 
 #: Gtk/ScheduleBox.vala:169
 msgid ""
@@ -280,42 +286,42 @@ msgstr ""
 
 #: Core/Main.vala:998
 msgid "Boot snapshots are enabled"
-msgstr ""
+msgstr "يتم تمكين لقطات التمهيد"
 
 #: Gtk/BootOptionsWindow.vala:49
 msgid "Bootloader Options"
-msgstr ""
+msgstr "خيارات محمل الإقلاع"
 
 #: Gtk/RestoreDeviceBox.vala:411
 msgid "Bootloader Options (Advanced)"
-msgstr ""
+msgstr "خيارات محمل الإقلاع (متقدم)"
 
 #: Gtk/MainWindow.vala:171
 msgid "Browse"
-msgstr ""
+msgstr "تصفح"
 
 #: Gtk/SnapshotListBox.vala:336
 msgid "Browse Files"
-msgstr ""
+msgstr "تصفح الملفات"
 
 #: Gtk/MainWindow.vala:172
 msgid "Browse selected snapshot"
-msgstr ""
+msgstr "تصفح اللقطة المحددة"
 
 #: Core/Main.vala:2499
 msgid "Building file list..."
-msgstr ""
+msgstr "يتم الآن إنشاء قائمه الملفات..."
 
 #: Utility/GtkHelper.vala:122 Utility/Gtk/CustomMessageDialog.vala:172
 #: Gtk/SetupWizardWindow.vala:214 Gtk/BackupWindow.vala:177
 #: Gtk/DeleteWindow.vala:187 Gtk/RestoreWindow.vala:206
 #: Gtk/RestoreWindow.vala:215
 msgid "Cancel"
-msgstr ""
+msgstr "إلغاء"
 
 #: Gtk/RestoreWindow.vala:221
 msgid "Cancel restore?"
-msgstr ""
+msgstr "إلغاء الاستعادة؟"
 
 #: Gtk/RestoreWindow.vala:223
 msgid ""
@@ -324,19 +330,22 @@ msgid ""
 "issues. After cancelling, you need to restore another snapshot, to bring the "
 "system to a consistent state. Click Yes to confirm."
 msgstr ""
+"سيؤدي إلغاء عملية الاستعادة إلى ترك النظام المستهدف في حالة غير متناسقة. قد "
+"يفشل النظام في التمهيد أو قد تواجه مشكلات متنوعة. بعد الإلغاء، تحتاج إلى "
+"استعادة لقطة أخرى، لإحضار النظام إلى حالة متناسقة. انقر فوق نعم للتأكيد."
 
 #: Gtk/MainWindow.vala:563
 msgid "Cannot Delete Live Snapshot"
-msgstr ""
+msgstr "لا يمكن حذف اللقطة المباشرة"
 
 #: Gtk/RsyncLogBox.vala:380 Gtk/RsyncLogBox.vala:383 Gtk/RsyncLogBox.vala:567
 #: Gtk/RsyncLogBox.vala:588 Gtk/RestoreBox.vala:125 Gtk/BackupBox.vala:87
 msgid "Changed"
-msgstr ""
+msgstr "تم تغيرها"
 
 #: Gtk/RestoreBox.vala:127 Gtk/BackupBox.vala:89
 msgid "Changed items:"
-msgstr ""
+msgstr "العناصر التي تغييرت:"
 
 #: Gtk/RestoreWindow.vala:104
 msgid "Checking Restore Actions (Dry Run)"
@@ -344,20 +353,20 @@ msgstr ""
 
 #: Core/Main.vala:2732
 msgid "Checking file systems for errors..."
-msgstr ""
+msgstr "يتم التحقق من أنظمة الملفات بحثاً عن أخطاء..."
 
 #: Gtk/RsyncLogBox.vala:390 Gtk/RestoreBox.vala:130 Gtk/BackupBox.vala:92
 #, c-format
 msgid "Checksum"
-msgstr ""
+msgstr "اختباري"
 
 #: Core/Main.vala:2388
 msgid "Cleaning up..."
-msgstr ""
+msgstr "تنظيف..."
 
 #: Gtk/UsersBox.vala:92 Gtk/ExcludeBox.vala:84
 msgid "Click to edit. Drag and drop to re-order."
-msgstr ""
+msgstr "إضغط للتحرير. قم بالسحب والإفلات لإعادة الترتيب."
 
 #: Gtk/ExcludeBox.vala:59
 msgid "Click to edit. Drag-drop to re-order."
@@ -365,31 +374,31 @@ msgstr ""
 
 #: Gtk/RestoreWindow.vala:69
 msgid "Clone System"
-msgstr ""
+msgstr "استنساخ النظام"
 
 #: Console/AppConsole.vala:364
 msgid "Clone current system"
-msgstr ""
+msgstr "استنساخ النظام الحالي"
 
 #: Gtk/RestoreFinishBox.vala:68
 msgid "Cloning"
-msgstr ""
+msgstr "استنساخ"
 
 #: Core/Main.vala:2782
 msgid "Cloning system..."
-msgstr ""
+msgstr "استنساخ النظام..."
 
 #: Utility/Gtk/AboutWindow.vala:326 Utility/Gtk/DonationWindow.vala:121
 #: Gtk/RsyncLogBox.vala:266 Gtk/BackupWindow.vala:168
 #: Gtk/BootOptionsWindow.vala:106 Gtk/DeleteWindow.vala:170
 #: Gtk/RestoreWindow.vala:508
 msgid "Close"
-msgstr ""
+msgstr "إغلاق"
 
 #: Gtk/RestoreFinishBox.vala:106 Gtk/BackupFinishBox.vala:70
 #: Gtk/FinishBox.vala:101 Gtk/DeleteFinishBox.vala:71
 msgid "Close window to exit"
-msgstr ""
+msgstr "إغلاق النافذة للإنهاء"
 
 #: Utility/Gtk/AboutWindow.vala:425
 msgid "Code Contributions"
@@ -397,11 +406,11 @@ msgstr ""
 
 #: Core/Main.vala:347
 msgid "Commands listed below are not available on this system"
-msgstr ""
+msgstr "الأوامر المذكورة أدناه غير متوفرة على هذا النظام"
 
 #: Gtk/SnapshotListBox.vala:224
 msgid "Comments"
-msgstr ""
+msgstr "التعليقات"
 
 #: Core/Main.vala:2775 Gtk/RestoreBox.vala:74 Gtk/RestoreBox.vala:187
 msgid "Comparing Files (Dry Run)..."
@@ -414,11 +423,11 @@ msgstr ""
 #: Gtk/RestoreFinishBox.vala:50 Gtk/RestoreFinishBox.vala:75
 #: Gtk/BackupFinishBox.vala:50 Gtk/DeleteFinishBox.vala:50
 msgid "Completed"
-msgstr ""
+msgstr "اكتمل"
 
 #: Gtk/RestoreFinishBox.vala:78
 msgid "Completed With Errors"
-msgstr ""
+msgstr "اكتمل مع أخطاء"
 
 #: Gtk/RsyncLogBox.vala:87 Gtk/RestoreWindow.vala:109
 msgid "Confirm Actions"
@@ -427,75 +436,76 @@ msgstr ""
 #: Console/AppConsole.vala:1068
 #, c-format
 msgid "Continue with restore? (y/n): "
-msgstr ""
+msgstr "متابعه مع الاستعادة؟ (y/n): "
 
 #: Console/AppConsole.vala:834 Console/AppConsole.vala:965
 msgid "Could not find device"
-msgstr ""
+msgstr "لا يمكن العثور على الجهاز"
 
 #: Utility/Device.vala:1187
 #, c-format
 msgid "Could not find file"
-msgstr ""
+msgstr "لا يمكن العثور على الملف"
 
 #: Console/AppConsole.vala:731
 msgid "Could not find snapshot"
-msgstr ""
+msgstr "لا يمكن العثور على اللقطة"
 
 #: Core/Main.vala:2946
 msgid "Could not find system subvolume"
-msgstr ""
+msgstr "لا يمكن العثور على وحده التخزين الفرعية للنظام"
 
 #: Core/Main.vala:2974
 msgid "Could not find system subvolumes for creating pre-restore snapshot"
 msgstr ""
+"لا يمكن العثور علي وحدات التخزين الفرعية للنظام لإنشاء لقطه ما قبل الاستعادة"
 
 #: Gtk/RsyncLogBox.vala:366 Gtk/RsyncLogBox.vala:571 Gtk/MainWindow.vala:141
 #, c-format
 msgid "Create"
-msgstr ""
+msgstr "إنشاء"
 
 #: Gtk/BackupWindow.vala:61
 msgid "Create Snapshot"
-msgstr ""
+msgstr "إنشاء لقطة"
 
 #: Gtk/ScheduleBox.vala:136
 msgid "Create one per boot"
-msgstr ""
+msgstr "إنشاء واحدة كل تمهيد"
 
 #: Gtk/ScheduleBox.vala:100
 msgid "Create one per day"
-msgstr ""
+msgstr "إنشاء واحدة كل يوم"
 
 #: Gtk/ScheduleBox.vala:118
 msgid "Create one per hour"
-msgstr ""
+msgstr "إنشاء واحدة كل ساعة"
 
 #: Gtk/ScheduleBox.vala:64
 msgid "Create one per month"
-msgstr ""
+msgstr "إنشاء واحدة كل شهر"
 
 #: Gtk/ScheduleBox.vala:82
 msgid "Create one per week"
-msgstr ""
+msgstr "إنشاء واحدة كل أسبوع"
 
 #: Console/AppConsole.vala:358
 msgid "Create snapshot (even if not scheduled)"
-msgstr ""
+msgstr "إنشاء لقطة (حتى وإن لم تكن مجدولة)"
 
 #: Console/AppConsole.vala:357
 msgid "Create snapshot if scheduled"
-msgstr ""
+msgstr "إنشاء لقطة في حالة الجدولة"
 
 #: Gtk/MainWindow.vala:142
 msgid "Create snapshot of current system"
-msgstr ""
+msgstr "إنشاء لقطة للنظام الحالي"
 
 #: Gtk/MainWindow.vala:1074
 msgid ""
 "Create snapshots manually or enable scheduled snapshots to protect your "
 "system"
-msgstr ""
+msgstr "إنشاء اللقطات يدوياً أو تمكين اللقطات المجدولة لحماية النظام الخاص بك"
 
 #: Gtk/SnapshotBackendBox.vala:95
 msgid "Create snapshots using BTRFS"
@@ -503,146 +513,146 @@ msgstr ""
 
 #: Gtk/SnapshotBackendBox.vala:78
 msgid "Create snapshots using RSYNC tool and hard-links"
-msgstr ""
+msgstr "إنشاء لقطات باستخدام أداة RSYNC والروابط الثابتة"
 
 #: Gtk/RsyncLogBox.vala:366 Gtk/RsyncLogBox.vala:571 Gtk/RsyncLogBox.vala:592
 #: Gtk/RestoreBox.vala:123 Gtk/BackupBox.vala:85
 #, c-format
 msgid "Created"
-msgstr ""
+msgstr "تم إنشاؤه"
 
 #: Core/Snapshot.vala:430
 msgid "Created control file"
-msgstr ""
+msgstr "تم إنشاء ملف التحكم"
 
 #: Utility/TeeJee.FileSystem.vala:351
 msgid "Created directory"
-msgstr ""
+msgstr "تم إنشاء الدليل"
 
 #: Core/Main.vala:2996
 msgid "Created pre-restore snapshot"
-msgstr ""
+msgstr "تم إنشاء لقطة ما قبل الاستعادة"
 
 #: Core/Main.vala:1499
 msgid "Created subvolume snapshot"
-msgstr ""
+msgstr "تم إنشاء لقطه وحده التخزين الفرعية"
 
 #: Gtk/BackupBox.vala:71
 msgid "Creating Snapshot..."
-msgstr ""
+msgstr "جاري إنشاء اللقطة..."
 
 #: Core/Main.vala:1437
 msgid "Creating new backup..."
-msgstr ""
+msgstr "جاري إنشاء نسخة احتياطية جديدة..."
 
 #: Core/Main.vala:1283
 msgid "Creating new snapshot..."
-msgstr ""
+msgstr "جاري إنشاء لقطة جديدة..."
 
 #: Core/Main.vala:2924
 msgid "Creating pre-restore snapshot from system subvolumes..."
-msgstr ""
+msgstr "إنشاء لقطة ما قبل الاستعادة من وحدة التخزين الفرعية للنظام..."
 
 #: Utility/Gtk/AboutWindow.vala:321 Utility/Gtk/AboutWindow.vala:387
 msgid "Credits"
-msgstr ""
+msgstr "الاعتمادات"
 
 #: Core/Main.vala:3518
 msgid "Critical Error"
-msgstr ""
+msgstr "خطأ فادح"
 
 #: Utility/CronTab.vala:136
 msgid "Cron job added"
-msgstr ""
+msgstr "تمت إضافة وظيفة Cron"
 
 #: Utility/CronTab.vala:217
 msgid "Cron job removed"
-msgstr ""
+msgstr "تم إزالة وظيفة Cron"
 
 #: Utility/CronTab.vala:304
 msgid "Cron task exists"
-msgstr ""
+msgstr "مهمة Cron موجودة"
 
 #: Gtk/ScheduleBox.vala:100 Gtk/SnapshotListBox.vala:300
 msgid "Daily"
-msgstr ""
+msgstr "اليومي"
 
 #: Core/Main.vala:1077
 msgid "Daily snapshot failed!"
-msgstr ""
+msgstr "اللقطة اليومية فشلت!"
 
 #: Core/Main.vala:1058
 msgid "Daily snapshots are enabled"
-msgstr ""
+msgstr "يتم تمكين اللقطات اليومية"
 
 #: Core/Main.vala:2111
 msgid "Data will be modified on following devices:"
-msgstr ""
+msgstr "سيتم تعديل البيانات على الأجهزة التالية:"
 
 #: Console/AppConsole.vala:370 Gtk/RsyncLogBox.vala:370
 #: Gtk/RsyncLogBox.vala:575 Gtk/MainWindow.vala:161
 #: Gtk/SnapshotListBox.vala:322 Gtk/DeleteWindow.vala:98
 #, c-format
 msgid "Delete"
-msgstr ""
+msgstr "حذف"
 
 #: Gtk/DeleteWindow.vala:62
 msgid "Delete Snapshots"
-msgstr ""
+msgstr "حذف اللقطات"
 
 #: Console/AppConsole.vala:372
 msgid "Delete all snapshots"
-msgstr ""
+msgstr "حذف كل اللقطات"
 
 #: Gtk/MainWindow.vala:162
 msgid "Delete selected snapshot"
-msgstr ""
+msgstr "حذف اللقطات المحددة"
 
 #: Console/AppConsole.vala:371
 msgid "Delete snapshot"
-msgstr ""
+msgstr "حذف اللقطة"
 
 #: Gtk/RsyncLogBox.vala:370 Gtk/RsyncLogBox.vala:575 Gtk/RsyncLogBox.vala:596
 #: Gtk/RestoreBox.vala:124 Gtk/BackupBox.vala:86
 #, c-format
 msgid "Deleted"
-msgstr ""
+msgstr "تم الحذف"
 
 #: Utility/TeeJee.FileSystem.vala:381
 msgid "Deleted directory"
-msgstr ""
+msgstr "تم حذف الدليل"
 
 #: Core/Subvolume.vala:154 Core/Main.vala:2903 Core/Main.vala:2907
 #, c-format
 msgid "Deleted subvolume"
-msgstr ""
+msgstr "تم حذف وحده التخزين الفرعية"
 
 #: Gtk/DeleteBox.vala:58
 msgid "Deleting Snapshots..."
-msgstr ""
+msgstr "جاري حذف اللقطات..."
 
 #: Core/Subvolume.vala:141
 #, c-format
 msgid "Deleting subvolume"
-msgstr ""
+msgstr "جاري حذف وحدة التخزين الفرعية"
 
 #: Gtk/RestoreExcludeBox.vala:105
 msgid "Deluge, Transmission"
-msgstr ""
+msgstr "الغمر، الناقل"
 
 #: Console/AppConsole.vala:427 Console/AppConsole.vala:542
 msgid "Description"
-msgstr ""
+msgstr "الوصف"
 
 #: Core/Subvolume.vala:168
 #, c-format
 msgid "Destroyed qgroup"
-msgstr ""
+msgstr "تم تدمير qgroup"
 
 #: Core/Subvolume.vala:158
 #, c-format
 msgid "Destroying qgroup"
-msgstr ""
+msgstr "جاري تدمير qgroup"
 
 #: Utility/Device.vala:1810 Utility/Device.vala:1820
 #: Console/AppConsole.vala:454 Console/AppConsole.vala:493
@@ -651,19 +661,19 @@ msgstr ""
 #: Core/Main.vala:2146 Gtk/RestoreDeviceBox.vala:97
 #, c-format
 msgid "Device"
-msgstr ""
+msgstr "الجهاز"
 
 #: Utility/Device.vala:1269
 msgid "Device is unlocked"
-msgstr ""
+msgstr "الجهاز غير مؤمن"
 
 #: Utility/Device.vala:1164 Utility/Device.vala:1226
 msgid "Device name is empty!"
-msgstr ""
+msgstr "اسم الجهاز فارغ!"
 
 #: Console/AppConsole.vala:663 Core/SnapshotRepo.vala:560 Core/Main.vala:3232
 msgid "Device not found"
-msgstr ""
+msgstr "الجهاز غير موجود"
 
 #: Gtk/BackupDeviceBox.vala:97
 #, c-format
@@ -677,11 +687,11 @@ msgstr ""
 
 #: Gtk/RestoreDeviceBox.vala:84
 msgid "Devices from which snapshot was created are pre-selected."
-msgstr ""
+msgstr "يتم تحديد الأجهزة التي تم إنشاء اللقطة منها مسبقاً."
 
 #: Console/AppConsole.vala:326
 msgid "Devices with Linux file systems"
-msgstr ""
+msgstr "الأجهزة مع أنظمة ملفات Linux"
 
 #: Gtk/BackupDeviceBox.vala:105
 msgid "Devices with Windows file systems are not supported (NTFS, FAT, etc)."
@@ -703,26 +713,39 @@ msgid ""
 "Tony George\n"
 "(teejeetech@gmail.com)"
 msgstr ""
+"هل وجدت هذا البرنامج مفيد؟\n"
+"\n"
+"يمكنك شراء قهوة أو تقديم تبرع عبر PayPal لإظهار دعمك. أو مجرد مراسلتي عبر "
+"البريد الإلكتروني والقول مرحبا. هذا التطبيق مجاني تماماً وسيستمر في البقاء "
+"على هذا النحو. ستساعد مساهماتك في الحفاظ على هذا المشروع على قيد الحياة "
+"وتحسينه بشكل أكبر.\n"
+"\n"
+"لا تتردد في إرسال بريد إلكتروني إلا إذا وجدت أي مشاكل في هذا التطبيق أو إذا "
+"كنت بحاجة إلى أي تغييرات. الاقتراحات وردود الفعل هي دائما موضع ترحيب.\n"
+"\n"
+"شكر،\n"
+"توني جورج\n"
+"(teejeetech@gmail.com)"
 
 #: Utility/TeeJee.FileSystem.vala:518
 msgid "Dir not found"
-msgstr ""
+msgstr "الدليل غير موجود"
 
 #: Core/SnapshotRepo.vala:982
 msgid "Directory not found"
-msgstr ""
+msgstr "الدليل غير موجود"
 
 #: Core/Main.vala:2206 Gtk/RestoreSummaryBox.vala:64
 msgid "Disclaimer"
-msgstr ""
+msgstr "إخلاء المسئولية"
 
 #: Gtk/BackupDeviceBox.vala:127
 msgid "Disk"
-msgstr ""
+msgstr "القرص"
 
 #: Core/Main.vala:226
 msgid "Distribution"
-msgstr ""
+msgstr "التوزيع"
 
 #: Utility/Gtk/AboutWindow.vala:449
 msgid "Documentation"
@@ -730,15 +753,15 @@ msgstr ""
 
 #: Utility/Gtk/DonationWindow.vala:42 Gtk/MainWindow.vala:388
 msgid "Donate"
-msgstr ""
+msgstr "تبرع"
 
 #: Utility/Gtk/DonationWindow.vala:81
 msgid "Donate with PayPal"
-msgstr ""
+msgstr "تبرع مع PayPal"
 
 #: Utility/Gtk/AboutWindow.vala:465
 msgid "Donations"
-msgstr ""
+msgstr "التبرعات"
 
 #: Gtk/UsersBox.vala:357
 msgid "Enable BTRFS qgroups (recommended)"
@@ -746,51 +769,51 @@ msgstr ""
 
 #: Gtk/MainWindow.vala:1068
 msgid "Enable scheduled snapshots to protect your system"
-msgstr ""
+msgstr "تمكين اللقطات المجدولة لحماية نظامك"
 
 #: Core/Main.vala:4030 Core/Main.vala:4070
 msgid "Enabled subvolume quota support"
-msgstr ""
+msgstr "تمكين دعم الحصة النسبية لوحدة التخزين الفرعية"
 
 #: Utility/Device.vala:1333
 msgid "Encrypted Device"
-msgstr ""
+msgstr "الجهاز المشفر"
 
 #: Gtk/UsersBox.vala:236
 msgid "Encrypted Home Directory"
-msgstr ""
+msgstr "الدليل الرئيسي المشفر"
 
 #: Console/AppConsole.vala:884
 #, c-format
 msgid "Enter device name or number"
-msgstr ""
+msgstr "أدخل اسم الجهاز أو رقمه"
 
 #: Console/AppConsole.vala:682 Console/AppConsole.vala:1013
 #, c-format
 msgid "Enter device name or number (a=Abort)"
-msgstr ""
+msgstr "أدخل اسم الجهاز أو رقمه (a=إجهاض)"
 
 #: Utility/Device.vala:1334
 #, c-format
 msgid "Enter passphrase to unlock '%s'"
-msgstr ""
+msgstr "أدخل عبارة المرور لإلغاء تأمين '%s'"
 
 #: Utility/GtkHelper.vala:805
 msgid "Enter path or browse for directory"
-msgstr ""
+msgstr "أدخل المسار أو تصفح للحصول على الدليل"
 
 #: Console/AppConsole.vala:754
 #, c-format
 msgid "Enter snapshot number (a=Abort, p=Previous, n=Next)"
-msgstr ""
+msgstr "أدخل رقم اللقطة (a=إجهاض، p=السابق، n=التالي)"
 
 #: Gtk/ExcludeBox.vala:225
 msgid "Enter the pattern to exclude (Ex: *.mp3, *.bak)"
-msgstr ""
+msgstr "أدخل النمط للاستبعاد (مثل: *.mp3, *.bak)"
 
 #: Utility/GtkHelper.vala:18 Gtk/RestoreDeviceBox.vala:534
 msgid "Error"
-msgstr ""
+msgstr "خطأ"
 
 #: Gtk/RestoreWindow.vala:488
 msgid "Error running Rsync"
@@ -798,19 +821,19 @@ msgstr ""
 
 #: Gtk/SetupWizardWindow.vala:99 Gtk/BackupWindow.vala:81
 msgid "Estimate"
-msgstr ""
+msgstr "التقدير"
 
 #: Gtk/EstimateBox.vala:56
 msgid "Estimating System Size..."
-msgstr ""
+msgstr "تقدير حجم النظام..."
 
 #: Core/Main.vala:1279
 msgid "Estimating system size..."
-msgstr ""
+msgstr "تقدير حجم النظام..."
 
 #: Console/AppConsole.vala:386
 msgid "Examples"
-msgstr ""
+msgstr "أمثلة"
 
 #: Gtk/UsersBox.vala:136
 msgid "Exclude All"
@@ -818,178 +841,178 @@ msgstr ""
 
 #: Gtk/ExcludeAppsBox.vala:51 Gtk/RestoreExcludeBox.vala:55
 msgid "Exclude Application Settings"
-msgstr ""
+msgstr "استبعاد إعدادات التطبيقات"
 
 #: Gtk/RestoreWindow.vala:99
 msgid "Exclude Apps"
-msgstr ""
+msgstr "استبعاد التطبيقات"
 
 #: Gtk/ExcludeMessageWindow.vala:70
 msgid "Exclude List"
-msgstr ""
+msgstr "قائمة الاستبعاد"
 
 #: Gtk/ExcludeListSummaryWindow.vala:49
 msgid "Exclude List Summary"
-msgstr ""
+msgstr "ملخص قائمه الاستبعاد"
 
 #: Gtk/ExcludeBox.vala:224
 msgid "Exclude Pattern"
-msgstr ""
+msgstr "استبعاد النمط"
 
 #: Gtk/ExcludeMessageWindow.vala:56
 msgid "Excluded Directories"
-msgstr ""
+msgstr "استبعاد الدلائل"
 
 #: Core/Main.vala:1567
 msgid "Expected values: O, B, H, D, W, M"
-msgstr ""
+msgstr "القيم المتوقعة: O ،B ،H ،D ،W ،M"
 
 #: Utility/CronTab.vala:132
 msgid "Failed to add cron job"
-msgstr ""
+msgstr "فشل إضافة وظيفة cron"
 
 #: Utility/TeeJee.FileSystem.vala:191
 msgid "Failed to copy file"
-msgstr ""
+msgstr "فشل نسخ الملف"
 
 #: Utility/TeeJee.FileSystem.vala:354 Utility/TeeJee.FileSystem.vala:362
 msgid "Failed to create directory"
-msgstr ""
+msgstr "فشل إنشاء الدليل"
 
 #: Core/Main.vala:1405
 msgid "Failed to create new snapshot"
-msgstr ""
+msgstr "فشل إنشاء لقطة جديدة"
 
 #: Core/Main.vala:1255
 msgid "Failed to create snapshot"
-msgstr ""
+msgstr "فشل إنشاء اللقطة"
 
 #: Core/Main.vala:1495
 msgid "Failed to create subvolume snapshot"
-msgstr ""
+msgstr "فشل إنشاء لقطه وحده التخزين الفرعية"
 
 #: Core/SnapshotRepo.vala:1023
 msgid "Failed to create symlinks"
-msgstr ""
+msgstr "فشل إنشاء الروابط الرمزية"
 
 #: Utility/TeeJee.FileSystem.vala:384
 msgid "Failed to delete directory"
-msgstr ""
+msgstr "فشل حذف الدليل"
 
 #: Utility/TeeJee.FileSystem.vala:100
 msgid "Failed to delete file"
-msgstr ""
+msgstr "فشل حذف الملف"
 
 #: Core/Subvolume.vala:150
 msgid "Failed to delete snapshot subvolume"
-msgstr ""
+msgstr "فشل حذف لقطه وحده التخزين الفرعية"
 
 #: Core/SnapshotRepo.vala:1049
 msgid "Failed to delete symlinks"
-msgstr ""
+msgstr "فشل حذف الروابط الرمزية"
 
 #: Core/Subvolume.vala:164
 msgid "Failed to destroy qgroup"
-msgstr ""
+msgstr "فشل تدمير qgroup"
 
 #: Core/Main.vala:4055
 msgid "Failed to enable subvolume quota"
-msgstr ""
+msgstr "فشل تمكين الحصة النسبية لوحده التخزين الفرعية"
 
 #: Core/Main.vala:3733 Core/Main.vala:3739
 msgid "Failed to estimate system size"
-msgstr ""
+msgstr "فشل تقدير حجم النظام"
 
 #: Utility/CronTab.vala:257
 msgid "Failed to export crontab file"
-msgstr ""
+msgstr "فشل تصدير ملف crontab"
 
 #: Console/AppConsole.vala:697 Console/AppConsole.vala:761
 #: Console/AppConsole.vala:893 Console/AppConsole.vala:988
 #: Console/AppConsole.vala:1033 Console/AppConsole.vala:1074
 msgid "Failed to get input from user in 3 attempts"
-msgstr ""
+msgstr "فشل الحصول على إدخال من المستخدم في 3 محاولات"
 
 #: Utility/Device.vala:615
 msgid "Failed to get partition list"
-msgstr ""
+msgstr "فشل الحصول علي قائمه الأقسام"
 
 #: Core/Main.vala:3315
 msgid "Failed to get partition list."
-msgstr ""
+msgstr "فشل الحصول علي قائمه الأقسام."
 
 #: Utility/CronTab.vala:240
 msgid "Failed to install crontab file"
-msgstr ""
+msgstr "فشل تثبيت ملف crontab"
 
 #: Gtk/RestoreDeviceBox.vala:535
 msgid "Failed to mount devices"
-msgstr ""
+msgstr "فشل تحميل الأجهزة"
 
 #: Utility/TeeJee.FileSystem.vala:210
 msgid "Failed to move file"
-msgstr ""
+msgstr "فشل نقل الملف"
 
 #: Core/Main.vala:2961
 msgid "Failed to move system subvolume to snapshot directory"
-msgstr ""
+msgstr "فشل نقل وحده التخزين الفرعية للنظام إلى دليل اللقطات"
 
 #: Core/Main.vala:3863
 msgid "Failed to query subvolume list"
-msgstr ""
+msgstr "فشل الاستعلام عن قائمه وحدات التخزين الفرعية"
 
 #: Core/Main.vala:3947
 msgid "Failed to query subvolume quota"
-msgstr ""
+msgstr "فشل الاستعلام عن الحصة النسبية لوحده التخزين الفرعية"
 
 #: Utility/CronTab.vala:50
 msgid "Failed to read cron tab"
-msgstr ""
+msgstr "فشل قراءه علامة التبويب cron"
 
 #: Utility/TeeJee.FileSystem.vala:148
 msgid "Failed to read file"
-msgstr ""
+msgstr "فشل قراءة الملف"
 
 #: Core/SnapshotRepo.vala:969
 msgid "Failed to remove"
-msgstr ""
+msgstr "فشل الإزالة"
 
 #: Utility/CronTab.vala:213
 msgid "Failed to remove cron job"
-msgstr ""
+msgstr "فشل إزالة وظيفة cron"
 
 #: Core/Snapshot.vala:530 Core/Snapshot.vala:542 Core/Snapshot.vala:550
 msgid "Failed to remove snapshot"
-msgstr ""
+msgstr "فشل إزالة اللقطة"
 
 #: Core/Main.vala:4094
 msgid "Failed to rescan subvolume quota"
-msgstr ""
+msgstr "فشل أعاده فحص الحصة النسبية لوحده التخزين الفرعية"
 
 #: Core/Subvolume.vala:202
 msgid "Failed to restore system subvolume"
-msgstr ""
+msgstr "فشل استعاده وحده التخزين الفرعية للنظام"
 
 #: Core/Main.vala:1355
 msgid "Failed to save exclude list"
-msgstr ""
+msgstr "فشل حفظ قائمه الاستبعاد"
 
 #: Utility/Device.vala:1260 Utility/Device.vala:1314 Utility/Device.vala:1339
 #: Utility/Device.vala:1360 Utility/Device.vala:1380
 msgid "Failed to unlock device"
-msgstr ""
+msgstr "فشل إلغاء تامين الجهاز"
 
 #: Utility/Device.vala:1611
 msgid "Failed to unmount"
-msgstr ""
+msgstr "فشل إلغاء تحميل"
 
 #: Core/Main.vala:3519
 msgid "Failed to unmount device!"
-msgstr ""
+msgstr "فشل إلغاء تحميل الجهاز!"
 
 #: Utility/TeeJee.FileSystem.vala:175
 msgid "Failed to write file"
-msgstr ""
+msgstr "فشل كتابه الملف"
 
 #: Gtk/RsyncLogBox.vala:122
 msgid "File (snapshot)"
@@ -1001,43 +1024,45 @@ msgstr ""
 
 #: Gtk/ExcludeMessageWindow.vala:98
 msgid "File Pattern"
-msgstr ""
+msgstr "نمط الملف"
 
 #: Gtk/BackupBox.vala:80
 msgid "File and directory counts:"
-msgstr ""
+msgstr "عدد الملفات والدليل:"
 
 #: Utility/TeeJee.FileSystem.vala:671 Utility/TeeJee.FileSystem.vala:720
 msgid "File is missing"
-msgstr ""
+msgstr "الملف مفقود"
 
 #: Utility/TeeJee.FileSystem.vala:205 Utility/TeeJee.FileSystem.vala:547
 #: Utility/CronTab.vala:225 Utility/RsyncTask.vala:296
 msgid "File not found"
-msgstr ""
+msgstr "الملف غير موجود"
 
 #: Gtk/ExcludeListSummaryWindow.vala:62
 msgid ""
 "Files &amp; directories matching the patterns below will be excluded. "
 "Patterns starting with a + will include the item instead of excluding."
 msgstr ""
+"الملفات &amp؛ سيتم استبعاد الدلائل التي تطابق الأنماط أدناه. ستتضمن الأنماط "
+"التي تبدأ بـ+ على العنصر بدلاً من الاستبعاد."
 
 #: Gtk/SnapshotBackendBox.vala:192
 msgid "Files and directories can be excluded to save disk space."
-msgstr ""
+msgstr "يمكن استبعاد الملفات والدلائل لتوفير مساحة على القرص."
 
 #: Gtk/RestoreBox.vala:119
 msgid "Files and directory counts:"
-msgstr ""
+msgstr "أعداد الملفات والدليل:"
 
 #: Gtk/ExcludeMessageWindow.vala:76
 msgid "Files matching the following patterns will be excluded"
-msgstr ""
+msgstr "سيتم استبعاد الملفات المطابقة للنماذج التالية"
 
 #: Utility/Device.vala:1828
 #, c-format
 msgid "Filesystem"
-msgstr ""
+msgstr "نظام الملفات"
 
 #: Gtk/RsyncLogBox.vala:302
 msgid "Filter by name or path"
@@ -1045,99 +1070,101 @@ msgstr ""
 
 #: Gtk/SettingsWindow.vala:100
 msgid "Filters"
-msgstr ""
+msgstr "الفلاتر"
 
 #: Gtk/SetupWizardWindow.vala:205 Gtk/BackupWindow.vala:96
 #: Gtk/DeleteWindow.vala:103
 msgid "Finish"
-msgstr ""
+msgstr "إنهاء"
 
 #: Gtk/SetupWizardWindow.vala:120 Gtk/RestoreWindow.vala:130
 msgid "Finished"
-msgstr ""
+msgstr "تم الانتهاء"
 
 #: Gtk/RestoreExcludeBox.vala:78
 msgid "Firefox, Chromium, Chrome, Opera, Epiphany, Midori"
-msgstr ""
+msgstr "فايرفوكس، كروميوم، كروم، أوبرا، Epiphany ،Midori"
 
 #: Core/SnapshotRepo.vala:667
 msgid "First snapshot requires:"
-msgstr ""
+msgstr "اللقطة الأولى تتطلب:"
 
 #: Core/Main.vala:2894
 msgid "Found existing pre-restore snapshot"
-msgstr ""
+msgstr "العثور على لقطة ما قبل الاستعادة الموجودة"
 
 #: Gtk/BackupDeviceBox.vala:215
 msgid "Free"
-msgstr ""
+msgstr "الحرة"
 
 #: Core/SnapshotRepo.vala:77 Core/SnapshotRepo.vala:147
 msgid "Free space"
-msgstr ""
+msgstr "المساحة الحرة"
 
 #: Console/AppConsole.vala:1042
 msgid "GRUB Device"
-msgstr ""
+msgstr "جهاز GRUB"
 
 #: Gtk/RestoreDeviceBox.vala:511
 msgid "GRUB device not selected"
-msgstr ""
+msgstr "لم يتم تحديد جهاز GRUB"
 
 #: Console/AppConsole.vala:1047
 msgid "GRUB will NOT be reinstalled"
-msgstr ""
+msgstr "لن يتم إعادة تثبيت GRUB"
 
 #: Core/Main.vala:2348
 msgid "Generating initramfs..."
-msgstr ""
+msgstr "جاري إنشاء initramfs..."
 
 #: Console/AppConsole.vala:374
 msgid "Global"
-msgstr ""
+msgstr "العمومي"
 
 #: Gtk/RsyncLogBox.vala:400 Gtk/RestoreBox.vala:135 Gtk/BackupBox.vala:97
 #, c-format
 msgid "Group"
-msgstr ""
+msgstr "المجموعة"
 
 #: Gtk/ExcludeMessageWindow.vala:129
 msgid ""
 "Hidden files and folders are included by default since they contain user-"
 "specific configuration files."
 msgstr ""
+"يتم تضمين الملفات والمجلدات المخفية بشكل افتراضي نظراً لأنها تحتوي على ملفات "
+"تكوين خاصة بالمستخدم."
 
 #: Gtk/DeleteWindow.vala:178
 msgid "Hide"
-msgstr ""
+msgstr "إخفاء"
 
 #: Console/AppConsole.vala:381
 msgid "Hide rsync output"
-msgstr ""
+msgstr "إخفاء إخراج إداة rsync"
 
 #: Gtk/DeleteWindow.vala:179
 msgid "Hide this window (files will be deleted in background)"
-msgstr ""
+msgstr "إخفاء هذه النافذة (سيتم حذف الملفات في الخلفية)"
 
 #: Gtk/UsersBox.vala:120
 msgid "Home"
-msgstr ""
+msgstr "المجلد الرئيسي"
 
 #: Gtk/ExcludeMessageWindow.vala:116
 msgid "Home Directory"
-msgstr ""
+msgstr "الدليل الرئيسي"
 
 #: Gtk/ScheduleBox.vala:118 Gtk/SnapshotListBox.vala:299
 msgid "Hourly"
-msgstr ""
+msgstr "بالساعة"
 
 #: Core/Main.vala:1047
 msgid "Hourly snapshot failed!"
-msgstr ""
+msgstr "فشل لقطه الساعة!"
 
 #: Core/Main.vala:1028
 msgid "Hourly snapshots are enabled"
-msgstr ""
+msgstr "يتم تمكين اللقطات بالساعة"
 
 #: Utility/Gtk/AboutWindow.vala:457
 msgid "Icon Themes & Utilities"
@@ -1148,20 +1175,22 @@ msgid ""
 "If the restored system fails to boot, then boot from the Live CD/USB, "
 "install Timeshift, and try restoring another snapshot."
 msgstr ""
+"إذا فشل النظام المستعاد في التمهيد، فقم بالتمهيد المباشر من CD/USB، ثم قم "
+"بتثبيت Timeshift، وحاول استعادة لقطة أخرى."
 
 #: Core/Main.vala:2212
 msgid ""
 "If these terms are not acceptable to you, please do not proceed beyond this "
 "point!"
-msgstr ""
+msgstr "إذا لم تكن هذه الشروط مقبولة لك، يرجى عدم المضي قدماً وراء هذه النقطة!"
 
 #: Gtk/ExcludeBox.vala:54
 msgid "Include / Exclude Patterns"
-msgstr ""
+msgstr "تضمين / استبعاد الأنماط"
 
 #: Gtk/UsersBox.vala:340
 msgid "Include @home subvolume in backups"
-msgstr ""
+msgstr "تضمين وحده التخزين الفرعيه home@ في النسخ الاحتياطية"
 
 #: Gtk/UsersBox.vala:266
 msgid "Include All"
@@ -1173,28 +1202,28 @@ msgstr ""
 
 #: Core/Main.vala:2026
 msgid "Invalid Snapshot"
-msgstr ""
+msgstr "اللقطة غير صالحة"
 
 #: Console/AppConsole.vala:251
 #, c-format
 msgid "Invalid command line arguments"
-msgstr ""
+msgstr "متغيرات سطر الأوامر غير صالحة"
 
 #: Gtk/MainWindow.vala:824
 msgid "Invalid snapshot"
-msgstr ""
+msgstr "اللقطة غير صالحة"
 
 #: Utility/Gtk/DonationWindow.vala:97
 msgid "Issue Tracker ~ Report Issues, Request Features, Ask Questions"
-msgstr ""
+msgstr "تعقب المشكلة ~ تقرير المشاكل، طلب الميزات، طرح الأسئلة"
 
 #: Gtk/ExcludeBox.vala:272
 msgid "Items Not Selected"
-msgstr ""
+msgstr "العناصر غير المحددة"
 
 #: Gtk/ScheduleBox.vala:283
 msgid "Keep"
-msgstr ""
+msgstr "إبقاء"
 
 #: Gtk/RestoreExcludeBox.vala:112
 msgid ""
@@ -1202,100 +1231,104 @@ msgid ""
 "etc. If un-checked, previous configuration files will be restored from "
 "snapshot."
 msgstr ""
+"احتفظ بملفات التكوين لعملاء بيتورنت مثل الغمر، الناقل، إلخ. إذا لم يتم "
+"التحقق منها، فستتم استعادة ملفات التكوين السابقة من اللقطة."
 
 #: Gtk/RestoreExcludeBox.vala:85
 msgid ""
 "Keep configuration files for web browsers like Firefox and Chrome. If un-"
 "checked, previous configuration files will be restored from snapshot"
 msgstr ""
+"احتفظ بملفات التكوين لمتصفحات الويب مثل Firefox و Chrome. في حالة عدم "
+"التحديد، سيتم استعادة ملفات التكوين السابقة من اللقطة"
 
 #: Gtk/RestoreDeviceBox.vala:244
 msgid "Keep on Root Device"
-msgstr ""
+msgstr "حافظ على جهاز الجذر"
 
 #: Gtk/RestoreDeviceBox.vala:229
 msgid "Keep this mount path on the root filesystem"
-msgstr ""
+msgstr "احتفظ بمسار التثبيت هذا على نظام ملفات الجذر"
 
 #: Gtk/SnapshotListBox.vala:519
 msgid "LIVE"
-msgstr ""
+msgstr "المباشر"
 
 #: Utility/Device.vala:1829 Console/AppConsole.vala:458
 #: Console/AppConsole.vala:497 Gtk/BackupDeviceBox.vala:254
 #, c-format
 msgid "Label"
-msgstr ""
+msgstr "التسمية"
 
 #: Core/Main.vala:1010
 #, c-format
 msgid "Last boot snapshot is %d hours old"
-msgstr ""
+msgstr "آخر لقطة من التمهيد أقدم من %d ساعات"
 
 #: Core/Main.vala:1005
 msgid "Last boot snapshot is older than system start time"
-msgstr ""
+msgstr "آخر لقطة تمهيد أقدم من وقت بدء النظام"
 
 #: Core/Main.vala:1001
 msgid "Last boot snapshot not found"
-msgstr ""
+msgstr "لم يتم العثور على لقطة التمهيد الأخيرة"
 
 #: Core/Main.vala:1070
 #, c-format
 msgid "Last daily snapshot is %d hours old"
-msgstr ""
+msgstr "آخر لقطة يومية أقدم من %d ساعات"
 
 #: Core/Main.vala:1065
 msgid "Last daily snapshot is more than 1 day old"
-msgstr ""
+msgstr "آخر لقطة يومية أقدم من يوم واحد"
 
 #: Core/Main.vala:1061
 msgid "Last daily snapshot not found"
-msgstr ""
+msgstr "لم يتم العثور على آخر لقطة يومية"
 
 #: Core/Main.vala:1040
 #, c-format
 msgid "Last hourly snapshot is %d minutes old"
-msgstr ""
+msgstr "آخر لقطة بالساعة أقدم من %d دقائق"
 
 #: Core/Main.vala:1035
 msgid "Last hourly snapshot is more than 1 hour old"
-msgstr ""
+msgstr "آخر لقطة بالساعة أقدم من ساعة واحدة"
 
 #: Core/Main.vala:1031
 msgid "Last hourly snapshot not found"
-msgstr ""
+msgstr "لم يتم العثور على آخر لقطة بالساعة"
 
 #: Core/Main.vala:1130
 #, c-format
 msgid "Last monthly snapshot is %d days old"
-msgstr ""
+msgstr "آخر لقطة شهرية أقدم من %d أيام"
 
 #: Core/Main.vala:1125
 msgid "Last monthly snapshot is more than 1 month old"
-msgstr ""
+msgstr "آخر لقطة شهرية أقدم من شهر واحد"
 
 #: Core/Main.vala:1121
 msgid "Last monthly snapshot not found"
-msgstr ""
+msgstr "لم يتم العثور على آخر لقطة شهرية"
 
 #: Core/Main.vala:1100
 #, c-format
 msgid "Last weekly snapshot is %d days old"
-msgstr ""
+msgstr "آخر لقطة أسبوعية أقدم من %d ايام"
 
 #: Core/Main.vala:1095
 msgid "Last weekly snapshot is more than 1 week old"
-msgstr ""
+msgstr "آخر لقطة أسبوعية أقدم من أسبوع واحد"
 
 #: Core/Main.vala:1091
 msgid "Last weekly snapshot not found"
-msgstr ""
+msgstr "لم يتم العثور على آخر لقطة أسبوعية"
 
 #: Gtk/MainWindow.vala:1049
 #, c-format
 msgid "Latest snapshot"
-msgstr ""
+msgstr "أحدث لقطة"
 
 #: Utility/Gtk/AboutWindow.vala:316 Utility/Gtk/AboutWindow.vala:356
 msgid "License"
@@ -1304,48 +1337,48 @@ msgstr ""
 #: Core/Main.vala:1344
 #, c-format
 msgid "Linking from snapshot"
-msgstr ""
+msgstr "الربط من لقطة"
 
 #: Console/AppConsole.vala:352
 msgid "List"
-msgstr ""
+msgstr "القائمة"
 
 #: Console/AppConsole.vala:354
 msgid "List devices"
-msgstr ""
+msgstr "قائمة الأجهزة"
 
 #: Console/AppConsole.vala:353
 msgid "List snapshots"
-msgstr ""
+msgstr "قائمة اللقطات"
 
 #: Gtk/MainWindow.vala:1000
 msgid "Live USB Mode (Restore Only)"
-msgstr ""
+msgstr "وضع USB المباشر (استعادة فقط)"
 
 #: Gtk/SetupWizardWindow.vala:104 Gtk/BackupWindow.vala:86
 #: Gtk/SettingsWindow.vala:89
 msgid "Location"
-msgstr ""
+msgstr "الموقع"
 
 #: Gtk/MainWindow.vala:459
 msgid "Main window closed by user"
-msgstr ""
+msgstr "النافذة الرئيسية مغلقة من قبل المستخدم"
 
 #: Gtk/SnapshotListBox.vala:329
 msgid "Mark for Deletion"
-msgstr ""
+msgstr "علامة للحذف"
 
 #: Gtk/MainWindow.vala:641
 msgid "Marked for deletion"
-msgstr ""
+msgstr "تم وضع علامة للحذف"
 
 #: Core/SnapshotRepo.vala:711 Core/SnapshotRepo.vala:748
 msgid "Maximum backups exceeded for backup level"
-msgstr ""
+msgstr "تم تجاوز الحد الأقصى للنسخ الاحتياطية لمستوى النسخ الاحتياطي"
 
 #: Gtk/MainWindow.vala:208
 msgid "Menu"
-msgstr ""
+msgstr "القائمة"
 
 #: Gtk/UsersBox.vala:354
 msgid "Miscellaneous"
@@ -1353,92 +1386,92 @@ msgstr ""
 
 #: Core/Main.vala:235
 msgid "Missing Dependencies"
-msgstr ""
+msgstr "التبعيات المفقودة"
 
 #: Core/SnapshotRepo.vala:689
 #, c-format
 msgid "Mode"
-msgstr ""
+msgstr "الوضع"
 
 #: Utility/Device.vala:1812
 #, c-format
 msgid "Model"
-msgstr ""
+msgstr "الطراز"
 
 #: Gtk/ScheduleBox.vala:64 Gtk/SnapshotListBox.vala:302
 msgid "Monthly"
-msgstr ""
+msgstr "الشهري"
 
 #: Core/Main.vala:1118
 msgid "Monthly snapshot are enabled"
-msgstr ""
+msgstr "يتم تمكين اللقطة الشهرية"
 
 #: Core/Main.vala:1137
 msgid "Monthly snapshot failed!"
-msgstr ""
+msgstr "اللقطات الشهرية فشلت!"
 
 #: Core/Main.vala:2113 Core/Main.vala:2146
 msgid "Mount"
-msgstr ""
+msgstr "تحميل"
 
 #: Core/Main.vala:2968
 msgid "Moved system subvolume to snapshot directory"
-msgstr ""
+msgstr "تم نقل وحده التخزين الفرعية للنظام إلى دليل اللقطات"
 
 #: Gtk/MainWindow.vala:800
 msgid "Multiple snapshots selected"
-msgstr ""
+msgstr "تم تحديد لقطات متعددة"
 
 #: Console/AppConsole.vala:425 Gtk/RsyncLogBox.vala:492
 #: Gtk/BackupDeviceBox.vala:235
 msgid "Name"
-msgstr ""
+msgstr "الاسم"
 
 #: Gtk/SetupWizardWindow.vala:197 Gtk/BackupWindow.vala:160
 #: Gtk/DeleteWindow.vala:162 Gtk/RestoreWindow.vala:198
 msgid "Next"
-msgstr ""
+msgstr "التالي"
 
 #: Utility/Gtk/CustomMessageDialog.vala:177
 msgid "No"
-msgstr ""
+msgstr "لا"
 
 #: Gtk/RestoreBox.vala:122 Gtk/BackupBox.vala:84
 msgid "No Change"
-msgstr ""
+msgstr "بدون تغيير"
 
 #: Gtk/MainWindow.vala:615 Gtk/DeleteWindow.vala:341
 msgid "No Snapshots Selected"
-msgstr ""
+msgstr "لا توجد لقطات محددة"
 
 #: Gtk/MainWindow.vala:1073
 msgid "No snapshots available"
-msgstr ""
+msgstr "لا توجد لقطات متاحة"
 
 #: Console/AppConsole.vala:320 Core/SnapshotRepo.vala:898
 #: Gtk/MainWindow.vala:1017
 msgid "No snapshots found"
-msgstr ""
+msgstr "لم يتم العثور على لقطات"
 
 #: Console/AppConsole.vala:740
 msgid "No snapshots found on device"
-msgstr ""
+msgstr "لم يتم العثور على لقطات على الجهاز"
 
 #: Gtk/MainWindow.vala:553
 msgid "No snapshots on device"
-msgstr ""
+msgstr "لا توجد لقطات على الجهاز"
 
 #: Core/SnapshotRepo.vala:665
 msgid "No snapshots on this device"
-msgstr ""
+msgstr "لا توجد لقطات على هذا الجهاز"
 
 #: Gtk/MainWindow.vala:793
 msgid "No snapshots selected"
-msgstr ""
+msgstr "لا توجد لقطات محددة"
 
 #: Gtk/MainWindow.vala:1050 Gtk/MainWindow.vala:1052
 msgid "None"
-msgstr ""
+msgstr "لا شيء"
 
 #: Core/Subvolume.vala:184
 #, c-format
@@ -1447,54 +1480,58 @@ msgstr ""
 
 #: Core/SnapshotRepo.vala:683
 msgid "Not Selected"
-msgstr ""
+msgstr "غير محددة"
 
 #: Core/Main.vala:379
 msgid "Not Supported"
-msgstr ""
+msgstr "غير مدعوم"
 
 #: Core/SnapshotRepo.vala:629 Core/SnapshotRepo.vala:656
 msgid "Not enough disk space"
-msgstr ""
+msgstr "مساحة القرص غير كافيه"
 
 #: Console/AppConsole.vala:397 Gtk/FinishBox.vala:55
 msgid "Notes"
-msgstr ""
+msgstr "ملاحظات"
 
 #: Core/Main.vala:1147
 msgid "Nothing to do!"
-msgstr ""
+msgstr "لا شيء لتفعله!"
 
 #: Console/AppConsole.vala:423 Console/AppConsole.vala:452
 #: Console/AppConsole.vala:491 Console/AppConsole.vala:539
 msgid "Num"
-msgstr ""
+msgstr "العدد"
 
 #: Gtk/ScheduleBox.vala:282
 msgid ""
 "Number of snapshots to keep.\n"
 "Older snapshots will be removed once this limit is exceeded."
 msgstr ""
+"عدد اللقطات للاحتفاظ بها.\n"
+"ستتم إزالة اللقطات القديمة بمجرد تجاوز هذا الحد."
 
 #: Utility/GtkHelper.vala:121 Utility/Gtk/CustomMessageDialog.vala:167
 #: Utility/Gtk/CustomMessageDialog.vala:171
 #: Gtk/ExcludeListSummaryWindow.vala:84
 msgid "OK"
-msgstr ""
+msgstr "موافق"
 
 #: Gtk/SnapshotBackendBox.vala:179
 msgid ""
 "OS must be installed on a BTRFS partition with Ubuntu-type subvolume layout "
 "(@ and @home subvolumes). Other layouts are not supported."
 msgstr ""
+"يجب أن يتم تثبيت نظام التشغيل على قسم BTRFS مع نوع Ubuntu تخطيط subbolume (@ "
+"ووحدة التخزين الفرعية home@). التنسيقات الأخرى غير مدعومة."
 
 #: Core/Main.vala:4201
 msgid "Older log files removed"
-msgstr ""
+msgstr "تم إزالة أقدم ملفات السجل"
 
 #: Gtk/MainWindow.vala:1051
 msgid "Oldest snapshot"
-msgstr ""
+msgstr "اقدم لقطة"
 
 #: Gtk/SnapshotListBox.vala:297
 msgid "On demand (manual)"
@@ -1504,96 +1541,97 @@ msgstr ""
 msgid ""
 "Only ubuntu-type layouts with @ and @home subvolumes are currently supported."
 msgstr ""
+"يتم حالياً دعم تخطيطات من نوع ubuntu مع @ وحدات التخزين الفرعية home@ فقط."
 
 #: Gtk/MainWindow.vala:209
 msgid "Open Menu"
-msgstr ""
+msgstr "فتح القائمة"
 
 #: Core/Main.vala:3214
 msgid ""
 "Option --snapshot-device should not be specified for creating snapshots in "
 "BTRFS mode"
-msgstr ""
+msgstr "الخيار --يجب عدم تحديد جهاز-التقاط لإنشاء لقطات في وضع BTRFS"
 
 #: Console/AppConsole.vala:350 Gtk/AppGtk.vala:114
 msgid "Options"
-msgstr ""
+msgstr "خيارات"
 
 #: Gtk/RestoreExcludeBox.vala:118
 msgid "Other applications (next page)"
-msgstr ""
+msgstr "تطبيقات أخرى (الصفحة التالية)"
 
 #: Gtk/RsyncLogBox.vala:398 Gtk/RestoreBox.vala:134 Gtk/BackupBox.vala:96
 #, c-format
 msgid "Owner"
-msgstr ""
+msgstr "المالك"
 
 #: Utility/Device.vala:1824
 #, c-format
 msgid "Parent Device"
-msgstr ""
+msgstr "الجهاز الأصل"
 
 #: Core/Main.vala:2469 Core/Main.vala:2560 Gtk/RsyncLogBox.vala:222
 msgid "Parsing log file..."
-msgstr ""
+msgstr "تحليل ملف السجل..."
 
 #: Gtk/RestoreDeviceBox.vala:524
 msgid "Partition has an unsupported subvolume layout."
-msgstr ""
+msgstr "يحتوي القسم علي تخطيط وحده تخزين فرعيه غير معتمد."
 
 #: Core/SnapshotRepo.vala:688 Gtk/RestoreDeviceBox.vala:93
 #, c-format
 msgid "Path"
-msgstr ""
+msgstr "المسار"
 
 #: Gtk/ExcludeBox.vala:162
 msgid "Pattern"
-msgstr ""
+msgstr "النمط"
 
 #: Gtk/RsyncLogBox.vala:396 Gtk/RestoreBox.vala:133 Gtk/BackupBox.vala:95
 #, c-format
 msgid "Permissions"
-msgstr ""
+msgstr "الأذونات"
 
 #: Core/Main.vala:254
 msgid "Please check if you have multiple windows open."
-msgstr ""
+msgstr "يرجى التحقق مما إذا كان لديك نوافذ متعددة مفتوحة."
 
 #: Core/Main.vala:2244
 msgid "Please do not interrupt the restore process!"
-msgstr ""
+msgstr "من فضلك لا تقاطع عملية الاستعادة!"
 
 #: Core/Main.vala:348
 msgid "Please install required packages and try running TimeShift again"
-msgstr ""
+msgstr "الرجاء تثبيت الحزم المطلوبة ومحاولة تشغيل TimeShift مرة أخرى"
 
 #: Gtk/AppGtk.vala:127
 msgid "Please re-run the application as admin (using 'sudo' or 'su')"
-msgstr ""
+msgstr "يرجى إعادة تشغيل التطبيق كمسئول (باستخدام 'sudo' أو 'su')"
 
 #: Console/AppConsole.vala:103
 msgid "Please run the application as admin (using 'sudo' or 'su')"
-msgstr ""
+msgstr "يرجى تشغيل التطبيق كمسئول (باستخدام 'sudo' أو 'su')"
 
 #: Core/Main.vala:2194
 msgid "Please save your work and close all applications."
-msgstr ""
+msgstr "يرجى حفظ عملك وإغلاق جميع التطبيقات."
 
 #: Gtk/MainWindow.vala:695
 msgid "Please select a snapshot to view the log!"
-msgstr ""
+msgstr "يرجى تحديد لقطة لعرض السجل!"
 
 #: Gtk/RestoreDeviceBox.vala:512
 msgid "Please select the GRUB device"
-msgstr ""
+msgstr "يرجى تحديد جهاز GRUB"
 
 #: Core/Main.vala:250
 msgid "Please wait a few minutes and try again."
-msgstr ""
+msgstr "يرجى الانتظار بضع دقائق وحاول مرة أخرى."
 
 #: Gtk/MainWindow.vala:762
 msgid "Please wait for snapshots to be deleted."
-msgstr ""
+msgstr "يرجى الانتظار حتى يتم حذف اللقطات."
 
 #: Gtk/EstimateBox.vala:66
 msgid "Please wait..."
@@ -1601,74 +1639,76 @@ msgstr ""
 
 #: Gtk/RsyncLogBox.vala:188
 msgid "Populating list..."
-msgstr ""
+msgstr "جاري ملء القائمة..."
 
 #: Core/Main.vala:1579 Gtk/RsyncLogBox.vala:232 Gtk/DeleteBox.vala:68
 #: Gtk/RestoreBox.vala:88 Gtk/BackupBox.vala:114
 msgid "Preparing..."
-msgstr ""
+msgstr "جاري التجهيز..."
 
 #: Gtk/SetupWizardWindow.vala:189 Gtk/BackupWindow.vala:152
 #: Gtk/DeleteWindow.vala:154 Gtk/RestoreWindow.vala:190
 msgid "Previous"
-msgstr ""
+msgstr "السابق"
 
 #: Gtk/AppGtk.vala:116
 msgid "Print debug information"
-msgstr ""
+msgstr "طباعة معلومات التصحيح"
 
 #: Core/Main.vala:3794
 msgid "Query completed"
-msgstr ""
+msgstr "اكتمل الاستعلام"
 
 #: Core/Main.vala:3777
 msgid "Querying subvolume info..."
-msgstr ""
+msgstr "يتم الآن الاستعلام عن معلومات وحدة التخزين الفرعية..."
 
 #: Gtk/SnapshotBackendBox.vala:77
 msgid "RSYNC"
-msgstr ""
+msgstr "أداة RSYNC"
 
 #: Gtk/SnapshotBackendBox.vala:184
 msgid "RSYNC Snapshots"
-msgstr ""
+msgstr "لقطات RSYNC"
 
 #: Gtk/BootOptionsBox.vala:137
 msgid ""
 "Re-generates initramfs for all installed kernels. This is generally not "
 "needed. Select this only if the restored system fails to boot."
 msgstr ""
+"إعادة إنشاء initramfs لجميع النواة المثبتة. هذا عموماً ليس له داعي. حدد هذا "
+"فقط في حالة فشل النظام المستعاد للتمهيد."
 
 #: Console/AppConsole.vala:982
 #, c-format
 msgid "Re-install GRUB2 bootloader?"
-msgstr ""
+msgstr "أعاده تثبيت GRUB2 محمل الإقلاع؟"
 
 #: Core/Main.vala:2307
 msgid "Re-installing GRUB2 bootloader..."
-msgstr ""
+msgstr "جاري إعادة تثبيت GRUB2 محمل الإقلاع..."
 
 #: Gtk/BootOptionsBox.vala:120
 msgid "Re-installs the GRUB2 bootloader on the selected device."
-msgstr ""
+msgstr "إعادة تثبيت GRUB2 محمل الإقلاع على الجهاز المحدد."
 
 #: Gtk/RsyncLogBox.vala:181
 #, c-format
 msgid "Read %'d of %'d lines..."
-msgstr ""
+msgstr "قراءة %'d من %'d خطوط..."
 
 #: Core/Main.vala:2400
 msgid "Rebooting system..."
-msgstr ""
+msgstr "جاري إعادة تمهيد النظام..."
 
 #: Gtk/RestoreExcludeBox.vala:61 Gtk/RestoreExcludeBox.vala:91
 #, c-format
 msgid "Recommended"
-msgstr ""
+msgstr "موصى به"
 
 #: Gtk/BackupDeviceBox.vala:65 Gtk/RestoreDeviceBox.vala:70
 msgid "Refresh"
-msgstr ""
+msgstr "تحديث"
 
 #: Gtk/BackupDeviceBox.vala:106
 msgid "Remote and network locations are not supported."
@@ -1676,40 +1716,40 @@ msgstr ""
 
 #: Gtk/ExcludeBox.vala:253
 msgid "Remove"
-msgstr ""
+msgstr "إزالة"
 
 #: Core/SnapshotRepo.vala:975 Core/Main.vala:1617 Core/Main.vala:1628
 #: Core/Main.vala:4197 Core/Snapshot.vala:509
 #, c-format
 msgid "Removed"
-msgstr ""
+msgstr "تم الإزالة"
 
 #: Utility/CronTab.vala:341
 msgid "Removed cron task"
-msgstr ""
+msgstr "تم إزالة مهمة cron"
 
 #: Core/Main.vala:3582
 #, c-format
 msgid "Removed mount directory: '%s'"
-msgstr ""
+msgstr "تم إزاله دليل التحميل: '%s'"
 
 #: Core/Snapshot.vala:555
 msgid "Removed snapshot"
-msgstr ""
+msgstr "تم إزالة اللقطة"
 
 #: Core/Snapshot.vala:484
 msgid "Removing"
-msgstr ""
+msgstr "إزالة"
 
 #: Core/Snapshot.vala:521
 msgid "Removing snapshot"
-msgstr ""
+msgstr "إزالة اللقطة"
 
 #: Core/SnapshotRepo.vala:831 Core/SnapshotRepo.vala:850
 #: Core/SnapshotRepo.vala:868 Core/SnapshotRepo.vala:882
 #, c-format
 msgid "Removing snapshots"
-msgstr ""
+msgstr "إزالة اللقطات"
 
 #: Gtk/UsersBox.vala:360
 msgid ""
@@ -1721,7 +1761,7 @@ msgstr ""
 #: Gtk/RsyncLogBox.vala:377 Gtk/RsyncLogBox.vala:567 Gtk/MainWindow.vala:151
 #: Gtk/RestoreWindow.vala:125
 msgid "Restore"
-msgstr ""
+msgstr "استعادة"
 
 #: Gtk/UsersBox.vala:329
 msgid "Restore @home subvolume"
@@ -1729,39 +1769,39 @@ msgstr ""
 
 #: Gtk/RestoreWindow.vala:89
 msgid "Restore Device"
-msgstr ""
+msgstr "استعادة الجهاز"
 
 #: Gtk/RestoreWindow.vala:94
 msgid "Restore Exclude"
-msgstr ""
+msgstr "استبعاد الاستعادة"
 
 #: Gtk/RestoreWindow.vala:69
 msgid "Restore Snapshot"
-msgstr ""
+msgstr "استعادة اللقطات"
 
 #: Core/Main.vala:2809 Core/Main.vala:2851
 msgid "Restore completed"
-msgstr ""
+msgstr "اكتملت الاستعادة"
 
 #: Gtk/MainWindow.vala:152
 msgid "Restore selected snapshot"
-msgstr ""
+msgstr "استعادة اللقطة المحددة"
 
 #: Console/AppConsole.vala:363
 msgid "Restore snapshot"
-msgstr ""
+msgstr "استعادة اللقطة"
 
 #: Gtk/RestoreFinishBox.vala:96
 msgid "Restored subvolumes will become active after system is restarted."
-msgstr ""
+msgstr "ستصبح وحدات التخزين الفرعية المستعادة نشطة بعد إعادة تشغيل النظام."
 
 #: Core/Subvolume.vala:206
 msgid "Restored system subvolume"
-msgstr ""
+msgstr "تم استعادة وحدة التخزين الفرعية للنظام"
 
 #: Gtk/RestoreBox.vala:77 Gtk/RestoreBox.vala:190
 msgid "Restoring Snapshot..."
-msgstr ""
+msgstr "جاري استعادة اللقطة..."
 
 #: Gtk/FinishBox.vala:85
 msgid ""
@@ -1769,10 +1809,13 @@ msgid ""
 "currently in use will be preserved as a new snapshot. If required, this "
 "snapshot can be restored later to 'undo' the restore."
 msgstr ""
+"سيؤدي استعاده اللقطه إلى استبدال وحدات التخزين الفرعية للنظام، سيتم الاحتفاظ "
+"بوحدات التخزين الفرعية للنظام المستخدمة حاليا كلقطه جديده. إذا لزم الأمر، "
+"يمكن استعاده هذه اللقطة فيما بعد إلى 'تراجع' عن الاستعادة."
 
 #: Core/Main.vala:2778
 msgid "Restoring snapshot..."
-msgstr ""
+msgstr "جاري استعادة اللقطة..."
 
 #: Gtk/FinishBox.vala:88
 msgid ""
@@ -1782,15 +1825,19 @@ msgid ""
 "files will be backed up when snapshot is created, and replaced when snapshot "
 "is restored."
 msgstr ""
+"استعاده اللقطات فقط يستبدل ملفات النظام وإعداداته. لن يتم لمس الملفات غير "
+"المخفية والدلائل في الدليل الرئيسي للمستخدم. يمكن تغيير هذا السلوك باضافه "
+"فلتر لتضمين هذه الملفات. سيتم نسخ الملفات المضمنة احتياطيا عند إنشاء اللقطة، "
+"واستبدالها عند استعاده اللقطة."
 
 #: Utility/Device.vala:1814
 #, c-format
 msgid "Revision"
-msgstr ""
+msgstr "المراجعة"
 
 #: Gtk/RestoreDeviceBox.vala:452
 msgid "Root device not selected"
-msgstr ""
+msgstr "لم يتم تحديد جهاز الجذر"
 
 #: Gtk/RsyncLogWindow.vala:49
 msgid "Rsync Log Viewer"
@@ -1799,21 +1846,22 @@ msgstr ""
 #: Gtk/AppGtk.vala:119
 #, c-format
 msgid "Run 'timeshift' for the command-line version of this tool"
-msgstr ""
+msgstr "تشغيل 'timeshift' لإصدار سطر الأوامر من هذه الأداة"
 
 #: Console/AppConsole.vala:382
 msgid "Run in non-interactive mode"
-msgstr ""
+msgstr "تشغيل في وضع غير تبادلي"
 
 #: Core/Main.vala:186
 msgid "Running"
-msgstr ""
+msgstr "تشغيل"
 
 #: Gtk/FinishBox.vala:95
 msgid ""
 "Save snapshots to an external disk instead of the system disk to guard "
 "against drive failures."
 msgstr ""
+"حفظ اللقطات إلى قرص خارجي بدلا من قرص النظام للحماية من فشل محرك الاقراص."
 
 #: Gtk/FinishBox.vala:97
 msgid ""
@@ -1822,245 +1870,250 @@ msgid ""
 "even install another Linux distribution and later roll-back the previous "
 "distribution by restoring a snapshot."
 msgstr ""
+"يتيح لك حفظ اللقطات على قرص غير النظام تهيئة نظام التشغيل وإعادة تثبيته على "
+"قرص النظام دون فقد اللقطات المخزنة عليه. يمكنك حتى تثبيت توزيعة Linux أخرى "
+"والتراجع في وقت لاحق عن التوزيعة السابقة عن طريق استعادة اللقطة."
 
 #: Core/Main.vala:1285 Core/Main.vala:1439 Core/Main.vala:1441
 msgid "Saving to device"
-msgstr ""
+msgstr "الحفظ إلى الجهاز"
 
 #: Gtk/SetupWizardWindow.vala:109 Gtk/SettingsWindow.vala:92
 msgid "Schedule"
-msgstr ""
+msgstr "الجدولة"
 
 #: Core/Main.vala:257
 msgid "Scheduled snapshot in progress..."
-msgstr ""
+msgstr "اللقطة المجدولة قيد التقدم..."
 
 #: Core/Main.vala:1147 Gtk/MainWindow.vala:1067 Gtk/ScheduleBox.vala:312
 msgid "Scheduled snapshots are disabled"
-msgstr ""
+msgstr "تم تعطيل اللقطات المجدولة"
 
 #: Gtk/FinishBox.vala:78
 msgid "Scheduled snapshots are disabled. It's recommended to enable it."
-msgstr ""
+msgstr "تم تعطيل اللقطات المجدولة. من المستحسن تمكينه."
 
 #: Gtk/ScheduleBox.vala:305
 msgid "Scheduled snapshots are enabled"
-msgstr ""
+msgstr "يتم تمكين اللقطات المجدولة"
 
 #: Gtk/FinishBox.vala:75
 msgid ""
 "Scheduled snapshots are enabled. Snapshots will be created automatically for "
 "selected levels."
 msgstr ""
+"يتم تمكين اللقطات المجدولة. سيتم إنشاء اللقطات تلقائيا للمستويات المحددة."
 
 #: Console/AppConsole.vala:870
 #, c-format
 msgid "Select '%s' device (default = %s)"
-msgstr ""
+msgstr "تحديد جهاز '%s' (افتراضي = %s)"
 
 #: Console/AppConsole.vala:689 Core/SnapshotRepo.vala:593
 msgid "Select BTRFS system disk with root subvolume (@)"
-msgstr ""
+msgstr "تحديد قرص نظام BTRFS مع وحده التخزين الفرعية الجذر (@)"
 
 #: Console/AppConsole.vala:998
 msgid "Select GRUB device"
-msgstr ""
+msgstr "تحديد جهاز GRUB"
 
 #: Utility/GtkHelper.vala:815
 msgid "Select Path"
-msgstr ""
+msgstr "تحديد المسار"
 
 #: Gtk/MainWindow.vala:694
 msgid "Select Snapshot"
-msgstr ""
+msgstr "تحديد اللقطة"
 
 #: Gtk/ScheduleBox.vala:57
 msgid "Select Snapshot Levels"
-msgstr ""
+msgstr "تحديد مستويات اللقطة"
 
 #: Gtk/BackupDeviceBox.vala:56
 msgid "Select Snapshot Location"
-msgstr ""
+msgstr "تحديد موقع اللقطة"
 
 #: Gtk/SnapshotBackendBox.vala:62
 msgid "Select Snapshot Type"
-msgstr ""
+msgstr "تحديد نوع اللقطة"
 
 #: Gtk/DeleteWindow.vala:85
 msgid "Select Snapshots"
-msgstr ""
+msgstr "تحديد اللقطات"
 
 #: Gtk/RestoreDeviceBox.vala:61
 msgid "Select Target Device"
-msgstr ""
+msgstr "تحديد الجهاز الهدف"
 
 #: Gtk/BackupDeviceBox.vala:392
 #, c-format
 msgid "Select a partition on this disk"
-msgstr ""
+msgstr "تحديد قسم على هذا القرص"
 
 #: Gtk/MainWindow.vala:801
 msgid "Select a single snapshot to restore"
-msgstr ""
+msgstr "تحديد لقطة واحدة للاستعادة"
 
 #: Gtk/RestoreDeviceBox.vala:481
 msgid "Select another device for root file system (/)"
-msgstr ""
+msgstr "تحديد جهاز آخر لنظام ملفات الجذر (/)"
 
 #: Core/SnapshotRepo.vala:632 Core/SnapshotRepo.vala:659
 msgid "Select another device or free up some space"
-msgstr ""
+msgstr "تحديد جهاز آخر أو تحرير بعض المساحة"
 
 #: Gtk/MainWindow.vala:547 Gtk/MainWindow.vala:554
 msgid "Select another device to delete snasphots"
-msgstr ""
+msgstr "تحديد جهاز آخر لحذف اللقطات"
 
 #: Gtk/MainWindow.vala:481
 msgid "Select another device?"
-msgstr ""
+msgstr "تحديد جهاز آخر؟"
 
 #: Gtk/RestoreExcludeBox.vala:57
 msgid "Select applications to exclude from restore"
-msgstr ""
+msgstr "تحديد التطبيقات لاستبعادها من الاستعادة"
 
 #: Console/AppConsole.vala:672
 msgid "Select backup device"
-msgstr ""
+msgstr "تحديد جهاز النسخ الاحتياطي"
 
 #: Gtk/ExcludeBox.vala:433
 msgid "Select directory"
-msgstr ""
+msgstr "تحديد الدليل"
 
 #: Gtk/ExcludeBox.vala:406
 msgid "Select file(s)"
-msgstr ""
+msgstr "تحديد الملف(ات)"
 
 #: Console/AppConsole.vala:746
 msgid "Select snapshot"
-msgstr ""
+msgstr "تحديد اللقطة"
 
 #: Gtk/DeleteWindow.vala:342
 msgid "Select snapshots to delete"
-msgstr ""
+msgstr "تحديد اللقطات للحذف"
 
 #: Gtk/RestoreDeviceBox.vala:453
 msgid "Select the device for root file system (/)"
-msgstr ""
+msgstr "تحديد جهاز لنظام الملفات الجذر (/)"
 
 #: Gtk/RestoreDeviceBox.vala:83
 msgid "Select the devices where files will be restored."
-msgstr ""
+msgstr "تحديد أجهزة حيث سيتم استعادة الملفات."
 
 #: Gtk/ScheduleBox.vala:313
 msgid "Select the intervals for creating snapshots"
-msgstr ""
+msgstr "تحديد الفواصل الزمنية لإنشاء اللقطات"
 
 #: Gtk/ExcludeBox.vala:273
 msgid "Select the items to be removed from the list"
-msgstr ""
+msgstr "تحديد العناصر المراد إزالتها من القائمة"
 
 #: Core/SnapshotRepo.vala:553
 msgid "Select the snapshot device"
-msgstr ""
+msgstr "تحديد جهاز اللقطة"
 
 #: Gtk/MainWindow.vala:794
 msgid "Select the snapshot to restore"
-msgstr ""
+msgstr "تحديد اللقطة للاستعادة"
 
 #: Gtk/DeleteWindow.vala:87
 msgid "Select the snapshots to be deleted"
-msgstr ""
+msgstr "تحديد اللقطات المراد حذفها"
 
 #: Gtk/MainWindow.vala:616
 msgid "Select the snapshots to mark for deletion"
-msgstr ""
+msgstr "تحديد اللقطات لتعليمها للحذف"
 
 #: Gtk/RestoreDeviceBox.vala:79
 msgid "Select the target devices where system will be cloned."
-msgstr ""
+msgstr "تحديد الأجهزة المستهدفة حيث سيتم استنساخ النظام."
 
 #: Core/Main.vala:3242
 msgid "Selected default snapshot device"
-msgstr ""
+msgstr "جهاز اللقطة الافتراضي المحدد"
 
 #: Core/Main.vala:3193 Core/Main.vala:3197
 msgid "Selected default snapshot type"
-msgstr ""
+msgstr "نوع اللقطة الافتراضية المحددة"
 
 #: Gtk/BackupDeviceBox.vala:373
 msgid "Selected device does not have BTRFS partition"
-msgstr ""
+msgstr "لا يحتوي الجهاز المحدد على قسم BTRFS"
 
 #: Gtk/BackupDeviceBox.vala:371
 msgid "Selected device does not have Linux partition"
-msgstr ""
+msgstr "لا يحتوي الجهاز المحدد على قسم Linux"
 
 #: Core/SnapshotRepo.vala:146
 msgid "Selected snapshot device"
-msgstr ""
+msgstr "جهاز اللقطة المحدد"
 
 #: Console/AppConsole.vala:688 Core/SnapshotRepo.vala:592
 msgid "Selected snapshot device is not a system disk"
-msgstr ""
+msgstr "جهاز اللقطة المحدد ليس قرص نظام"
 
 #: Core/Main.vala:2027
 msgid "Selected snapshot is marked for deletion"
-msgstr ""
+msgstr "تعليم اللقطة المحددة للحذف"
 
 #: Gtk/MainWindow.vala:825
 msgid "Selected snapshot is marked for deletion and cannot be restored"
-msgstr ""
+msgstr "تم وضع علامة على اللقطة المحددة للحذف ولا يمكن استعادتها"
 
 #: Gtk/UsersBox.vala:238
 msgid ""
 "Selected user has an encrypted home directory. It's not possible to include "
 "only hidden files."
 msgstr ""
+"المستخدم المحدد لديه دليل رئيسي مشفر. لا يمكن تضمين الملفات المخفية فقط."
 
 #: Utility/Device.vala:1813
 #, c-format
 msgid "Serial"
-msgstr ""
+msgstr "المسلسل"
 
 #: Core/Main.vala:214
 msgid "Session log file"
-msgstr ""
+msgstr "ملف سجل الجلسة"
 
 #: Console/AppConsole.vala:359
 msgid "Set snapshot description"
-msgstr ""
+msgstr "تعيين وصف اللقطة"
 
 #: Gtk/MainWindow.vala:181 Gtk/MainWindow.vala:182 Gtk/SettingsWindow.vala:55
 msgid "Settings"
-msgstr ""
+msgstr "الإعدادات"
 
 #: Gtk/MainWindow.vala:192
 msgid "Settings wizard"
-msgstr ""
+msgstr "معالج الإعدادات"
 
 #: Gtk/FinishBox.vala:58
 msgid "Setup Complete"
-msgstr ""
+msgstr "اكتمل الإعداد"
 
 #: Gtk/SetupWizardWindow.vala:64
 msgid "Setup Wizard"
-msgstr ""
+msgstr "معالج الإعداد"
 
 #: Console/AppConsole.vala:379
 msgid "Show additional debug messages"
-msgstr ""
+msgstr "عرض رسائل تصحيح إضافية"
 
 #: Console/AppConsole.vala:383 Gtk/AppGtk.vala:117
 msgid "Show all options"
-msgstr ""
+msgstr "عرض كل الخيارات"
 
 #: Gtk/RestoreExcludeBox.vala:121
 msgid "Show more applications to exclude on the next page"
-msgstr ""
+msgstr "عرض المزيد من التطبيقات لاستبعادها في الصفحة التالية"
 
 #: Console/AppConsole.vala:380
 msgid "Show rsync output (default)"
-msgstr ""
+msgstr "عرض إخراج rsync (افتراضي)"
 
 #: Utility/Device.vala:1816 Utility/Device.vala:1831
 #: Console/AppConsole.vala:456 Console/AppConsole.vala:495
@@ -2069,7 +2122,7 @@ msgstr ""
 #: Gtk/SnapshotListBox.vala:174
 #, c-format
 msgid "Size"
-msgstr ""
+msgstr "الحجم"
 
 #: Gtk/SnapshotBackendBox.vala:177
 msgid ""
@@ -2078,16 +2131,20 @@ msgid ""
 "(copy-on-write). Files in the snapshot continue to point to original data "
 "blocks."
 msgstr ""
+"حجم لقطات BTRFS في البداية هي صفر. كملفات النظام تتغير تدريجيا مع مرور "
+"الوقت، تتم كتابة البيانات إلى كتل البيانات الجديدة التي تشغل مساحة القرص "
+"(النسخ عند الكتابة). تستمر الملفات في اللقطة في الإشارة إلى كتل البيانات "
+"الأصلية."
 
 #: Console/AppConsole.vala:368
 msgid "Skip GRUB2 reinstall"
-msgstr ""
+msgstr "تخطي إعادة تثبيت GRUB2"
 
 #: Core/SnapshotRepo.vala:714 Core/SnapshotRepo.vala:752 Core/Main.vala:2032
 #: Gtk/SnapshotListBox.vala:95
 #, c-format
 msgid "Snapshot"
-msgstr ""
+msgstr "اللقطة"
 
 #: Gtk/MainWindow.vala:564
 #, c-format
@@ -2095,10 +2152,12 @@ msgid ""
 "Snapshot '%s' is being used by the system and cannot be deleted. Restart the "
 "system to activate the restored snapshot."
 msgstr ""
+"اللقطة '%s' قيد الاستخدام من قبل النظام ولا يمكن حذفها. أعد تشغيل النظام "
+"لتنشيط اللقطة المستعادة."
 
 #: Gtk/BackupFinishBox.vala:60
 msgid "Snapshot Created"
-msgstr ""
+msgstr "تم إنشاء اللقطة"
 
 #: Gtk/SnapshotListBox.vala:296
 #, c-format
@@ -2107,62 +2166,66 @@ msgstr ""
 
 #: Gtk/MainWindow.vala:761
 msgid "Snapshot deletion in progress..."
-msgstr ""
+msgstr "حذف اللقطة قيد التقدم..."
 
 #: Core/SnapshotRepo.vala:470
 #, c-format
 msgid "Snapshot device"
-msgstr ""
+msgstr "جهاز اللقطة"
 
 #: Console/AppConsole.vala:662 Core/SnapshotRepo.vala:559
 msgid "Snapshot device not available"
-msgstr ""
+msgstr "جهاز اللقطة غير متوفر"
 
 #: Console/AppConsole.vala:658 Core/SnapshotRepo.vala:552
 msgid "Snapshot device not selected"
-msgstr ""
+msgstr "لم يتم تحديد جهاز اللقطة"
 
 #: Core/SnapshotRepo.vala:474
 #, c-format
 msgid "Snapshot location"
-msgstr ""
+msgstr "موقع اللقطة"
 
 #: Core/Main.vala:1252
 msgid "Snapshot saved successfully"
-msgstr ""
+msgstr "تم حفظ اللقطة بنجاح"
 
 #: Core/Main.vala:2022
 msgid "Snapshot to restore not specified!"
-msgstr ""
+msgstr "لم يتم تحديد لقطة للاستعادة!"
 
 #: Core/Main.vala:2855
 msgid "Snapshot will become active after system is rebooted."
-msgstr ""
+msgstr "ستصبح اللقطة نشطة بعد إعاده تمهيد النظام."
 
 #: Gtk/DeleteFinishBox.vala:60
 msgid "Snapshot(s) Deleted"
-msgstr ""
+msgstr "اللقطة(ات) المحذوفة"
 
 #: Gtk/MainWindow.vala:310 Gtk/DeleteWindow.vala:89
 msgid "Snapshots"
-msgstr ""
+msgstr "اللقطات"
 
 #: Gtk/SnapshotBackendBox.vala:169
 msgid ""
 "Snapshots are created and restored instantly. Snapshot creation is an atomic "
 "transaction at the file system level."
 msgstr ""
+"يتم إنشاء اللقطات واستعادتها على الفور. إنشاء لقطة عبارة عن معاملة ذرية على "
+"مستوى نظام الملفات."
 
 #: Gtk/SnapshotBackendBox.vala:186
 msgid ""
 "Snapshots are created by creating copies of system files using rsync, and "
 "hard-linking unchanged files from previous snapshot."
 msgstr ""
+"يتم إنشاء اللقطات عن طريق إنشاء نسخ من ملفات النظام باستخدام أداة rsync، "
+"والملفات الثابتة غير المتغيرة من اللقطات السابقة."
 
 #: Gtk/SnapshotBackendBox.vala:167
 msgid ""
 "Snapshots are created using the built-in features of the BTRFS file system."
-msgstr ""
+msgstr "يتم إنشاء اللقطات باستخدام الميزات المضمنة في نظام ملفات BTRFS."
 
 #: Gtk/ScheduleBox.vala:167
 #, c-format
@@ -2173,7 +2236,7 @@ msgstr ""
 msgid ""
 "Snapshots are perfect, byte-for-byte copies of the system. Nothing is "
 "excluded."
-msgstr ""
+msgstr "اللقطات المثالية، نسخ بايت لبايت النظام. لا شيء مستبعد."
 
 #: Gtk/SnapshotBackendBox.vala:171
 msgid ""
@@ -2181,6 +2244,9 @@ msgid ""
 "copied, deleted or overwritten, there is no risk of data loss. The existing "
 "system is preserved as a new snapshot after restore."
 msgstr ""
+"يتم استعاده اللقطات باستبدال وحدات التخزين الفرعية للنظام. وبما ان الملفات "
+"لم يتم نسخها أو حذفها أو الكتابة فوقها، فلن يكون هناك اي خطر من فقدان "
+"البيانات. يتم الاحتفاظ بالنظام الموجود كلقطه جديده بعد الاستعادة."
 
 #: Gtk/SnapshotBackendBox.vala:175
 msgid ""
@@ -2188,6 +2254,9 @@ msgid ""
 "disk). Storage on other disks is not supported. If system disk fails then "
 "snapshots stored on it will be lost along with the system."
 msgstr ""
+"يتم حفظ اللقطات على نفس القرص الذي يتم إنشاؤها منه (قرص النظام). التخزين على "
+"الأقراص الأخرى غير مدعوم. في حالة فشل قرص النظام، سيتم فقدان اللقطات المخزنة "
+"عليه مع النظام."
 
 #: Gtk/BackupDeviceBox.vala:107
 msgid ""
@@ -2203,7 +2272,7 @@ msgstr ""
 
 #: Gtk/MainWindow.vala:1012
 msgid "Snapshots available for restore"
-msgstr ""
+msgstr "اللقطات المتاحة للاستعادة"
 
 #: Gtk/SnapshotBackendBox.vala:190
 msgid ""
@@ -2211,53 +2280,58 @@ msgid ""
 "Saving snapshots to non-system or external disk allows the system to be "
 "restored even if system disk is damaged or re-formatted."
 msgstr ""
+"يمكن حفظ اللقطات على أي قرص تم تنسيقه باستخدام نظام ملفات Linux. يسمح حفظ "
+"اللقطات إلى غير النظام أو القرص الخارجي باستعادة النظام حتى في حالة تلف قرص "
+"النظام أو إعادة تنسيقه."
 
 #: Console/AppConsole.vala:283
 msgid "Snapshots cannot be created in Live CD mode"
-msgstr ""
+msgstr "لا يمكن إنشاء اللقطات في وضع CD المباشر"
 
 #: Gtk/MainWindow.vala:1059
 msgid "Snapshots will be created at selected intervals"
-msgstr ""
+msgstr "سيتم إنشاء اللقطات في فترات زمنية محددة"
 
 #: Gtk/ScheduleBox.vala:306
 msgid ""
 "Snapshots will be created at selected intervals if snapshot disk has enough "
 "space (> 1 GB)"
 msgstr ""
+"سيتم إنشاء اللقطات على فترات زمنية محددة إذا كانت مساحة قرص اللقطة كافية (> "
+"1 غيغابايت)"
 
 #: Gtk/MainWindow.vala:642
 msgid "Snapshots will be removed during the next scheduled run"
-msgstr ""
+msgstr "ستتم إزالة اللقطات أثناء التشغيل المجدول التالي"
 
 #: Console/AppConsole.vala:375
 msgid "Specify backup device (default: config)"
-msgstr ""
+msgstr "تحديد جهاز النسخ الاحتياطي (الافتراضي: التكوين)"
 
 #: Console/AppConsole.vala:367
 msgid "Specify device for installing GRUB2 bootloader"
-msgstr ""
+msgstr "حدد الجهاز لتثبيت محمل إقلاع GRUB2"
 
 #: Console/AppConsole.vala:365
 msgid "Specify snapshot to restore"
-msgstr ""
+msgstr "تحديد لقطة للاستعادة"
 
 #: Console/AppConsole.vala:366
 msgid "Specify target device"
-msgstr ""
+msgstr "تحديد الجهاز الهدف"
 
 #: Core/SnapshotRepo.vala:480 Gtk/RsyncLogBox.vala:472
 #, c-format
 msgid "Status"
-msgstr ""
+msgstr "الحالة"
 
 #: Gtk/ScheduleBox.vala:154
 msgid "Stop cron emails for scheduled tasks"
-msgstr ""
+msgstr "إيقاف رسائل بريد إلكتروني cron للمهام المجدولة"
 
 #: Utility/TeeJee.Process.vala:511
 msgid "Stopped"
-msgstr ""
+msgstr "توقف"
 
 #: Core/Subvolume.vala:189
 #, c-format
@@ -2272,78 +2346,80 @@ msgstr ""
 #: Gtk/ExcludeAppsBox.vala:135 Gtk/ExcludeBox.vala:258
 #: Gtk/RestoreWindow.vala:120
 msgid "Summary"
-msgstr ""
+msgstr "الملخص"
 
 #: Console/AppConsole.vala:377
 msgid "Switch to BTRFS mode (default: config)"
-msgstr ""
+msgstr "التبديل إلى وضع BTRFS (الافتراضي: التكوين)"
 
 #: Console/AppConsole.vala:378
 msgid "Switch to RSYNC mode (default: config)"
-msgstr ""
+msgstr "التبديل إلى وضع RSYNC (الافتراضي: التكوين)"
 
 #: Core/SnapshotRepo.vala:1029
 msgid "Symlinks updated"
-msgstr ""
+msgstr "الروابط الرمزية محدثة"
 
 #: Core/Main.vala:2382
 msgid "Synching file systems..."
-msgstr ""
+msgstr "مزامنة أنظمة الملفات..."
 
 #: Core/Main.vala:1361 Core/Main.vala:2544 Core/Main.vala:2785
 msgid "Synching files with rsync..."
-msgstr ""
+msgstr "جاري مزامنة الملفات مع rsync..."
 
 #: Gtk/AppGtk.vala:112
 msgid "Syntax"
-msgstr ""
+msgstr "Syntax"
 
 #: Utility/Device.vala:1837 Gtk/SnapshotListBox.vala:127
 #, c-format
 msgid "System"
-msgstr ""
+msgstr "النظام"
 
 #: Gtk/MainWindow.vala:957
 msgid "System Restore Utility"
-msgstr ""
+msgstr "أداه استعاده النظام"
 
 #: Gtk/FinishBox.vala:82
 msgid "System can be rolled-back to a previous date by restoring a snapshot."
-msgstr ""
+msgstr "يمكن إرجاع النظام إلى تاريخ سابق عن طريق استعادة لقطة."
 
 #: Core/Main.vala:2245
 msgid "System will reboot after files are restored"
-msgstr ""
+msgstr "سيتم إعادة تمهيد النظام بعد استعادة الملفات"
 
 #: Core/Main.vala:2195
 msgid "System will reboot after files are restored."
-msgstr ""
+msgstr "سيتم إعادة تمهيد النظام بعد استعادة الملفات."
 
 #: Core/Main.vala:1221 Core/Main.vala:1262
 msgid "Tagged snapshot"
-msgstr ""
+msgstr "لقطة معلمه"
 
 #: Console/AppConsole.vala:426 Gtk/SnapshotListBox.vala:151
 msgid "Tags"
-msgstr ""
+msgstr "العلامات"
 
 #: Core/Main.vala:2057
 msgid "Target device is not mounted"
-msgstr ""
+msgstr "لم يتم تحميل الجهاز الهدف"
 
 #: Gtk/RestoreDeviceBox.vala:480
 msgid "Target device is same as system device"
-msgstr ""
+msgstr "الجهاز الهدف هو نفسه جهاز النظام"
 
 #: Core/Main.vala:2051
 msgid "Target device not specified!"
-msgstr ""
+msgstr "لم يتم تحديد الجهاز الهدف!"
 
 #: Gtk/SnapshotBackendBox.vala:118
 msgid ""
 "The 'btrfs' command is not available on your system. Install the 'btrfs-"
 "tools' package and try again."
 msgstr ""
+"لا يتوفر الأمر 'btrfs' على نظامك. قم بتثبيت حزمة \"btrfs-tools\" وحاول مرة "
+"أخرى."
 
 #: Gtk/ScheduleBox.vala:156
 msgid ""
@@ -2351,33 +2427,38 @@ msgid ""
 "current user. Select this option to suppress the emails for cron tasks "
 "created by Timeshift."
 msgstr ""
+"ترسل خدمة cron إخراج المهام المجدولة كرسالة بريد إلكتروني إلى المستخدم "
+"الحالي. حدد هذا الخيار لمنع رسائل البريد الإلكتروني الخاصة بمهام cron التي "
+"أنشأها Timeshift."
 
 #: Core/Main.vala:376
 msgid "The system partition has an unsupported subvolume layout."
-msgstr ""
+msgstr "يحتوي قسم النظام على تخطيط وحده تخزين فرعيه غير معتمد."
 
 #: Core/Main.vala:3431
 msgid "The target partition has an unsupported subvolume layout."
-msgstr ""
+msgstr "يحتوي القسم الهدف على تخطيط وحده تخزين فرعيه غير معتمد."
 
 #: Gtk/BackupDeviceBox.vala:494
 #, c-format
 msgid "There are no snapshots on this device"
-msgstr ""
+msgstr "لا توجد لقطات على هذا الجهاز"
 
 #: Utility/Device.vala:1259
 msgid "This device is not encrypted"
-msgstr ""
+msgstr "هذا الجهاز غير مشفر"
 
 #: Core/Main.vala:2211
 msgid ""
 "This software comes without absolutely NO warranty and the author takes no "
 "responsibility for any damage arising from the use of this program."
 msgstr ""
+"يأتي هذا البرنامج بدون أي ضمان على الإطلاق ولا يتحمل المؤلف أية مسؤولية عن "
+"أي ضرر ينشأ عن استخدام هذا البرنامج."
 
 #: Gtk/MainWindow.vala:1047 Gtk/MainWindow.vala:1058
 msgid "Timeshift is active"
-msgstr ""
+msgstr "Timeshift نشط"
 
 #: Gtk/MainWindow.vala:948
 msgid ""
@@ -2388,12 +2469,12 @@ msgstr ""
 #: Gtk/RsyncLogBox.vala:394 Gtk/RestoreBox.vala:132 Gtk/BackupBox.vala:94
 #, c-format
 msgid "Timestamp"
-msgstr ""
+msgstr "الطابع الزمني"
 
 #: Console/AppConsole.vala:611
 #, c-format
 msgid "To restore with default options, press the ENTER key for all prompts!"
-msgstr ""
+msgstr "لاستعاده الخيارات الافتراضية، اضغط المفتاح ENTER لكافة المطالبات!"
 
 #: Utility/Gtk/AboutWindow.vala:441
 msgid "Translations"
@@ -2404,101 +2485,101 @@ msgstr ""
 #: Gtk/SettingsWindow.vala:86
 #, c-format
 msgid "Type"
-msgstr ""
+msgstr "النوع"
 
 #: Utility/Device.vala:1826
 #, c-format
 msgid "UUID"
-msgstr ""
+msgstr "UUID"
 
 #: Gtk/AppGtk.vala:99
 msgid "Unknown option"
-msgstr ""
+msgstr "خيار غير معروف"
 
 #: Core/Main.vala:1203
 msgid "Unknown snapshot type"
-msgstr ""
+msgstr "نوع اللقطة غير معروف"
 
 #: Core/Main.vala:1566
 msgid "Unknown value specified for option --tags"
-msgstr ""
+msgstr "قيمة محددة غير معروفة للخيار --العلامات"
 
 #: Utility/Device.vala:1270 Utility/Device.vala:1386
 #, c-format
 msgid "Unlocked device is mapped to '%s'"
-msgstr ""
+msgstr "تم تعيين الجهاز غير المؤمن إلى '%s'"
 
 #: Utility/Device.vala:1385
 msgid "Unlocked successfully"
-msgstr ""
+msgstr "تم إلغاء التأمين بنجاح"
 
 #: Utility/Device.vala:1600
 msgid "Unmounting from"
-msgstr ""
+msgstr "إلغاء التحميل من"
 
 #: Gtk/SnapshotListBox.vala:199
 msgid "Unshared"
-msgstr ""
+msgstr "غير مشترك"
 
 #: Core/Main.vala:3435 Gtk/RestoreDeviceBox.vala:522
 msgid "Unsupported Subvolume Layout"
-msgstr ""
+msgstr "تخطيط وحده تخزين فرعيه غير معتمده"
 
 #: Gtk/BootOptionsBox.vala:150
 msgid "Update GRUB menu"
-msgstr ""
+msgstr "تحديث قائمة GRUB"
 
 #: Gtk/BootOptionsBox.vala:135
 msgid "Update initramfs"
-msgstr ""
+msgstr "تحديث initramfs"
 
 #: Core/Main.vala:2724
 msgid "Updated /etc/crypttab on target device"
-msgstr ""
+msgstr "تحديث /etc/crypttab على الجهاز الهدف"
 
 #: Core/Main.vala:2644
 msgid "Updated /etc/fstab on target device"
-msgstr ""
+msgstr "تحديث /etc/fstab على الجهاز الهدف"
 
 #: Gtk/BootOptionsBox.vala:152
 msgid ""
 "Updates the GRUB menu entries (recommended). This is safe to run and should "
 "be left selected."
-msgstr ""
+msgstr "تحديث إدخالات قائمة GRUB (مستحسن). هذا آمن للتشغيل ويجب تركه محدداً."
 
 #: Core/Main.vala:2365
 msgid "Updating GRUB menu..."
-msgstr ""
+msgstr "جاري تحديث قائمة GRUB..."
 
 #: Core/Main.vala:2568
 msgid "Updating bootloader configuration..."
-msgstr ""
+msgstr "جارٍ تحديث تكوين محمل الإقلاع..."
 
 #: Utility/Device.vala:1834
 #, c-format
 msgid "Used"
-msgstr ""
+msgstr "المستخدمة"
 
 #: Gtk/SetupWizardWindow.vala:114 Gtk/UsersBox.vala:105
 msgid "User"
-msgstr ""
+msgstr "المستخدم"
 
 #: Gtk/UsersBox.vala:63
 msgid "User Home Directories"
-msgstr ""
+msgstr "دليل المستخدم الرئيسي"
 
 #: Utility/Device.vala:1340
 msgid "User cancelled the password prompt"
-msgstr ""
+msgstr "المستخدم ألغى المطالبه بكلمه المرور"
 
 #: Gtk/UsersBox.vala:67
 msgid ""
 "User home directories are excluded by default unless you enable them here"
-msgstr ""
+msgstr "يتم استبعاد دلائل المستخدم الرئيسية افتراضياً ما لم تقم بتمكينها هنا"
 
 #: Gtk/SettingsWindow.vala:98
 msgid "Users"
-msgstr ""
+msgstr "المستخدمين"
 
 #: Gtk/RestoreWindow.vala:114
 msgid "Users Home"
@@ -2507,7 +2588,7 @@ msgstr ""
 #: Utility/Device.vala:1811
 #, c-format
 msgid "Vendor"
-msgstr ""
+msgstr "البائع"
 
 #: Gtk/SnapshotListBox.vala:343
 msgid "View Rsync Log for Create"
@@ -2519,56 +2600,56 @@ msgstr ""
 
 #: Gtk/MainWindow.vala:378
 msgid "View TimeShift Logs"
-msgstr ""
+msgstr "عرض سجلات TimeShift"
 
 #: Gtk/RestoreDeviceBox.vala:101
 msgid "Volume"
-msgstr ""
+msgstr "وحدة التخزين"
 
 #: Core/Main.vala:2106 Gtk/RestoreSummaryBox.vala:53
 msgid "Warning"
-msgstr ""
+msgstr "تحذير"
 
 #: Gtk/RestoreExcludeBox.vala:61
 msgid "Web Browsers"
-msgstr ""
+msgstr "متصفحات الإنترنت"
 
 #: Utility/Gtk/DonationWindow.vala:113
 #, c-format
 msgid "Website"
-msgstr ""
+msgstr "موقع الإنترنت"
 
 #: Gtk/ScheduleBox.vala:82 Gtk/SnapshotListBox.vala:301
 msgid "Weekly"
-msgstr ""
+msgstr "أسبوعي"
 
 #: Core/Main.vala:1107
 msgid "Weekly snapshot failed!"
-msgstr ""
+msgstr "فشلت اللقطة الأسبوعية!"
 
 #: Core/Main.vala:1088
 msgid "Weekly snapshots are enabled"
-msgstr ""
+msgstr "يتم تمكين اللقطات الأسبوعية"
 
 #: Utility/Gtk/DonationWindow.vala:105
 msgid "Wiki ~ Documentation & Help"
-msgstr ""
+msgstr "Wiki ~ التوثيق & المساعدة"
 
 #: Gtk/BackupFinishBox.vala:63 Gtk/DeleteFinishBox.vala:63
 msgid "With Errors"
-msgstr ""
+msgstr "مع أخطاء"
 
 #: Gtk/MainWindow.vala:191
 msgid "Wizard"
-msgstr ""
+msgstr "المعالج"
 
 #: Utility/Device.vala:1313 Utility/Device.vala:1359
 msgid "Wrong password"
-msgstr ""
+msgstr "كلمة المرور خاطئة"
 
 #: Utility/Gtk/CustomMessageDialog.vala:176
 msgid "Yes"
-msgstr ""
+msgstr "نعم"
 
 #: Gtk/RestoreFinishBox.vala:98
 msgid ""
@@ -2576,73 +2657,165 @@ msgid ""
 "system will be visible as a new snapshot. This snapshot can be restored "
 "later if required, to 'undo' the restore."
 msgstr ""
+"يمكنك متابعه العمل علي النظام الحالي. بعد أعاده التشغيل، سيكون النظام الحالي "
+"مرئياً كلقطه جديده. يمكن استعاده هذه اللقطة في وقت لاحق إذا لزم الأمر، إلى "
+"'تراجع' عن الاستعادة."
 
 #: Gtk/RestoreDeviceBox.vala:413
 msgid ""
 "[Advanced Users Only] Change these settings only if the restored system "
 "fails to boot."
 msgstr ""
+"[للمستخدمين المتقدمين فقط] قم بتغيير هذه الإعدادات فقط في حالة فشل النظام "
+"المستعاد في التمهيد."
 
 #: Console/AppConsole.vala:1010
 #, c-format
 msgid "[ENTER = Default (%s), a = Abort]"
-msgstr ""
+msgstr "[ENTER = افتراضي (%s)، a = إجهاض]"
 
 #: Console/AppConsole.vala:881
 #, c-format
 msgid "[ENTER = Default (%s), r = Root device, a = Abort]"
-msgstr ""
+msgstr "[ENTER = افتراضي (%s)، r = جهاز الجذر، a = إجهاض]"
 
 #: Utility/AppLock.vala:54
 msgid "[Warning] Deleted invalid lock"
-msgstr ""
+msgstr "[تحذير] تم حذف تامين غير صالح"
 
 #: Core/SnapshotRepo.vala:882
 msgid "all"
-msgstr ""
+msgstr "الكل"
 
 #: Core/Subvolume.vala:201 Core/Main.vala:1494 Core/Main.vala:3862
 #: Core/Main.vala:3946 Core/Main.vala:4054 Core/Main.vala:4093
 msgid "btrfs returned an error"
-msgstr ""
+msgstr "تم إرجاع btrfs بخطأ"
 
 #: Core/Main.vala:1393 Core/Snapshot.vala:500
 msgid "complete"
-msgstr ""
+msgstr "اكتمل"
 
 #: Utility/CronTab.vala:261
 msgid "crontab file exported"
-msgstr ""
+msgstr "تم تصدير ملف crontab"
 
 #: Utility/CronTab.vala:244
 msgid "crontab file installed"
-msgstr ""
+msgstr "تم تثبيت ملف crontab"
 
 #: Core/SnapshotRepo.vala:868
 msgid "incomplete"
-msgstr ""
+msgstr "غير مكتمل"
 
 #: Core/SnapshotRepo.vala:850
 msgid "marked for deletion"
-msgstr ""
+msgstr "معلمة للحذف"
 
 #: Core/Main.vala:1285 Core/Main.vala:1439 Core/Main.vala:1441
 msgid "mounted at path"
-msgstr ""
+msgstr "مسار المحملة"
 
 #: Core/Main.vala:1393 Core/Snapshot.vala:501 Gtk/DeleteBox.vala:149
 #: Gtk/RestoreBox.vala:237 Gtk/BackupBox.vala:234
 msgid "remaining"
-msgstr ""
+msgstr "المتبقية"
 
 #: Core/Main.vala:1404
 msgid "rsync returned an error"
-msgstr ""
+msgstr "تم إرجاع rsync بخطأ"
 
 #: Core/SnapshotRepo.vala:714 Core/SnapshotRepo.vala:752
 #: Core/SnapshotRepo.vala:831
 msgid "un-tagged"
-msgstr ""
+msgstr "غير-المعلمة"
+
+#~ msgid ""
+#~ "<b>Backup Levels</b>\n"
+#~ "\n"
+#~ "O\tOn demand (manual)\n"
+#~ "B\tBoot\n"
+#~ "H\tHourly\n"
+#~ "D\tDaily\n"
+#~ "W\tWeekly\n"
+#~ "M\tMonthly"
+#~ msgstr ""
+#~ "<b>مستويات النسخ الاحتياطي</b>\n"
+#~ "\n"
+#~ "O\tعند الطلب (يدوي)\n"
+#~ "\n"
+#~ "B\tالتمهيد\n"
+#~ "H\tكل ساعة\n"
+#~ "D\tيوميا\n"
+#~ "W\tأسبوعي\n"
+#~ "M\tشهري"
+
+#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
+#~ msgstr "<b>تاريخ اللقطات:</b> تاريخ إنشاء اللقطة"
 
 #~ msgid "<b>System:</b> Installed Linux distribution"
-#~ msgstr "<b>نظام</b> توزيعة لينيكس المثبتة"
+#~ msgstr "<b>النظام:</b> توزيعة Linux المثبتة"
+
+#~ msgid ""
+#~ "Click an item to edit the pattern.\n"
+#~ "Drag and drop items with mouse to re-order."
+#~ msgstr ""
+#~ "انقر فوق عنصر لتحرير النمط.\n"
+#~ "اسحب العناصر وأفلتها باستخدام الماوس لإعادة الترتيب."
+
+#~ msgid "Cloning System..."
+#~ msgstr "استنساخ النظام..."
+
+#~ msgid "Close Window"
+#~ msgstr "إغلاق النافذة"
+
+#~ msgid "Contributions"
+#~ msgstr "مساهمات"
+
+#~ msgid "Create snapshots using RSYNC"
+#~ msgstr "إنشاء لقطات باستخدام أداة RSYNC"
+
+#~ msgid "Deleted system subvolumes"
+#~ msgstr "تم حذف وحدات التخزين الفرعية للنظام"
+
+#~ msgid "Documenters"
+#~ msgstr "الموثقين"
+
+#~ msgid "Editing and Re-Ordering"
+#~ msgstr "التحرير وإعادة الترتيب"
+
+#~ msgid "Include everything"
+#~ msgstr "تضمين كل شيء"
+
+#~ msgid "Include hidden items"
+#~ msgstr "تضمين العناصر المخفية"
+
+#~ msgid "Info"
+#~ msgstr "معلومات"
+
+#~ msgid "Log Viewer"
+#~ msgstr "عارض السجل"
+
+#~ msgid "Refresh Snapshot List"
+#~ msgstr "تحديث قائمة اللقطة"
+
+#~ msgid "Scheduled task runs once every hour"
+#~ msgstr "يتم تشغيل المهمة المجدولة مره كل ساعة"
+
+#~ msgid "Selected snapshot path"
+#~ msgstr "مسار اللقطة المحددة"
+
+#~ msgid "Third Party Tools"
+#~ msgstr "أدوات الطرف الثالث"
+
+#~ msgid "Translators"
+#~ msgstr "المترجمين"
+
+#~ msgid "View Log for Create"
+#~ msgstr "عرض سجل للإنشاء"
+
+#~ msgid "View Log for Restore"
+#~ msgstr "عرض سجل للاستعادة"
+
+#~ msgid "View:"
+#~ msgstr "عرض:"

--- a/po/timeshift-az.po
+++ b/po/timeshift-az.po
@@ -1,13 +1,8 @@
-# Azerbaijani translation for linuxmint
-# Copyright (c) 2017 Rosetta Contributors and Canonical Ltd 2017
-# This file is distributed under the same license as the linuxmint package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
 "PO-Revision-Date: 2017-10-20 22:08+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Azerbaijani <az@li.org>\n"
@@ -15,10 +10,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:01+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -203,12 +196,6 @@ msgstr ""
 msgid "Available"
 msgstr ""
 
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
-
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr ""
@@ -223,6 +210,12 @@ msgstr ""
 
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
+msgstr ""
+
+#: Gtk/BackupDeviceBox.vala:98
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
 msgstr ""
 
 #: Gtk/FinishBox.vala:92

--- a/po/timeshift-bg.po
+++ b/po/timeshift-bg.po
@@ -1,13 +1,8 @@
-# Bulgarian translation for linuxmint
-# Copyright (c) 2017 Rosetta Contributors and Canonical Ltd 2017
-# This file is distributed under the same license as the linuxmint package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
 "PO-Revision-Date: 2017-11-03 18:52+0000\n"
 "Last-Translator: spacy01 <Unknown>\n"
 "Language-Team: Bulgarian <bg@li.org>\n"
@@ -15,10 +10,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:01+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -216,12 +209,6 @@ msgstr "Автори"
 msgid "Available"
 msgstr "Наличен"
 
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
-
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr "BTRFS"
@@ -237,6 +224,13 @@ msgstr "BTRFS инструментите не са намерени"
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
 msgstr "BTRFS устройството не е монтирано"
+
+#: Gtk/BackupDeviceBox.vala:98
+#, fuzzy
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
+msgstr "Други приложение (следваща страница)"
 
 #: Gtk/FinishBox.vala:92
 msgid ""
@@ -2784,35 +2778,6 @@ msgstr "rsync върна грешка"
 msgid "un-tagged"
 msgstr "без-таг"
 
-#, fuzzy
-#~ msgid "Click to edit and drag-drop to re-order"
-#~ msgstr "Щракнете за редакция. Влачете за пренареждане."
-
-#~ msgid ""
-#~ "Click an item to edit the pattern.\n"
-#~ "Drag and drop items with mouse to re-order."
-#~ msgstr ""
-#~ "Щракнете на елемента за редакция на шаблона.\n"
-#~ "Влачете елементи с мишката за пренареждане."
-
-#~ msgid "Editing and Re-Ordering"
-#~ msgstr "Редакция и пренареждане"
-
-#~ msgid "Info"
-#~ msgstr "Данни"
-
-#~ msgid "Deleted system subvolumes"
-#~ msgstr "Изтрити системни подустройства"
-
-#~ msgid "<b>System:</b> Installed Linux distribution"
-#~ msgstr "<b>Система:</b> Инсталирана Линукс дистрибуция"
-
-#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
-#~ msgstr "<b>Дата на моментната снимка:</b> Дата на всяка създадена снимка"
-
-#~ msgid "Selected snapshot path"
-#~ msgstr "Избран път за снимка"
-
 #~ msgid ""
 #~ "<b>Backup Levels</b>\n"
 #~ "\n"
@@ -2831,6 +2796,19 @@ msgstr "без-таг"
 #~ "W\tСедмично\n"
 #~ "M\tМесечно"
 
+#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
+#~ msgstr "<b>Дата на моментната снимка:</b> Дата на всяка създадена снимка"
+
+#~ msgid "<b>System:</b> Installed Linux distribution"
+#~ msgstr "<b>Система:</b> Инсталирана Линукс дистрибуция"
+
+#~ msgid ""
+#~ "Click an item to edit the pattern.\n"
+#~ "Drag and drop items with mouse to re-order."
+#~ msgstr ""
+#~ "Щракнете на елемента за редакция на шаблона.\n"
+#~ "Влачете елементи с мишката за пренареждане."
+
 #~ msgid "Cloning System..."
 #~ msgstr "Клониране на система"
 
@@ -2840,14 +2818,26 @@ msgstr "без-таг"
 #~ msgid "Contributions"
 #~ msgstr "Приноси"
 
+#~ msgid "Create snapshots using RSYNC"
+#~ msgstr "Създавай снимки с RSYNC"
+
+#~ msgid "Deleted system subvolumes"
+#~ msgstr "Изтрити системни подустройства"
+
 #~ msgid "Documenters"
 #~ msgstr "Документатори"
+
+#~ msgid "Editing and Re-Ordering"
+#~ msgstr "Редакция и пренареждане"
 
 #~ msgid "Include everything"
 #~ msgstr "Включи всичко"
 
 #~ msgid "Include hidden items"
 #~ msgstr "Включване на скрити елементи"
+
+#~ msgid "Info"
+#~ msgstr "Данни"
 
 #~ msgid "Log Viewer"
 #~ msgstr "Преглед на журналите"
@@ -2857,6 +2847,9 @@ msgstr "без-таг"
 
 #~ msgid "Scheduled task runs once every hour"
 #~ msgstr "Задача по график ще се изпълнява на всеки час"
+
+#~ msgid "Selected snapshot path"
+#~ msgstr "Избран път за снимка"
 
 #~ msgid "Third Party Tools"
 #~ msgstr "Инструменти от трети страни"
@@ -2872,6 +2865,10 @@ msgstr "без-таг"
 
 #~ msgid "View:"
 #~ msgstr "Преглед:"
+
+#, fuzzy
+#~ msgid "Click to edit and drag-drop to re-order"
+#~ msgstr "Щракнете за редакция. Влачете за пренареждане."
 
 #~ msgid "Change"
 #~ msgstr "Променено"

--- a/po/timeshift-ca.po
+++ b/po/timeshift-ca.po
@@ -1,24 +1,17 @@
-# Catalan translation for timeshift
-# Copyright (c) 2014 Rosetta Contributors and Canonical Ltd 2014
-# This file is distributed under the same license as the timeshift package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: timeshift\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
-"PO-Revision-Date: 2017-11-22 17:43+0000\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
+"PO-Revision-Date: 2018-03-16 22:55+0000\n"
 "Last-Translator: Robert Antoni Buj Gelonch <Unknown>\n"
 "Language-Team: Catalan <ca@li.org>\n"
 "Language: ca\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:00+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -46,9 +39,7 @@ msgstr "'%s' estarà sobre el dispositiu arrel"
 
 #: Gtk/BootOptionsBox.vala:118
 msgid "(Re)install GRUB2 on:"
-msgstr ""
-"(Re)instal·la GRUB2 a:\n"
-"(Re)instal·lar Grub2 a:"
+msgstr "(Re)instal·la GRUB2 a:"
 
 #: Core/Main.vala:362
 msgid "** Uninstalled Timeshift BTRFS **"
@@ -84,9 +75,7 @@ msgstr ""
 #: Console/AppConsole.vala:1034 Console/AppConsole.vala:1075
 #: Console/AppConsole.vala:1093
 msgid "Aborted."
-msgstr ""
-"Avortat.\n"
-"Cancel·lat."
+msgstr "Avortat."
 
 #: Gtk/MainWindow.vala:393
 msgid "About"
@@ -114,9 +103,7 @@ msgstr "Afegeix patró personalitzat"
 
 #: Gtk/ExcludeBox.vala:239
 msgid "Add directories"
-msgstr ""
-"Afegeix directoris\n"
-"Afegeix carpetes"
+msgstr "Afegeix directoris"
 
 #: Gtk/ExcludeBox.vala:233
 msgid "Add files"
@@ -124,9 +111,7 @@ msgstr "Afegeix fitxers"
 
 #: Console/AppConsole.vala:360
 msgid "Add tags to snapshot (default: O)"
-msgstr ""
-"Afegeix etiquetes a la instantània (defecte: O)\n"
-"Afegir etiquetes a la instantània (defecte: O)"
+msgstr "Afegeix etiquetes a la instantània (defecte: O)"
 
 #: Utility/CronTab.vala:312
 msgid "Added cron task"
@@ -158,9 +143,7 @@ msgstr ""
 
 #: Gtk/ExcludeMessageWindow.vala:130
 msgid "All other files and folders are excluded."
-msgstr ""
-"S'han exclòs la resta dels fitxers i carpetes.\n"
-"S'han exclòs la resta dels fitxers i carpetes"
+msgstr "S'han exclòs la resta dels fitxers i carpetes."
 
 #: Gtk/RestoreDeviceBox.vala:500
 msgid ""
@@ -188,9 +171,7 @@ msgstr "Una altra instància d'aquesta aplicació s'està executant"
 
 #: Core/Main.vala:253
 msgid "Another instance of timeshift is currently running!"
-msgstr ""
-"Ja s'està executant una altra instància de timeshift!\n"
-"Ja s'està executant altre instància del TimeShift!"
+msgstr "Ja s'està executant una altra instància de timeshift!"
 
 #: Console/AppConsole.vala:376
 msgid "Answer YES to all confirmation prompts"
@@ -228,12 +209,6 @@ msgstr "Autors"
 msgid "Available"
 msgstr "Disponibles"
 
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
-
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr "BTRFS"
@@ -248,9 +223,14 @@ msgstr "No es troben les utilitats BTRFS"
 
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
-msgstr ""
-"El dispositiu BTRFS no està muntat\n"
-"El dispositivu BTRFS no està muntat"
+msgstr "El dispositiu BTRFS no està muntat"
+
+#: Gtk/BackupDeviceBox.vala:98
+#, fuzzy
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
+msgstr "Altres aplicacions (pàgina següent)"
 
 #: Gtk/FinishBox.vala:92
 msgid ""
@@ -278,15 +258,11 @@ msgstr "Còpia de seguretat"
 
 #: Core/Main.vala:2017
 msgid "Backup Device"
-msgstr ""
-"Dispositiu de còpia de seguretat\n"
-"Dispositiu per a la còpia de seguretat"
+msgstr "Dispositiu de còpia de seguretat"
 
 #: Core/Main.vala:2012
 msgid "Backup device not specified!"
-msgstr ""
-"Dispositiu de còpia de seguretat no especificat!\n"
-"Dispositiu de còpia no especificat!"
+msgstr "Dispositiu de còpia de seguretat no especificat!"
 
 #: Utility/Gtk/DonationWindow.vala:89
 msgid "Become a Patron"
@@ -317,21 +293,15 @@ msgstr ""
 
 #: Core/Main.vala:998
 msgid "Boot snapshots are enabled"
-msgstr ""
-"Les instantànies de l'arrencada estan habilitades\n"
-"Les instantànies de l'arrencada estan activades"
+msgstr "Les instantànies de l'arrencada estan habilitades"
 
 #: Gtk/BootOptionsWindow.vala:49
 msgid "Bootloader Options"
-msgstr ""
-"Opcions del gestor d'arrencada\n"
-"Opcions del carregador d'arrencada"
+msgstr "Opcions del gestor d'arrencada"
 
 #: Gtk/RestoreDeviceBox.vala:411
 msgid "Bootloader Options (Advanced)"
-msgstr ""
-"Opcions del gestor d'arrencada (avançat)\n"
-"Opcions del carregador d'arrencada (Avançat)"
+msgstr "Opcions del gestor d'arrencada (avançat)"
 
 #: Gtk/MainWindow.vala:171
 msgid "Browse"
@@ -358,9 +328,7 @@ msgstr "Cancel·la"
 
 #: Gtk/RestoreWindow.vala:221
 msgid "Cancel restore?"
-msgstr ""
-"Cancel·lar la restauració?\n"
-"Cancel·lar restauració?"
+msgstr "Cancel·lar la restauració?"
 
 #: Gtk/RestoreWindow.vala:223
 msgid ""
@@ -385,9 +353,7 @@ msgstr "Canviat"
 
 #: Gtk/RestoreBox.vala:127 Gtk/BackupBox.vala:89
 msgid "Changed items:"
-msgstr ""
-"Ítems que han canviat:\n"
-"Elements que han canviat:"
+msgstr "Ítems que han canviat:"
 
 #: Gtk/RestoreWindow.vala:104
 msgid "Checking Restore Actions (Dry Run)"
@@ -395,9 +361,7 @@ msgstr ""
 
 #: Core/Main.vala:2732
 msgid "Checking file systems for errors..."
-msgstr ""
-"Comprovació dels sistemes de fitxers per si hi ha cap error...\n"
-"S'estàn comprovant els sistemes de fitxers per si hi ha cap error..."
+msgstr "Comprovació dels sistemes de fitxers per si hi ha cap error..."
 
 #: Gtk/RsyncLogBox.vala:390 Gtk/RestoreBox.vala:130 Gtk/BackupBox.vala:92
 #, c-format
@@ -431,9 +395,7 @@ msgstr "Clonant"
 
 #: Core/Main.vala:2782
 msgid "Cloning system..."
-msgstr ""
-"Clonació del sistema...\n"
-"Clonant el sistema..."
+msgstr "Clonació del sistema..."
 
 #: Utility/Gtk/AboutWindow.vala:326 Utility/Gtk/DonationWindow.vala:121
 #: Gtk/RsyncLogBox.vala:266 Gtk/BackupWindow.vala:168
@@ -484,15 +446,11 @@ msgstr ""
 #: Console/AppConsole.vala:1068
 #, c-format
 msgid "Continue with restore? (y/n): "
-msgstr ""
-"Continuar amb la restauració? (y/n): \n"
-"Continua la restauració? (y/n): "
+msgstr "Continuar amb la restauració? (y/n): "
 
 #: Console/AppConsole.vala:834 Console/AppConsole.vala:965
 msgid "Could not find device"
-msgstr ""
-"No s'ha pogut trobar el dispositiu\n"
-"No s'ha trobat el dispositiu"
+msgstr "No s'ha pogut trobar el dispositiu"
 
 #: Utility/Device.vala:1187
 #, c-format
@@ -501,23 +459,17 @@ msgstr "No s'ha pogut trobar el fitxer"
 
 #: Console/AppConsole.vala:731
 msgid "Could not find snapshot"
-msgstr ""
-"No s'ha pogut trobar la instantània.\n"
-"No es troba la instantània."
+msgstr "No s'ha pogut trobar la instantània."
 
 #: Core/Main.vala:2946
 msgid "Could not find system subvolume"
-msgstr ""
-"No s'ha pogut trobar el subvolum de sistema\n"
-"Subvolumen del sistema no trobat"
+msgstr "No s'ha pogut trobar el subvolum de sistema"
 
 #: Core/Main.vala:2974
 msgid "Could not find system subvolumes for creating pre-restore snapshot"
 msgstr ""
 "No s'han pogut trobar els subvolums de sistema per crear la instantània de "
-"pre-restauració.\n"
-"No es troben subvolums del sistema per crear una instantània de pre-"
-"restauració."
+"pre-restauració."
 
 #: Gtk/RsyncLogBox.vala:366 Gtk/RsyncLogBox.vala:571 Gtk/MainWindow.vala:141
 #, c-format
@@ -526,9 +478,7 @@ msgstr "Crea"
 
 #: Gtk/BackupWindow.vala:61
 msgid "Create Snapshot"
-msgstr ""
-"Crea la instantània\n"
-"Crea instantània"
+msgstr "Crea la instantània"
 
 #: Gtk/ScheduleBox.vala:136
 msgid "Create one per boot"
@@ -552,15 +502,11 @@ msgstr "Crea'n una cada setmana"
 
 #: Console/AppConsole.vala:358
 msgid "Create snapshot (even if not scheduled)"
-msgstr ""
-"Crea la instantània (encara que no estigui programada)\n"
-"Crear instantània (encara que no estigui programada)"
+msgstr "Crea la instantània (encara que no estigui programada)"
 
 #: Console/AppConsole.vala:357
 msgid "Create snapshot if scheduled"
-msgstr ""
-"Crea la instantània si està programada\n"
-"Crea instantània si està programada"
+msgstr "Crea la instantània si està programada"
 
 #: Gtk/MainWindow.vala:142
 msgid "Create snapshot of current system"
@@ -572,9 +518,7 @@ msgid ""
 "system"
 msgstr ""
 "Creeu manualment les instantànies o habiliteu les instantànies programades "
-"per protegir el vostre sistema\n"
-"Crea instantànies manualment o permet instantànies programades per protegir "
-"el sistema"
+"per protegir el vostre sistema"
 
 #: Gtk/SnapshotBackendBox.vala:95
 #, fuzzy
@@ -597,9 +541,7 @@ msgstr "S'ha creat el fitxer de control"
 
 #: Utility/TeeJee.FileSystem.vala:351
 msgid "Created directory"
-msgstr ""
-"Directori creat\n"
-"Creada carpeta"
+msgstr "Directori creat"
 
 #: Core/Main.vala:2996
 msgid "Created pre-restore snapshot"
@@ -607,33 +549,24 @@ msgstr "Creada una instantània de pre-restauració"
 
 #: Core/Main.vala:1499
 msgid "Created subvolume snapshot"
-msgstr ""
-"Instantània de subvolum creada\n"
-"Creada instantània del subvolum"
+msgstr "Instantània de subvolum creada"
 
 #: Gtk/BackupBox.vala:71
 msgid "Creating Snapshot..."
-msgstr ""
-"Creació de la instantània...\n"
-"S'està creant la instantània..."
+msgstr "Creació de la instantània..."
 
 #: Core/Main.vala:1437
 msgid "Creating new backup..."
-msgstr ""
-"Creació de la còpia de seguretat nova...\n"
-"S'està creant una còpia de seguretat nova..."
+msgstr "Creació de la còpia de seguretat nova..."
 
 #: Core/Main.vala:1283
 msgid "Creating new snapshot..."
-msgstr ""
-"Creació de la instantània nova...\n"
-"S'està creant una instantània nova..."
+msgstr "Creació de la instantània nova..."
 
 #: Core/Main.vala:2924
 msgid "Creating pre-restore snapshot from system subvolumes..."
 msgstr ""
-"Creació de la instantània de pre-restauració dels subvolums de sistema...\n"
-"Creant instantània de pre-restauració dels subvolums del sistema"
+"Creació de la instantània de pre-restauració dels subvolums de sistema..."
 
 #: Utility/Gtk/AboutWindow.vala:321 Utility/Gtk/AboutWindow.vala:387
 msgid "Credits"
@@ -645,15 +578,11 @@ msgstr "Error crític"
 
 #: Utility/CronTab.vala:136
 msgid "Cron job added"
-msgstr ""
-"S'ha afegit el treball de cron\n"
-"S'ha afegit la tasca cron"
+msgstr "S'ha afegit el treball de cron"
 
 #: Utility/CronTab.vala:217
 msgid "Cron job removed"
-msgstr ""
-"S'ha suprimit el treball de cron\n"
-"S'ha suprimit la tasca cron"
+msgstr "S'ha suprimit el treball de cron"
 
 #: Utility/CronTab.vala:304
 msgid "Cron task exists"
@@ -669,9 +598,7 @@ msgstr "Ha fallat la instantània diària!"
 
 #: Core/Main.vala:1058
 msgid "Daily snapshots are enabled"
-msgstr ""
-"Les instantànies diàries estan habilitades\n"
-"Les instantànies diàries estan actives"
+msgstr "Les instantànies diàries estan habilitades"
 
 #: Core/Main.vala:2111
 msgid "Data will be modified on following devices:"
@@ -713,15 +640,11 @@ msgstr "Directori suprimit"
 #: Core/Subvolume.vala:154 Core/Main.vala:2903 Core/Main.vala:2907
 #, c-format
 msgid "Deleted subvolume"
-msgstr ""
-"Subvolum suprimit\n"
-"Subvolumen suprimit"
+msgstr "Subvolum suprimit"
 
 #: Gtk/DeleteBox.vala:58
 msgid "Deleting Snapshots..."
-msgstr ""
-"Supressió d'instantànies...\n"
-"S'estan suprimint les instantànies..."
+msgstr "Supressió d'instantànies..."
 
 #: Core/Subvolume.vala:141
 #, c-format
@@ -829,9 +752,7 @@ msgstr "Dir no trobat"
 
 #: Core/SnapshotRepo.vala:982
 msgid "Directory not found"
-msgstr ""
-"Directori no trobat\n"
-"Carpeta no trobada"
+msgstr "Directori no trobat"
 
 #: Core/Main.vala:2206 Gtk/RestoreSummaryBox.vala:64
 msgid "Disclaimer"
@@ -867,15 +788,11 @@ msgstr ""
 
 #: Gtk/MainWindow.vala:1068
 msgid "Enable scheduled snapshots to protect your system"
-msgstr ""
-"Habiliteu les instantànies programades per protegir el vostre sistema\n"
-"Activeu les instantànies programades per protegir el sistema"
+msgstr "Habiliteu les instantànies programades per protegir el vostre sistema"
 
 #: Core/Main.vala:4030 Core/Main.vala:4070
 msgid "Enabled subvolume quota support"
-msgstr ""
-"Suport de quota del subvolum habilitat\n"
-"Activat el suport de quotes del subvolumen"
+msgstr "Suport de quota del subvolum habilitat"
 
 #: Utility/Device.vala:1333
 msgid "Encrypted Device"
@@ -883,9 +800,7 @@ msgstr "Dispositiu xifrat"
 
 #: Gtk/UsersBox.vala:236
 msgid "Encrypted Home Directory"
-msgstr ""
-"Directori de l'usuari xifrat\n"
-"Carpeta personal xifrada"
+msgstr "Directori de l'usuari xifrat"
 
 #: Console/AppConsole.vala:884
 #, c-format
@@ -895,9 +810,7 @@ msgstr "Introduïu nom o número del dispositiu"
 #: Console/AppConsole.vala:682 Console/AppConsole.vala:1013
 #, c-format
 msgid "Enter device name or number (a=Abort)"
-msgstr ""
-"Introduïu el nom o número de dispositiu (a=avorta)\n"
-"Introduïu el nom o número de dispositiu (a = Avortar)"
+msgstr "Introduïu el nom o número de dispositiu (a=avorta)"
 
 #: Utility/Device.vala:1334
 #, c-format
@@ -911,15 +824,11 @@ msgstr "Introduïu el camí o navegueu al directori"
 #: Console/AppConsole.vala:754
 #, c-format
 msgid "Enter snapshot number (a=Abort, p=Previous, n=Next)"
-msgstr ""
-"Introduïu el número d'instantània (a=avorta, p=anterior, n=següent)\n"
-"Introduïu el número de instantània (a=avorta, p=prèvia, n=següent)"
+msgstr "Introduïu el número d'instantània (a=avorta, p=anterior, n=següent)"
 
 #: Gtk/ExcludeBox.vala:225
 msgid "Enter the pattern to exclude (Ex: *.mp3, *.bak)"
-msgstr ""
-"Introduïu el patró a excloure (p. ex.: *.mp3, *.bak)\n"
-"Introduïu el patró a excloure (Ej: *.mp3, *.bak)"
+msgstr "Introduïu el patró a excloure (p. ex.: *.mp3, *.bak)"
 
 #: Utility/GtkHelper.vala:18 Gtk/RestoreDeviceBox.vala:534
 msgid "Error"
@@ -935,15 +844,11 @@ msgstr "Estimat"
 
 #: Gtk/EstimateBox.vala:56
 msgid "Estimating System Size..."
-msgstr ""
-"Estimació de la mida del sistema...\n"
-"Càlcul de la mida del sistema..."
+msgstr "Estimació de la mida del sistema..."
 
 #: Core/Main.vala:1279
 msgid "Estimating system size..."
-msgstr ""
-"Estimació de la mida del sistema...\n"
-"Càlcul de la mida del sistema..."
+msgstr "Estimació de la mida del sistema..."
 
 #: Console/AppConsole.vala:386
 msgid "Examples"
@@ -963,27 +868,19 @@ msgstr "Exclou aplicacions"
 
 #: Gtk/ExcludeMessageWindow.vala:70
 msgid "Exclude List"
-msgstr ""
-"Llista d'exclusions\n"
-"Exclou llista"
+msgstr "Llista d'exclusions"
 
 #: Gtk/ExcludeListSummaryWindow.vala:49
 msgid "Exclude List Summary"
-msgstr ""
-"Resum de la llista d'exclusions\n"
-"Resum de la llista d'exclusió"
+msgstr "Resum de la llista d'exclusions"
 
 #: Gtk/ExcludeBox.vala:224
 msgid "Exclude Pattern"
-msgstr ""
-"Patró d'exclusió\n"
-"Exclou patró"
+msgstr "Patró d'exclusió"
 
 #: Gtk/ExcludeMessageWindow.vala:56
 msgid "Excluded Directories"
-msgstr ""
-"Directoris exclosos\n"
-"Carpetes excloses"
+msgstr "Directoris exclosos"
 
 #: Core/Main.vala:1567
 msgid "Expected values: O, B, H, D, W, M"
@@ -991,9 +888,7 @@ msgstr "Valors esperats: O, B, H, D, W, M"
 
 #: Utility/CronTab.vala:132
 msgid "Failed to add cron job"
-msgstr ""
-"Ha fallat l'addició del treball de cron\n"
-"Ha fallat l'addició de la tasca cron"
+msgstr "Ha fallat l'addició del treball de cron"
 
 #: Utility/TeeJee.FileSystem.vala:191
 msgid "Failed to copy file"
@@ -1041,9 +936,7 @@ msgstr "Ha fallat la destrucció de qgroup"
 
 #: Core/Main.vala:4055
 msgid "Failed to enable subvolume quota"
-msgstr ""
-"Ha fallat l'habilitació  de la quota del subvolum\n"
-"Ha fallat l'activació  de la quota del subvolum"
+msgstr "Ha fallat l'habilitació  de la quota del subvolum"
 
 #: Core/Main.vala:3733 Core/Main.vala:3739
 msgid "Failed to estimate system size"
@@ -1057,9 +950,7 @@ msgstr "Ha fallat l'exportació del fitxer crontab"
 #: Console/AppConsole.vala:893 Console/AppConsole.vala:988
 #: Console/AppConsole.vala:1033 Console/AppConsole.vala:1074
 msgid "Failed to get input from user in 3 attempts"
-msgstr ""
-"Ha fallat l'obtenció de l'entrada de l'usuari en 3 intents\n"
-"Error obtenint entrada de l'usuari en 3 intents"
+msgstr "Ha fallat l'obtenció de l'entrada de l'usuari en 3 intents"
 
 #: Utility/Device.vala:615
 msgid "Failed to get partition list"
@@ -1075,40 +966,28 @@ msgstr "Ha fallat la instal·lació del fitxer crontab"
 
 #: Gtk/RestoreDeviceBox.vala:535
 msgid "Failed to mount devices"
-msgstr ""
-"Ha fallat el muntatge de dispositius\n"
-"Error muntant dispositius"
+msgstr "Ha fallat el muntatge de dispositius"
 
 #: Utility/TeeJee.FileSystem.vala:210
 msgid "Failed to move file"
-msgstr ""
-"Ha fallat el moviment del fitxer\n"
-"Ha fallat el trasllat del fitxer"
+msgstr "Ha fallat el moviment del fitxer"
 
 #: Core/Main.vala:2961
 msgid "Failed to move system subvolume to snapshot directory"
 msgstr ""
-"Ha fallat el moviment del subvolum de sistema al directori de la "
-"instantània\n"
-"Error movent el subvolum del sistema a la carpeta d'instantània"
+"Ha fallat el moviment del subvolum de sistema al directori de la instantània"
 
 #: Core/Main.vala:3863
 msgid "Failed to query subvolume list"
-msgstr ""
-"Ha fallat la consulta de la llista de subvolums\n"
-"Error en demanar la llista de subvolums"
+msgstr "Ha fallat la consulta de la llista de subvolums"
 
 #: Core/Main.vala:3947
 msgid "Failed to query subvolume quota"
-msgstr ""
-"Ha fallat la consulta de la quota del subvolum\n"
-"Error en demanar la quota del subvolum"
+msgstr "Ha fallat la consulta de la quota del subvolum"
 
 #: Utility/CronTab.vala:50
 msgid "Failed to read cron tab"
-msgstr ""
-"Ha fallat la lectura de la fixa de cron\n"
-"Error al llegir la fitxa cron"
+msgstr "Ha fallat la lectura de la fixa de cron"
 
 #: Utility/TeeJee.FileSystem.vala:148
 msgid "Failed to read file"
@@ -1128,15 +1007,11 @@ msgstr "Ha fallat la supressió de la instantània"
 
 #: Core/Main.vala:4094
 msgid "Failed to rescan subvolume quota"
-msgstr ""
-"Ha fallat el rescaneig de la quota del subvolum\n"
-"Error reescanejant la quota de subvolum"
+msgstr "Ha fallat el rescaneig de la quota del subvolum"
 
 #: Core/Subvolume.vala:202
 msgid "Failed to restore system subvolume"
-msgstr ""
-"Ha fallat la restauració del subvolum de sistema\n"
-"Error restaurant el subvolume de sistema"
+msgstr "Ha fallat la restauració del subvolum de sistema"
 
 #: Core/Main.vala:1355
 msgid "Failed to save exclude list"
@@ -1190,9 +1065,7 @@ msgid ""
 "Patterns starting with a + will include the item instead of excluding."
 msgstr ""
 "S'exclouran els fitxers i directoris coincidents amb els patrons de sota. "
-"Els patrons que comencin amb + inclouran l'ítem en lloc d'excloure'l.\n"
-"S'exclouran els fitxers i directoris coincidents amb els patrons de sota. "
-"Els patrons que comencin amb + inclouran l'element en lloc d'excloure'l."
+"Els patrons que comencin amb + inclouran l'ítem en lloc d'excloure'l."
 
 #: Gtk/SnapshotBackendBox.vala:192
 msgid "Files and directories can be excluded to save disk space."
@@ -1238,9 +1111,7 @@ msgstr "La primera instantània requereix:"
 
 #: Core/Main.vala:2894
 msgid "Found existing pre-restore snapshot"
-msgstr ""
-"S'ha trobada una instantània de pre-restauració\n"
-"Trobada una instantània de pre-restauració"
+msgstr "S'ha trobada una instantània de pre-restauració"
 
 #: Gtk/BackupDeviceBox.vala:215
 msgid "Free"
@@ -1264,9 +1135,7 @@ msgstr "NO es reinstal·larà GRUB"
 
 #: Core/Main.vala:2348
 msgid "Generating initramfs..."
-msgstr ""
-"Generació d'initramfs...\n"
-"Generant initramfs ..."
+msgstr "Generació d'initramfs..."
 
 #: Console/AppConsole.vala:374
 msgid "Global"
@@ -1299,15 +1168,11 @@ msgstr "Oculta aquesta finestra (els fitxers se suprimiran en segon pla)"
 
 #: Gtk/UsersBox.vala:120
 msgid "Home"
-msgstr ""
-"Directori de l'usuari\n"
-"Carpeta personal"
+msgstr "Directori de l'usuari"
 
 #: Gtk/ExcludeMessageWindow.vala:116
 msgid "Home Directory"
-msgstr ""
-"Directori de l'usuari\n"
-"Carpeta personal"
+msgstr "Directori de l'usuari"
 
 #: Gtk/ScheduleBox.vala:118 Gtk/SnapshotListBox.vala:299
 msgid "Hourly"
@@ -1315,15 +1180,11 @@ msgstr "Cada hora"
 
 #: Core/Main.vala:1047
 msgid "Hourly snapshot failed!"
-msgstr ""
-"Ha fallat la instantània de cada hora!\n"
-"La instantània horària ha fallat!"
+msgstr "Ha fallat la instantània de cada hora!"
 
 #: Core/Main.vala:1028
 msgid "Hourly snapshots are enabled"
-msgstr ""
-"Les instantànies a cada hora estan habilitades\n"
-"Les instantànies horàries estan activades"
+msgstr "Les instantànies a cada hora estan habilitades"
 
 #: Utility/Gtk/AboutWindow.vala:457
 msgid "Icon Themes & Utilities"
@@ -1335,9 +1196,7 @@ msgid ""
 "install Timeshift, and try restoring another snapshot."
 msgstr ""
 "Si el sistema restaurat no arrenca, inicieu amb el CD o USB autònom, "
-"instal·leu Timeshift, i intenteu restaurar una altra instantània.\n"
-"Si el sistema restaurat no arrenca, inicieu amb el Live CD/USB, instal·leu "
-"Timeshift, i intenteu restaurar una altra instantània."
+"instal·leu Timeshift, i intenteu restaurar una altra instantània."
 
 #: Core/Main.vala:2212
 msgid ""
@@ -1351,9 +1210,7 @@ msgstr "Patrons d'inclusió o d'exclusió"
 
 #: Gtk/UsersBox.vala:340
 msgid "Include @home subvolume in backups"
-msgstr ""
-"Inclou el subvolum @home a les còpies de seguretat\n"
-"Inclour subvolum @home en les còpies"
+msgstr "Inclou el subvolum @home a les còpies de seguretat"
 
 #: Gtk/UsersBox.vala:266
 msgid "Include All"
@@ -1384,9 +1241,7 @@ msgstr ""
 
 #: Gtk/ExcludeBox.vala:272
 msgid "Items Not Selected"
-msgstr ""
-"Ítems no seleccionats\n"
-"Elements no seleccionats"
+msgstr "Ítems no seleccionats"
 
 #: Gtk/ScheduleBox.vala:283
 msgid "Keep"
@@ -1400,10 +1255,7 @@ msgid ""
 msgstr ""
 "Mantén els fitxers de configuració per als clients bittorrent, com ara "
 "Deluge, Transmission, etc. Si desmarqueu aquesta opció, els anteriors "
-"fitxers de configuració es restauraran de la instantània.\n"
-"Mantén els fitxers de configuració dels clients bittorrent, com ara Deluge, "
-"Transmission, etc. Si desactiveu aquesta opció, es restauraran a partir de "
-"la instantània dels fitxers anteriors de configuració."
+"fitxers de configuració es restauraran de la instantània."
 
 #: Gtk/RestoreExcludeBox.vala:85
 msgid ""
@@ -1412,10 +1264,7 @@ msgid ""
 msgstr ""
 "Mantén els fitxers de configuració per als navegadors, com ara Firefox o "
 "Chrome. Si desmarqueu aquesta opció, els anteriors fitxers de configuració "
-"es restauraran de la instantània.\n"
-"Mantén els fitxers de configuració de navegadors com ara Firefox o Chrome. "
-"Si no ho activeu, es restauraran els fitxers anteriors de configuració de la "
-"instantània."
+"es restauraran de la instantània."
 
 #: Gtk/RestoreDeviceBox.vala:244
 msgid "Keep on Root Device"
@@ -1427,9 +1276,7 @@ msgstr "Mantén aquest camí de muntatge sobre l'arrel del sistema de fitxers"
 
 #: Gtk/SnapshotListBox.vala:519
 msgid "LIVE"
-msgstr ""
-"Autònom\n"
-"LIVE"
+msgstr "Autònom"
 
 #: Utility/Device.vala:1829 Console/AppConsole.vala:458
 #: Console/AppConsole.vala:497 Gtk/BackupDeviceBox.vala:254
@@ -1449,9 +1296,7 @@ msgstr ""
 
 #: Core/Main.vala:1001
 msgid "Last boot snapshot not found"
-msgstr ""
-"No s'ha trobat l'última instantània de l'arrencada\n"
-"No es troba l'última instantània del boot"
+msgstr "No s'ha trobat l'última instantània de l'arrencada"
 
 #: Core/Main.vala:1070
 #, c-format
@@ -1464,9 +1309,7 @@ msgstr "L'última instantània diària és de fa més d'1 dia"
 
 #: Core/Main.vala:1061
 msgid "Last daily snapshot not found"
-msgstr ""
-"No s'ha trobat l'última instantània diària\n"
-"No es troba l'última instantània diària"
+msgstr "No s'ha trobat l'última instantània diària"
 
 #: Core/Main.vala:1040
 #, c-format
@@ -1479,9 +1322,7 @@ msgstr "L'última instantània horària és de fa més d'1 hora"
 
 #: Core/Main.vala:1031
 msgid "Last hourly snapshot not found"
-msgstr ""
-"No s'ha trobat l'última instantània de cada hora\n"
-"No es troba l'última instantània horària"
+msgstr "No s'ha trobat l'última instantània de cada hora"
 
 #: Core/Main.vala:1130
 #, c-format
@@ -1494,9 +1335,7 @@ msgstr "L'última instantània mensual és de fa més d'1 mes"
 
 #: Core/Main.vala:1121
 msgid "Last monthly snapshot not found"
-msgstr ""
-"No s'ha trobat l'última instantània mensual\n"
-"No es troba l'última instantània mensual"
+msgstr "No s'ha trobat l'última instantània mensual"
 
 #: Core/Main.vala:1100
 #, c-format
@@ -1509,9 +1348,7 @@ msgstr "L'última instantània setmanal és de fa més d'1 setmana"
 
 #: Core/Main.vala:1091
 msgid "Last weekly snapshot not found"
-msgstr ""
-"No s'ha trobat l'última instantània setmanal\n"
-"No es troba l'última instantània setmanal"
+msgstr "No s'ha trobat l'última instantània setmanal"
 
 #: Gtk/MainWindow.vala:1049
 #, c-format
@@ -1541,9 +1378,7 @@ msgstr "Llista les instantànies"
 
 #: Gtk/MainWindow.vala:1000
 msgid "Live USB Mode (Restore Only)"
-msgstr ""
-"Mode USB autònom (només restauració)\n"
-"Mode Live USB (només restauració)"
+msgstr "Mode USB autònom (només restauració)"
 
 #: Gtk/SetupWizardWindow.vala:104 Gtk/BackupWindow.vala:86
 #: Gtk/SettingsWindow.vala:89
@@ -1576,9 +1411,7 @@ msgstr ""
 
 #: Core/Main.vala:235
 msgid "Missing Dependencies"
-msgstr ""
-"Dependències que falten\n"
-"Manquen dependències"
+msgstr "Dependències que falten"
 
 #: Core/SnapshotRepo.vala:689
 #, c-format
@@ -1596,9 +1429,7 @@ msgstr "Mensual"
 
 #: Core/Main.vala:1118
 msgid "Monthly snapshot are enabled"
-msgstr ""
-"Les instantànies mensuals estan habilitades\n"
-"Instantània mensual activada"
+msgstr "Les instantànies mensuals estan habilitades"
 
 #: Core/Main.vala:1137
 msgid "Monthly snapshot failed!"
@@ -1610,9 +1441,7 @@ msgstr "Munta"
 
 #: Core/Main.vala:2968
 msgid "Moved system subvolume to snapshot directory"
-msgstr ""
-"S'ha mogut el subvolum de sistema al directori de la instantània\n"
-"El subvolumen de sistema s'ha mogut a la carpeta d'instantània"
+msgstr "S'ha mogut el subvolum de sistema al directori de la instantània"
 
 #: Gtk/MainWindow.vala:800
 msgid "Multiple snapshots selected"
@@ -1638,9 +1467,7 @@ msgstr "Sense canvis"
 
 #: Gtk/MainWindow.vala:615 Gtk/DeleteWindow.vala:341
 msgid "No Snapshots Selected"
-msgstr ""
-"No s'ha seleccionat cap instantània\n"
-"No s'ha selecionat cap instantània"
+msgstr "No s'ha seleccionat cap instantània"
 
 #: Gtk/MainWindow.vala:1073
 msgid "No snapshots available"
@@ -1649,33 +1476,23 @@ msgstr "No hi ha cap instantània disponible"
 #: Console/AppConsole.vala:320 Core/SnapshotRepo.vala:898
 #: Gtk/MainWindow.vala:1017
 msgid "No snapshots found"
-msgstr ""
-"No s'ha trobat cap instantània\n"
-"No s'han trobat instantànies"
+msgstr "No s'ha trobat cap instantània"
 
 #: Console/AppConsole.vala:740
 msgid "No snapshots found on device"
-msgstr ""
-"No s'ha trobat cap instantània al dispositiu\n"
-"No s'han trobat instantànies en el dispositiu"
+msgstr "No s'ha trobat cap instantània al dispositiu"
 
 #: Gtk/MainWindow.vala:553
 msgid "No snapshots on device"
-msgstr ""
-"No hi ha cap instantània al dispositiu\n"
-"No hi ha instantànies en el dispositiu"
+msgstr "No hi ha cap instantània al dispositiu"
 
 #: Core/SnapshotRepo.vala:665
 msgid "No snapshots on this device"
-msgstr ""
-"No hi ha cap instantània en aquest dispositiu\n"
-"No hi ha instantànies en aquest dispositiu"
+msgstr "No hi ha cap instantània en aquest dispositiu"
 
 #: Gtk/MainWindow.vala:793
 msgid "No snapshots selected"
-msgstr ""
-"No s'ha seleccionat cap instantània\n"
-"No s'ha seleccionat instantànies"
+msgstr "No s'ha seleccionat cap instantània"
 
 #: Gtk/MainWindow.vala:1050 Gtk/MainWindow.vala:1052
 msgid "None"
@@ -1696,7 +1513,7 @@ msgstr "No compatible"
 
 #: Core/SnapshotRepo.vala:629 Core/SnapshotRepo.vala:656
 msgid "Not enough disk space"
-msgstr "Manca espai en el disc"
+msgstr "No hi ha prou espai de disc"
 
 #: Console/AppConsole.vala:397 Gtk/FinishBox.vala:55
 msgid "Notes"
@@ -1733,16 +1550,11 @@ msgid ""
 msgstr ""
 "El sistema operatiu ha d'instal·lar-se en una partició BTRFS amb una "
 "estructura de subvolums de tipus Ubuntu (subvolums @ i @home). Altres "
-"estructures no són compatibles.\n"
-"El sistema operatiu ha d'instal·lar-se en una partició BTRFS amb una "
-"estructura de subvolum tipus Ubuntu (subvolums @ i @home). Altres "
 "estructures no són compatibles."
 
 #: Core/Main.vala:4201
 msgid "Older log files removed"
-msgstr ""
-"S'han suprimit els fitxers de registre antics\n"
-"Eliminats els archius de registre antics"
+msgstr "S'han suprimit els fitxers de registre antics"
 
 #: Gtk/MainWindow.vala:1051
 msgid "Oldest snapshot"
@@ -1757,9 +1569,7 @@ msgid ""
 "Only ubuntu-type layouts with @ and @home subvolumes are currently supported."
 msgstr ""
 "Actualment només són compatibles les estructures de tipus Ubuntu amb "
-"subvolums @ i @home.\n"
-"Actualment només són compatibles les estructures tipus Ubuntu amb subvolums "
-"@ i @home."
+"subvolums @ i @home."
 
 #: Gtk/MainWindow.vala:209
 msgid "Open Menu"
@@ -1771,9 +1581,7 @@ msgid ""
 "BTRFS mode"
 msgstr ""
 "L'opció --snapshot-device no s'hauria d'especificar per a la creació "
-"d'instantànies en mode BTRFS\n"
-"L'opció --snapshot-device nos' hauria d'especificar per crear instantànies "
-"en mode BTRFS"
+"d'instantànies en mode BTRFS"
 
 #: Console/AppConsole.vala:350 Gtk/AppGtk.vala:114
 msgid "Options"
@@ -1795,9 +1603,7 @@ msgstr "Dispositiu pare"
 
 #: Core/Main.vala:2469 Core/Main.vala:2560 Gtk/RsyncLogBox.vala:222
 msgid "Parsing log file..."
-msgstr ""
-"Anàlisi del fitxer del registre...\n"
-"S'està analitzant el fitxer del registre..."
+msgstr "Anàlisi del fitxer del registre..."
 
 #: Gtk/RestoreDeviceBox.vala:524
 msgid "Partition has an unsupported subvolume layout."
@@ -1819,15 +1625,11 @@ msgstr "Permisos"
 
 #: Core/Main.vala:254
 msgid "Please check if you have multiple windows open."
-msgstr ""
-"Comproveu si hi teniu diverses finestres obertes.\n"
-"Comproveu si hi ha obertes diverses finestres."
+msgstr "Comproveu si hi teniu diverses finestres obertes."
 
 #: Core/Main.vala:2244
 msgid "Please do not interrupt the restore process!"
-msgstr ""
-"No interrompeu el procés de restauració!\n"
-"No interrompiu el procés de restauració!"
+msgstr "No interrompeu el procés de restauració!"
 
 #: Core/Main.vala:348
 msgid "Please install required packages and try running TimeShift again"
@@ -1867,16 +1669,12 @@ msgstr ""
 
 #: Gtk/RsyncLogBox.vala:188
 msgid "Populating list..."
-msgstr ""
-"Ompliment de la llista...\n"
-"Omplint la llista..."
+msgstr "Ompliment de la llista..."
 
 #: Core/Main.vala:1579 Gtk/RsyncLogBox.vala:232 Gtk/DeleteBox.vala:68
 #: Gtk/RestoreBox.vala:88 Gtk/BackupBox.vala:114
 msgid "Preparing..."
-msgstr ""
-"Preparació...\n"
-"Preparant..."
+msgstr "Preparació..."
 
 #: Gtk/SetupWizardWindow.vala:189 Gtk/BackupWindow.vala:152
 #: Gtk/DeleteWindow.vala:154 Gtk/RestoreWindow.vala:190
@@ -1885,9 +1683,7 @@ msgstr "Anterior"
 
 #: Gtk/AppGtk.vala:116
 msgid "Print debug information"
-msgstr ""
-"Imprimeix la informació de depuració\n"
-"Imprimeix informació de depuració"
+msgstr "Imprimeix la informació de depuració"
 
 #: Core/Main.vala:3794
 msgid "Query completed"
@@ -1895,9 +1691,7 @@ msgstr "Consulta completada"
 
 #: Core/Main.vala:3777
 msgid "Querying subvolume info..."
-msgstr ""
-"Consulta de la informació del subvolum...\n"
-"Consultant info de subvolum ..."
+msgstr "Consulta de la informació del subvolum..."
 
 #: Gtk/SnapshotBackendBox.vala:77
 msgid "RSYNC"
@@ -1918,34 +1712,24 @@ msgstr ""
 #: Console/AppConsole.vala:982
 #, c-format
 msgid "Re-install GRUB2 bootloader?"
-msgstr ""
-"Reinstal·lar el gestor d'arrencada GRUB2?\n"
-"Reinstal·lar el carregador d'arrencada GRUB2?"
+msgstr "Reinstal·lar el gestor d'arrencada GRUB2?"
 
 #: Core/Main.vala:2307
 msgid "Re-installing GRUB2 bootloader..."
-msgstr ""
-"Reinstal·lació del gestor d'arrencada GRUB2...\n"
-"Reinstal·lant el carregador d'arrencada GRUB2..."
+msgstr "Reinstal·lació del gestor d'arrencada GRUB2..."
 
 #: Gtk/BootOptionsBox.vala:120
 msgid "Re-installs the GRUB2 bootloader on the selected device."
-msgstr ""
-"Reinstal·la el gestor d'arrencada GRUB2 en el dispositiu seleccionat.\n"
-"Reinstal·la el carregador d'arrencada GRUB2 en el dispositiu seleccionat."
+msgstr "Reinstal·la el gestor d'arrencada GRUB2 en el dispositiu seleccionat."
 
 #: Gtk/RsyncLogBox.vala:181
-#, fuzzy, c-format
+#, c-format
 msgid "Read %'d of %'d lines..."
-msgstr ""
-"Lectura de la línia %'d de %'d...\n"
-"Llegeix %'d de %'d línies..."
+msgstr "Lectura de la línia %'d de %'d..."
 
 #: Core/Main.vala:2400
 msgid "Rebooting system..."
-msgstr ""
-"Reinici el sistema...\n"
-"Reiniciant el sistema..."
+msgstr "Reinici el sistema..."
 
 #: Gtk/RestoreExcludeBox.vala:61 Gtk/RestoreExcludeBox.vala:91
 #, c-format
@@ -1975,11 +1759,9 @@ msgid "Removed cron task"
 msgstr "Tasca cron eliminada"
 
 #: Core/Main.vala:3582
-#, fuzzy, c-format
+#, c-format
 msgid "Removed mount directory: '%s'"
-msgstr ""
-"Directori de muntatge eliminat: '%s'\n"
-"Carpeta de muntatge eliminada: '%s'"
+msgstr "Directori de muntatge eliminat: '%s'"
 
 #: Core/Snapshot.vala:555
 msgid "Removed snapshot"
@@ -2050,9 +1832,7 @@ msgstr "Subvolum de sistema restaurat"
 
 #: Gtk/RestoreBox.vala:77 Gtk/RestoreBox.vala:190
 msgid "Restoring Snapshot..."
-msgstr ""
-"Restauració de la instantània...\n"
-"Restaurant instantània..."
+msgstr "Restauració de la instantània..."
 
 #: Gtk/FinishBox.vala:85
 msgid ""
@@ -2063,16 +1843,11 @@ msgstr ""
 "La restauració d'una instantània substituirà els subvolums de sistema, i els "
 "subvolums de sistema que estiguin actualment en ús es preservaran com una "
 "nova instantània. Si cal, aquesta instantània pot restaurar-se més endavant "
-"per 'desfer' la restauració.\n"
-"Restaurar una instantània reemplaçarà subvolums de sistema, i els que estan "
-"actualment en ús es conservaran com una nova instantània. Si cal, aquesta "
-"instantània pot restaurar-se més endavant per 'desfer' la restauració."
+"per 'desfer' la restauració."
 
 #: Core/Main.vala:2778
 msgid "Restoring snapshot..."
-msgstr ""
-"Restauració de la instantània...\n"
-"S'està restaurant la instantània..."
+msgstr "Restauració de la instantània..."
 
 #: Gtk/FinishBox.vala:88
 msgid ""
@@ -2087,12 +1862,7 @@ msgstr ""
 "directoris dels usuaris. Aquest comportament es pot canviar amb l'afegiment "
 "d'un filtre per incloure aquests fitxers. Els fitxers inclosos es "
 "resguardaran quan es creï la instantània, i se substituiran quan es restauri "
-"la instantània.\n"
-"Restaurar instantànies només reemplaça arxius de sistema i configuracions. "
-"Els arxius i carpetes no ocults en les carpetes personals de l'usuari no "
-"seran afectats. Això es pot canviar afegint un filtre per incloure aquests "
-"arxius. Els arxius inclosos es copiaran en crear la instantània, i es "
-"reemplaçaran al restaurar-la."
+"la instantània."
 
 #: Utility/Device.vala:1814
 #, c-format
@@ -2140,12 +1910,7 @@ msgstr ""
 "formatar i reinstal·lar el sistema operatiu al disc del sistema sense perdre "
 "les instantànies emmagatzemades en aquest disc. Fins i tot podeu instal·lar "
 "una altra distribució de Linux i després revertir la distribució anterior "
-"amb la restauració d'una instantània.\n"
-"Desar instantànies en un disc que no sigui del sistema us permet formatar i "
-"tornar a instal·lar el sistema operatiu en el disc del sistema sense perdre "
-"les instantànies emmagatzemades en ell. Fins i tot podeu instal·lar una "
-"altra distribució de Linux i després revertir la distribució anterior "
-"restaurant una instantània."
+"amb la restauració d'una instantània."
 
 #: Core/Main.vala:1285 Core/Main.vala:1439 Core/Main.vala:1441
 msgid "Saving to device"
@@ -2157,28 +1922,20 @@ msgstr "Planifica"
 
 #: Core/Main.vala:257
 msgid "Scheduled snapshot in progress..."
-msgstr ""
-"Instantània programada en curs...\n"
-"Instantània programada en curs ..."
+msgstr "Instantània programada en curs..."
 
 #: Core/Main.vala:1147 Gtk/MainWindow.vala:1067 Gtk/ScheduleBox.vala:312
 msgid "Scheduled snapshots are disabled"
-msgstr ""
-"Les instantànies programades estan inhabilitades\n"
-"Les instantànies programades estan desactivades"
+msgstr "Les instantànies programades estan inhabilitades"
 
 #: Gtk/FinishBox.vala:78
 msgid "Scheduled snapshots are disabled. It's recommended to enable it."
 msgstr ""
-"Les instantànies programades estan inhabilitades. Es recomana habilitar-"
-"les.\n"
-"Les instantànies programades estan desactivades. Es recomana activar-les."
+"Les instantànies programades estan inhabilitades. Es recomana habilitar-les."
 
 #: Gtk/ScheduleBox.vala:305
 msgid "Scheduled snapshots are enabled"
-msgstr ""
-"Les instantànies programades estan habilitades.\n"
-"Les instantànies programades estan activades."
+msgstr "Les instantànies programades estan habilitades"
 
 #: Gtk/FinishBox.vala:75
 msgid ""
@@ -2186,9 +1943,7 @@ msgid ""
 "selected levels."
 msgstr ""
 "Les instantànies programades estan habilitades. Es crearan automàticament "
-"les instantànies per als nivells seleccionats.\n"
-"Les instantànies programades estan activades. Es crearan automàticament per "
-"als nivells seleccionats."
+"les instantànies per als nivells seleccionats."
 
 #: Console/AppConsole.vala:870
 #, c-format
@@ -2197,9 +1952,7 @@ msgstr "Seleccioneu un dispositiu '%s' (defecte =%s)"
 
 #: Console/AppConsole.vala:689 Core/SnapshotRepo.vala:593
 msgid "Select BTRFS system disk with root subvolume (@)"
-msgstr ""
-"Seleccioneu el disc del sistema BTRFS amb el subvolum arrel (@)\n"
-"Seleccioneu el disc del sistema BTRFS amb subvolum arrel (@)"
+msgstr "Seleccioneu el disc del sistema BTRFS amb el subvolum arrel (@)"
 
 #: Console/AppConsole.vala:998
 msgid "Select GRUB device"
@@ -2264,21 +2017,15 @@ msgstr "Seleccioneu les aplicacions a excloure de la restauració"
 
 #: Console/AppConsole.vala:672
 msgid "Select backup device"
-msgstr ""
-"Seleccioneu el dispositiu de còpia de seguretat\n"
-"Seleccioneu el dispositiu de còpia"
+msgstr "Seleccioneu el dispositiu de còpia de seguretat"
 
 #: Gtk/ExcludeBox.vala:433
 msgid "Select directory"
-msgstr ""
-"Seleccioneu el directori\n"
-"Seleccioneu una carpeta"
+msgstr "Seleccioneu el directori"
 
 #: Gtk/ExcludeBox.vala:406
 msgid "Select file(s)"
-msgstr ""
-"Seleccioneu el(s) fitxer(s)\n"
-"Seleccioneu fitxer(s)"
+msgstr "Seleccioneu el(s) fitxer(s)"
 
 #: Console/AppConsole.vala:746
 msgid "Select snapshot"
@@ -2302,9 +2049,7 @@ msgstr "Seleccioneu els intervals de creació d'instantànies"
 
 #: Gtk/ExcludeBox.vala:273
 msgid "Select the items to be removed from the list"
-msgstr ""
-"Seleccioneu els ítems a eliminar de la llista\n"
-"Seleccioneu els elements a eliminar de la llista"
+msgstr "Seleccioneu els ítems a eliminar de la llista"
 
 #: Core/SnapshotRepo.vala:553
 msgid "Select the snapshot device"
@@ -2348,9 +2093,7 @@ msgstr "Dispositiu d'instantània seleccionat"
 
 #: Console/AppConsole.vala:688 Core/SnapshotRepo.vala:592
 msgid "Selected snapshot device is not a system disk"
-msgstr ""
-"El dispositiu d'instantània seleccionat no és un disc de sistema\n"
-"El dispositiu de instantània seleccionat no és un disc de sistema"
+msgstr "El dispositiu d'instantània seleccionat no és un disc de sistema"
 
 #: Core/Main.vala:2027
 msgid "Selected snapshot is marked for deletion"
@@ -2368,9 +2111,7 @@ msgid ""
 "only hidden files."
 msgstr ""
 "L'usuari seleccionat té un directori d'usuari xifrat. No és possible "
-"incloure només els fitxers ocults.\n"
-"L'usuari seleccionat té la carpeta xifrada. No és possible incloure només "
-"els fitxers ocults."
+"incloure només els fitxers ocults."
 
 #: Utility/Device.vala:1813
 #, c-format
@@ -2436,17 +2177,11 @@ msgstr ""
 "La mida de les instantànies BTRFS és inicialment zero. A mesura que els "
 "fitxers del sistema canvien amb el temps, les dades s'escriuen en nous blocs "
 "de dades que ocupen espai en disc (còpia per escriptura). Els fitxers de la "
-"instantània continuen apuntant als blocs de dades originals.\n"
-"La mida de les instantànies BTRFS és inicialment zero. A mesura que els "
-"arxius del sistema canvien amb el temps, les dades s'escriuen en nous blocs "
-"de dades que ocupen espai en disc (còpia per escriptura). Els arxius de la "
-"instantània continuen apuntant a blocs de dades originals."
+"instantània continuen apuntant als blocs de dades originals."
 
 #: Console/AppConsole.vala:368
 msgid "Skip GRUB2 reinstall"
-msgstr ""
-"Omet la reinstal·lació de GRUB2\n"
-"Omet reinstal·lar GRUB2"
+msgstr "Omet la reinstal·lació de GRUB2"
 
 #: Core/SnapshotRepo.vala:714 Core/SnapshotRepo.vala:752 Core/Main.vala:2032
 #: Gtk/SnapshotListBox.vala:95
@@ -2504,9 +2239,7 @@ msgstr "No s'ha especificat la instantània a restaurar!"
 
 #: Core/Main.vala:2855
 msgid "Snapshot will become active after system is rebooted."
-msgstr ""
-"La instantània estarà activa després de reiniciar el sistema.\n"
-"La instantània estarà activa després de reiniciar el sistema"
+msgstr "La instantània estarà activa després de reiniciar el sistema."
 
 #: Gtk/DeleteFinishBox.vala:60
 msgid "Snapshot(s) Deleted"
@@ -2560,10 +2293,6 @@ msgid ""
 "system is preserved as a new snapshot after restore."
 msgstr ""
 "Les instantànies es restauren amb la substitució dels subvolums de sistema. "
-"Atès que els fitxers mai es copien, eliminen o sobreescriuen, no hi ha cap "
-"risc de pèrdua de dades. El sistema existent es preserva com una instantània "
-"nova després de la restauració.\n"
-"Les instantànies es restauren amb la substitució de subvolums de sistema. "
 "Atès que els fitxers mai es copien, eliminen o sobreescriuen, no hi ha cap "
 "risc de pèrdua de dades. El sistema existent es preserva com una instantània "
 "nova després de la restauració."
@@ -2628,15 +2357,11 @@ msgstr "Les instantànies s'eliminaran durant la següent execució programada"
 
 #: Console/AppConsole.vala:375
 msgid "Specify backup device (default: config)"
-msgstr ""
-"Especifiqueu el dispositiu de còpia de seguretat (defecte: config)\n"
-"Especifiqueu el dispositiu de còpia (defecte: config)"
+msgstr "Especifiqueu el dispositiu de còpia de seguretat (defecte: config)"
 
 #: Console/AppConsole.vala:367
 msgid "Specify device for installing GRUB2 bootloader"
-msgstr ""
-"Especifiqueu el dispositiu per instal·lar el gestor d'arrencada GRUB2\n"
-"Especifiqueu el dispositiu per instal·lar el carregador d'arrencada de GRUB2"
+msgstr "Especifiqueu el dispositiu per instal·lar el gestor d'arrencada GRUB2"
 
 #: Console/AppConsole.vala:365
 msgid "Specify snapshot to restore"
@@ -2676,15 +2401,11 @@ msgstr "Resum"
 
 #: Console/AppConsole.vala:377
 msgid "Switch to BTRFS mode (default: config)"
-msgstr ""
-"Canvia al mode BTRFS (defecte: config)\n"
-"Canviar a mode BTRFS (defecte: config)"
+msgstr "Canvia al mode BTRFS (defecte: config)"
 
 #: Console/AppConsole.vala:378
 msgid "Switch to RSYNC mode (default: config)"
-msgstr ""
-"Canvia al mode RSYNC (defecte: config)\n"
-"Canviar a mode RSYNC (defecte: config)"
+msgstr "Canvia al mode RSYNC (defecte: config)"
 
 #: Core/SnapshotRepo.vala:1029
 msgid "Symlinks updated"
@@ -2692,15 +2413,11 @@ msgstr "Symlinks actualitzats"
 
 #: Core/Main.vala:2382
 msgid "Synching file systems..."
-msgstr ""
-"Sincronització dels sistemes de fitxers...\n"
-"S'estan sincronitzant els sistemes de fitxers..."
+msgstr "Sincronització dels sistemes de fitxers..."
 
 #: Core/Main.vala:1361 Core/Main.vala:2544 Core/Main.vala:2785
 msgid "Synching files with rsync..."
-msgstr ""
-"Sincronització dels fitxers amb rsync...\n"
-"S'estan sincronitzant els fitxers amb rsync..."
+msgstr "Sincronització dels fitxers amb rsync..."
 
 #: Gtk/AppGtk.vala:112
 msgid "Syntax"
@@ -2719,8 +2436,7 @@ msgstr "Utilitat de restauració del sistema"
 msgid "System can be rolled-back to a previous date by restoring a snapshot."
 msgstr ""
 "El sistema es pot revertir a una data anterior amb la restauració d'una "
-"instantània.\n"
-"El sistema es pot retrotreure a una data anterior restaurant una instantània."
+"instantània."
 
 #: Core/Main.vala:2245
 msgid "System will reboot after files are restored"
@@ -2779,9 +2495,7 @@ msgstr "La partició de destinació té una estructura de subvolum no compatible
 #: Gtk/BackupDeviceBox.vala:494
 #, c-format
 msgid "There are no snapshots on this device"
-msgstr ""
-"No hi ha cap instantània en aquest dispositiu\n"
-"No hi ha instantànies en aquest dispositiu"
+msgstr "No hi ha cap instantània en aquest dispositiu"
 
 #: Utility/Device.vala:1259
 msgid "This device is not encrypted"
@@ -2793,9 +2507,7 @@ msgid ""
 "responsibility for any damage arising from the use of this program."
 msgstr ""
 "Aquest programari NO té absolutament cap garantia i l'autor no es fa "
-"responsable dels danys derivats de l'ús d'aquest programa.\n"
-"Aquest programari vé sense CAP garantia en absolut i l'autor no assumeix cap "
-"responsabilitat per qualsevol dany que sorgeixi de l'ús d'aquest programa."
+"responsable dels danys derivats de l'ús d'aquest programa."
 
 #: Gtk/MainWindow.vala:1047 Gtk/MainWindow.vala:1058
 msgid "Timeshift is active"
@@ -2817,8 +2529,6 @@ msgstr "Marca de temps"
 msgid "To restore with default options, press the ENTER key for all prompts!"
 msgstr ""
 "Per restaurar amb les opcions predeterminades, premeu RETORN a totes les "
-"preguntes!\n"
-"Per restaurar amb les opcions predeterminades, premeu INTRO a totes les "
 "preguntes!"
 
 #: Utility/Gtk/AboutWindow.vala:441
@@ -2896,15 +2606,11 @@ msgstr ""
 
 #: Core/Main.vala:2365
 msgid "Updating GRUB menu..."
-msgstr ""
-"Actualització del menú de GRUB...\n"
-"S'està actualitzant el menú de GRUB..."
+msgstr "Actualització del menú de GRUB..."
 
 #: Core/Main.vala:2568
 msgid "Updating bootloader configuration..."
-msgstr ""
-"Actualització de la configuració del gestor d'arrencada...\n"
-"S'està actualitzant la configuració del gestor d'arrencada..."
+msgstr "Actualització de la configuració del gestor d'arrencada..."
 
 #: Utility/Device.vala:1834
 #, c-format
@@ -2917,9 +2623,7 @@ msgstr "Usuari"
 
 #: Gtk/UsersBox.vala:63
 msgid "User Home Directories"
-msgstr ""
-"Directoris dels usuaris\n"
-"Directoris personals dels usuaris"
+msgstr "Directoris dels usuaris"
 
 #: Utility/Device.vala:1340
 msgid "User cancelled the password prompt"
@@ -2930,9 +2634,7 @@ msgid ""
 "User home directories are excluded by default unless you enable them here"
 msgstr ""
 "Els directoris dels usuaris s'exclouen per defecte tret que els habiliteu "
-"aquí\n"
-"Els directoris personals dels usuaris s'exclouen per defecte tret que els "
-"habiliteu aquí"
+"aquí"
 
 #: Gtk/SettingsWindow.vala:98
 msgid "Users"
@@ -2970,20 +2672,16 @@ msgstr "Avís"
 
 #: Gtk/RestoreExcludeBox.vala:61
 msgid "Web Browsers"
-msgstr ""
-"Navegadors web\n"
-"Navegadors Web"
+msgstr "Navegadors web"
 
 #: Utility/Gtk/DonationWindow.vala:113
 #, c-format
 msgid "Website"
-msgstr ""
-"Lloc web\n"
-"Pàgina web"
+msgstr "Lloc web"
 
 #: Gtk/ScheduleBox.vala:82 Gtk/SnapshotListBox.vala:301
 msgid "Weekly"
-msgstr "Setmanalment"
+msgstr "Setmanal"
 
 #: Core/Main.vala:1107
 msgid "Weekly snapshot failed!"
@@ -2991,9 +2689,7 @@ msgstr "Ha fallat la instantània setmanal!"
 
 #: Core/Main.vala:1088
 msgid "Weekly snapshots are enabled"
-msgstr ""
-"Les instantànies setmanals estan habilitades\n"
-"Les instantànies setmanals estan activades"
+msgstr "Les instantànies setmanals estan habilitades"
 
 #: Utility/Gtk/DonationWindow.vala:105
 msgid "Wiki ~ Documentation & Help"
@@ -3023,9 +2719,6 @@ msgid ""
 msgstr ""
 "Podeu continuar treballant en el sistema actual. Després de reiniciar, el "
 "sistema actual serà visible com una nova instantània. Aquesta instantània es "
-"pot restaurar més tard si cal, per a \"desfer\" la restauració.\n"
-"Pot continuar treballant en el sistema actual. Després de reiniciar, el "
-"sistema actual serà visible com una nova instantània. Aquesta instantània es "
 "pot restaurar més tard si cal, per a \"desfer\" la restauració."
 
 #: Gtk/RestoreDeviceBox.vala:413
@@ -3037,18 +2730,14 @@ msgstr ""
 "restaurat falla en l'arrencada."
 
 #: Console/AppConsole.vala:1010
-#, fuzzy, c-format
+#, c-format
 msgid "[ENTER = Default (%s), a = Abort]"
-msgstr ""
-"[RETORN = predeterminat (%s), a = avorta]\n"
-"[ENTER = Predeterminat (%s), a = Avorta]"
+msgstr "[RETORN = predeterminat (%s), a = avorta]"
 
 #: Console/AppConsole.vala:881
-#, fuzzy, c-format
+#, c-format
 msgid "[ENTER = Default (%s), r = Root device, a = Abort]"
-msgstr ""
-"[RETORN = predeterminat (%s), r = dispositiu arrel, a = avorta]\n"
-"[ENTER = Predeterminat (%s), r = dispositiu arrel, a = Avorta]"
+msgstr "[RETORN = predeterminat (%s), r = dispositiu arrel, a = avorta]"
 
 #: Utility/AppLock.vala:54
 msgid "[Warning] Deleted invalid lock"
@@ -3101,44 +2790,6 @@ msgstr "rsync ha tornat un error"
 msgid "un-tagged"
 msgstr "no etiquetada"
 
-#, fuzzy
-#~ msgid "Click to edit and drag-drop to re-order"
-#~ msgstr "Feu clic per editar. Arrossegueu i deixeu anar per reordenar."
-
-#~ msgid ""
-#~ "Click an item to edit the pattern.\n"
-#~ "Drag and drop items with mouse to re-order."
-#~ msgstr ""
-#~ "Feu clic a un ítem per editar el patró.\n"
-#~ "Arrossegueu i deixeu anar els ítem amb el ratolí per reordenar-los.\n"
-#~ "Feu clic a un element per editar el patró.\n"
-#~ "Arrossegueu i deixeu anar elements amb el ratolí per reordenar-los."
-
-#~ msgid "Editing and Re-Ordering"
-#~ msgstr "Edició i reordenació"
-
-#~ msgid "Info"
-#~ msgstr ""
-#~ "Informació\n"
-#~ "Info"
-
-#~ msgid "Deleted system subvolumes"
-#~ msgstr ""
-#~ "Subvolums de sistema suprimits\n"
-#~ "Subvolums del sistema suprimits"
-
-#~ msgid "<b>System:</b> Installed Linux distribution"
-#~ msgstr "<b>Sistema:</b> Distribució de Linux instal·lada"
-
-#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
-#~ msgstr ""
-#~ "<b>Data de la instantània:</b> Data en què es va crear la instantània"
-
-#~ msgid "Selected snapshot path"
-#~ msgstr ""
-#~ "Camí a la instantània seleccionada\n"
-#~ "Camí de la instantània seleccionada"
-
 #~ msgid ""
 #~ "<b>Backup Levels</b>\n"
 #~ "\n"
@@ -3156,41 +2807,51 @@ msgstr "no etiquetada"
 #~ "H\tCada hora\n"
 #~ "D\tDiari\n"
 #~ "W\tSetmanal\n"
-#~ "M\tMensual\n"
-#~ "<b>Nivells de còpia de seguretat</b>\n"
-#~ "\n"
-#~ "O\tSota demanda (manual)\n"
-#~ "B\tA l'inici\n"
-#~ "H\tHorari\n"
-#~ "D\tDiari\n"
-#~ "W\tSetmanal\n"
 #~ "M\tMensual"
 
-#~ msgid "Cloning System..."
+#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
 #~ msgstr ""
-#~ "Clonació del sistema...\n"
-#~ "Clonant el sistema..."
+#~ "<b>Data de la instantània:</b> Data en què es va crear la instantània"
+
+#~ msgid "<b>System:</b> Installed Linux distribution"
+#~ msgstr "<b>Sistema:</b> Distribució de Linux instal·lada"
+
+#~ msgid ""
+#~ "Click an item to edit the pattern.\n"
+#~ "Drag and drop items with mouse to re-order."
+#~ msgstr ""
+#~ "Feu clic a un ítem per editar el patró.\n"
+#~ "Arrossegueu i deixeu anar els ítem amb el ratolí per reordenar-los."
+
+#~ msgid "Cloning System..."
+#~ msgstr "Clonació del sistema..."
 
 #~ msgid "Close Window"
-#~ msgstr ""
-#~ "Tanca la finestra\n"
-#~ "Tanca finestra"
+#~ msgstr "Tanca la finestra"
 
 #~ msgid "Contributions"
 #~ msgstr "Contribucions"
 
+#~ msgid "Create snapshots using RSYNC"
+#~ msgstr "Crea les instantànies amb RSYNC"
+
+#~ msgid "Deleted system subvolumes"
+#~ msgstr "Subvolums de sistema suprimits"
+
 #~ msgid "Documenters"
-#~ msgstr ""
-#~ "Documentalistes\n"
-#~ "Documentadors"
+#~ msgstr "Documentalistes"
+
+#~ msgid "Editing and Re-Ordering"
+#~ msgstr "Edició i reordenació"
 
 #~ msgid "Include everything"
-#~ msgstr ""
-#~ "Inclou-ho tot\n"
-#~ "Inclou tot"
+#~ msgstr "Inclou-ho tot"
 
 #~ msgid "Include hidden items"
 #~ msgstr "Inclou els ítems ocults"
+
+#~ msgid "Info"
+#~ msgstr "Informació"
 
 #~ msgid "Log Viewer"
 #~ msgstr "Visualitzador de registres"
@@ -3200,6 +2861,9 @@ msgstr "no etiquetada"
 
 #~ msgid "Scheduled task runs once every hour"
 #~ msgstr "La tasca programada s'executa una vegada cada hora"
+
+#~ msgid "Selected snapshot path"
+#~ msgstr "Camí a la instantània seleccionada"
 
 #~ msgid "Third Party Tools"
 #~ msgstr "Eines de tercers"
@@ -3215,6 +2879,10 @@ msgstr "no etiquetada"
 
 #~ msgid "View:"
 #~ msgstr "Mostra:"
+
+#, fuzzy
+#~ msgid "Click to edit and drag-drop to re-order"
+#~ msgstr "Feu clic per editar. Arrossegueu i deixeu anar per reordenar."
 
 #~ msgid "Change"
 #~ msgstr "Canviat"

--- a/po/timeshift-ca@valencia.po
+++ b/po/timeshift-ca@valencia.po
@@ -1,23 +1,19 @@
-# Catalan (Valencian) translation for linuxmint
-# Copyright (c) 2017 Rosetta Contributors and Canonical Ltd 2017
-# This file is distributed under the same license as the linuxmint package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
-"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
-"POT-Creation-Date: 2017-10-01 15:06+0530\n"
+"Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
 "PO-Revision-Date: 2017-09-23 03:21+0000\n"
 "Last-Translator: Diwi Tape <Unknown>\n"
 "Language-Team: Catalan (Valencian) <ca@valencia@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:01+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
-#: Console/AppConsole.vala:611
+#: Console/AppConsole.vala:613
 #, c-format
 msgid ""
 "\n"
@@ -26,115 +22,94 @@ msgstr ""
 "\n"
 "Pulse ENTER per a continuar..."
 
-#: Core/SnapshotRepo.vala:597
+#: Core/SnapshotRepo.vala:641
 #, c-format
 msgid "%d snapshots, %s free"
 msgstr "%d images, %s lliure"
 
-#: Console/AppConsole.vala:912
+#: Console/AppConsole.vala:914
 #, c-format
 msgid "'%s' will be on '%s'"
 msgstr "'%s' estarà en '%s'"
 
-#: Console/AppConsole.vala:909
+#: Console/AppConsole.vala:911
 #, c-format
 msgid "'%s' will be on root device"
 msgstr "'%s' estarà en el dispositiu root"
 
-#: Gtk/BootOptionsBox.vala:119
+#: Gtk/BootOptionsBox.vala:118
 msgid "(Re)install GRUB2 on:"
 msgstr "(Re)instalar GRUB2 en:"
 
-#: Core/Main.vala:353
+#: Core/Main.vala:362
 msgid "** Uninstalled Timeshift BTRFS **"
 msgstr "** Desinstalat Timeshift BTRFS **"
 
-#: Core/Main.vala:3203
+#: Core/Main.vala:3342
 msgid "/ is mapped to device"
 msgstr "/ està mapeat al dispositiu"
 
-#: Core/Main.vala:3225
+#: Core/Main.vala:3364
 msgid "/boot is mapped to device"
 msgstr "/boot està mapeat al dispositiu"
 
-#: Core/Main.vala:3236
+#: Core/Main.vala:3375
 msgid "/boot/efi is mapped to device"
 msgstr "/boot/efi està mapeat al dispositiu"
 
-#: Core/Main.vala:3214
+#: Core/Main.vala:3353
 msgid "/home is mapped to device"
 msgstr "/home està mapeat al dispositiu"
 
-#: Gtk/SnapshotListBox.vala:274
-msgid ""
-"<b>Backup Levels</b>\n"
-"\n"
-"O\tOn demand (manual)\n"
-"B\tBoot\n"
-"H\tHourly\n"
-"D\tDaily\n"
-"W\tWeekly\n"
-"M\tMonthly"
-msgstr ""
-"<b>Backup Levels</b>\n"
-"\n"
-"O\tBaix demanda (manual)\n"
-"B\tArranque\n"
-"H\tHorari\n"
-"D\tDiari\n"
-"W\tSemanal\n"
-"M\tMensual"
-
-#: Gtk/SnapshotListBox.vala:266
+#: Gtk/SnapshotListBox.vala:290
 msgid "<b>Comments</b> (double-click to edit)"
 msgstr "<b>Comentaris</b> (doble-click per a editar)"
 
-#: Gtk/SnapshotListBox.vala:262
-msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
+#: Gtk/ScheduleBox.vala:168
+msgid ""
+"A maintenance task runs once every hour and creates snapshots as needed."
 msgstr ""
-"<b>Data de la captura de pantalla:</b> Data en que va crearse la captura de "
-"pantalla"
 
-#: Gtk/SnapshotListBox.vala:270
-msgid "<b>System:</b> Installed Linux distribution"
-msgstr "<b>Sistema:</b> Distribució Linux instalada"
-
-#: Console/AppConsole.vala:696 Console/AppConsole.vala:760
-#: Console/AppConsole.vala:892 Console/AppConsole.vala:987
-#: Console/AppConsole.vala:1032 Console/AppConsole.vala:1073
-#: Console/AppConsole.vala:1090
+#: Console/AppConsole.vala:698 Console/AppConsole.vala:762
+#: Console/AppConsole.vala:894 Console/AppConsole.vala:989
+#: Console/AppConsole.vala:1034 Console/AppConsole.vala:1075
+#: Console/AppConsole.vala:1093
 msgid "Aborted."
 msgstr "Cancelat"
 
-#: Gtk/MainWindow.vala:384
+#: Gtk/MainWindow.vala:393
 msgid "About"
 msgstr "Acerca de"
 
-#: Gtk/ExcludeBox.vala:223
+#: Gtk/RsyncLogBox.vala:472
+msgid "Action"
+msgstr ""
+
+#: Gtk/ExcludeBox.vala:219
 msgid "Add"
 msgstr "Afegir"
 
-#: Gtk/ExcludeBox.vala:237
+#: Gtk/ExcludeBox.vala:233
 msgid "Add Files"
 msgstr "Afegir archius"
 
-#: Gtk/ExcludeBox.vala:243
+#: Gtk/ExcludeBox.vala:239
 msgid "Add Folders"
 msgstr "Afegir directoris"
 
-#: Gtk/ExcludeBox.vala:223
+#: Gtk/ExcludeBox.vala:219
 msgid "Add custom pattern"
 msgstr "Afegir patró personaliçat"
 
-#: Gtk/ExcludeBox.vala:243
+#: Gtk/ExcludeBox.vala:239
 msgid "Add directories"
 msgstr "Afegir directoris"
 
-#: Gtk/ExcludeBox.vala:237
+#: Gtk/ExcludeBox.vala:233
 msgid "Add files"
 msgstr "Afegir archius"
 
-#: Console/AppConsole.vala:358
+#: Console/AppConsole.vala:360
 msgid "Add tags to snapshot (default: O)"
 msgstr "Afegir etiquetes a la image"
 
@@ -142,17 +117,22 @@ msgstr "Afegir etiquetes a la image"
 msgid "Added cron task"
 msgstr "Tarea cron afegida"
 
-#: Gtk/AppGtk.vala:129
+#: Gtk/AppGtk.vala:131
 msgid "Admin Access Required"
 msgstr "Es requerix accés d'administraor"
 
-#: Gtk/AppGtk.vala:124
+#: Gtk/AppGtk.vala:126
 msgid "Admin access is required to backup and restore system files."
 msgstr ""
 "Es requerix accés d'administraor per a fer copia de seguretat i restaurar "
 "archius de sistema."
 
-#: Gtk/SnapshotBackendBox.vala:182
+#: Gtk/RsyncLogBox.vala:363
+#, fuzzy
+msgid "All Files"
+msgstr "Afegir archius"
+
+#: Gtk/SnapshotBackendBox.vala:188
 msgid ""
 "All files are copied when first snapshot is created. Subsequent snapshots "
 "are incremental. Unchanged files will be hard-linked from the previous "
@@ -162,11 +142,11 @@ msgstr ""
 "incrementals. Els archius no modificats es vinculen a la image precedent, si "
 "està disponible."
 
-#: Gtk/ExcludeMessageWindow.vala:137
+#: Gtk/ExcludeMessageWindow.vala:130
 msgid "All other files and folders are excluded."
 msgstr "La resta d'archius i directoris s'excluixen."
 
-#: Gtk/RestoreDeviceBox.vala:497
+#: Gtk/RestoreDeviceBox.vala:500
 msgid ""
 "An encrypted device is selected for root file system (/). The boot directory "
 "(/boot) must be mounted on a non-encrypted device for the system to boot "
@@ -179,73 +159,77 @@ msgstr ""
 "directori d'arranque (/boot) s'ha de montar en un dispositiu que no estiga "
 "encriptat per a que el sistema arranque correctament."
 
-#: Core/Main.vala:243
+#: Core/Main.vala:249
 msgid "Another instance of Timeshift is creating a snapshot."
 msgstr "Otra instancia de Timeshift està fent una image."
 
-#: Utility/AppLock.vala:50
+#: Utility/AppLock.vala:49
 msgid "Another instance of this application is running"
 msgstr "S'està executant atra instancia d'esta aplicació"
 
-#: Core/Main.vala:247
+#: Core/Main.vala:253
 msgid "Another instance of timeshift is currently running!"
 msgstr "¡Ja s'està executant atra instancia de Timeshift!"
 
-#: Console/AppConsole.vala:374
+#: Console/AppConsole.vala:376
 msgid "Answer YES to all confirmation prompts"
 msgstr "Conteste SÍ a totes les peticions de confirmació"
 
-#: Core/Main.vala:3042
+#: Core/Main.vala:3179
 msgid "App config loaded"
 msgstr "Configuració de la aplicació carregada"
 
-#: Core/Main.vala:2948
+#: Core/Main.vala:3076
 msgid "App config saved"
 msgstr "Configuració de la aplicació guardada"
 
-#: Console/AppConsole.vala:100
+#: Console/AppConsole.vala:102
 msgid "Application needs admin access."
 msgstr "L'aplicació necesita accés d'administraor"
 
-#: Core/Main.vala:3380
+#: Core/Main.vala:3519
 msgid "Application will exit"
 msgstr "L'aplicació es tancarà"
 
-#: Core/Main.vala:369
+#: Core/Main.vala:378
 msgid "Application will exit."
 msgstr "L'aplicació es tancarà."
 
-#: Utility/Gtk/AboutWindow.vala:344
-#, c-format
+#: Utility/Gtk/AboutWindow.vala:433
 msgid "Artists"
 msgstr "Artistes"
 
-#: Utility/Gtk/AboutWindow.vala:320
-#, c-format
+#: Utility/Gtk/AboutWindow.vala:417
 msgid "Authors"
 msgstr "Autors"
 
-#: Gtk/MainWindow.vala:332
+#: Gtk/MainWindow.vala:346
 msgid "Available"
 msgstr "Disponible"
 
-#: Gtk/SnapshotBackendBox.vala:95
+#: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr "BTRFS"
 
-#: Gtk/SnapshotBackendBox.vala:159
+#: Gtk/SnapshotBackendBox.vala:165
 msgid "BTRFS Snapshots"
 msgstr "Images BTRFS"
 
-#: Gtk/SnapshotBackendBox.vala:118
+#: Gtk/SnapshotBackendBox.vala:119
 msgid "BTRFS Tools Not Found"
 msgstr "Ferramentes BTRFS no trobades"
 
-#: Core/Main.vala:1915 Core/Main.vala:1919
+#: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
 msgstr "Dispositiu BTRFS no s'ha montat"
 
-#: Gtk/FinishBox.vala:91
+#: Gtk/BackupDeviceBox.vala:98
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
+msgstr ""
+
+#: Gtk/FinishBox.vala:92
 msgid ""
 "BTRFS snapshots are saved on the same disk from which it is created. If the "
 "system disk fails, snapshots will be lost along with the system. Save "
@@ -257,85 +241,91 @@ msgstr ""
 "images en un disc extern que no siga de sistema, en modo RSYNC per a "
 "protegirse contra errors de disc."
 
-#: Utility/Gtk/AboutWindow.vala:294
+#: Utility/Gtk/AboutWindow.vala:349 Utility/Gtk/AboutWindow.vala:381
 msgid "Back"
 msgstr "Tornar"
 
-#: Gtk/SetupWizardWindow.vala:89
+#: Gtk/SetupWizardWindow.vala:94
 msgid "Backend"
 msgstr "Respaldament"
 
-#: Console/AppConsole.vala:354 Gtk/BackupWindow.vala:89
+#: Console/AppConsole.vala:356 Gtk/BackupWindow.vala:91
 msgid "Backup"
 msgstr "Copia de seguretat"
 
-#: Core/Main.vala:1891
+#: Core/Main.vala:2017
 msgid "Backup Device"
 msgstr "Dispositiu de copia de seguretat"
 
-#: Core/Main.vala:1886
+#: Core/Main.vala:2012
 msgid "Backup device not specified!"
 msgstr "Dispositiu de copia de seguretat no especificat!"
 
-#: Utility/Gtk/DonationWindow.vala:85
+#: Utility/Gtk/DonationWindow.vala:89
 msgid "Become a Patron"
 msgstr ""
 
-#: Gtk/RestoreExcludeBox.vala:116
+#: Gtk/RestoreExcludeBox.vala:91
 msgid "Bittorrent Clients"
 msgstr "Clients de Bittorrent"
 
-#: Gtk/ScheduleBox.vala:133
+#: Gtk/ScheduleBox.vala:136 Gtk/SnapshotListBox.vala:298
 msgid "Boot"
 msgstr "Arranque"
 
-#: Gtk/RestoreDeviceBox.vala:496
+#: Gtk/RestoreDeviceBox.vala:499
 msgid "Boot device not selected"
 msgstr "Dispositiu d'arranque no seleccionat"
 
-#: Core/Main.vala:925
+#: Core/Main.vala:1017
 msgid "Boot snapshot failed!"
 msgstr "La image d'arranque ha fallat!"
 
-#: Core/Main.vala:906
+#: Gtk/ScheduleBox.vala:169
+msgid ""
+"Boot snapshots are created with a delay of 10 minutes after system startup."
+msgstr ""
+
+#: Core/Main.vala:998
 msgid "Boot snapshots are enabled"
 msgstr "Les images d'arranque estàn activaes"
 
-#: Gtk/BootOptionsWindow.vala:48
+#: Gtk/BootOptionsWindow.vala:49
 msgid "Bootloader Options"
 msgstr "Opcions del carregaor d'arranque"
 
-#: Gtk/RestoreDeviceBox.vala:409
+#: Gtk/RestoreDeviceBox.vala:411
 msgid "Bootloader Options (Advanced)"
 msgstr "Opcions del carregaor d'arranque (Avançat)"
 
-#: Gtk/MainWindow.vala:168
+#: Gtk/MainWindow.vala:171
 msgid "Browse"
 msgstr "Examinar"
 
-#: Gtk/SnapshotListBox.vala:306
+#: Gtk/SnapshotListBox.vala:336
 msgid "Browse Files"
 msgstr "Examinar archius"
 
-#: Gtk/MainWindow.vala:169
+#: Gtk/MainWindow.vala:172
 msgid "Browse selected snapshot"
 msgstr "Examinar image seleccionada"
 
-#: Core/Main.vala:2353
+#: Core/Main.vala:2499
 msgid "Building file list..."
 msgstr "Creant lista d'archius..."
 
-#: Utility/Gtk/CustomMessageDialog.vala:173 Utility/GtkHelper.vala:122
-#: Gtk/DeleteWindow.vala:184 Gtk/SetupWizardWindow.vala:202
-#: Gtk/RestoreWindow.vala:185 Gtk/BackupWindow.vala:173
+#: Utility/GtkHelper.vala:122 Utility/Gtk/CustomMessageDialog.vala:172
+#: Gtk/SetupWizardWindow.vala:214 Gtk/BackupWindow.vala:177
+#: Gtk/DeleteWindow.vala:187 Gtk/RestoreWindow.vala:206
+#: Gtk/RestoreWindow.vala:215
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: Gtk/RestoreWindow.vala:189
+#: Gtk/RestoreWindow.vala:221
 msgid "Cancel restore?"
 msgstr "Cancelar restauració?"
 
-#: Gtk/RestoreWindow.vala:191
+#: Gtk/RestoreWindow.vala:223
 msgid ""
 "Cancelling the restore process will leave the target system in an "
 "inconsistent state. The system may fail to boot or you may run into various "
@@ -347,79 +337,79 @@ msgstr ""
 "Després de cancelar, ha de restaurar atra image per a portar el sistema a un "
 "estat consistent. Pulse Sí per a confirmar."
 
-#: Gtk/MainWindow.vala:554
+#: Gtk/MainWindow.vala:563
 msgid "Cannot Delete Live Snapshot"
 msgstr "No se pot eliminar una image viva"
 
-#: Gtk/BackupBox.vala:87 Gtk/RestoreBox.vala:124
+#: Gtk/RsyncLogBox.vala:380 Gtk/RsyncLogBox.vala:383 Gtk/RsyncLogBox.vala:567
+#: Gtk/RsyncLogBox.vala:588 Gtk/RestoreBox.vala:125 Gtk/BackupBox.vala:87
 msgid "Changed"
 msgstr "Modificat"
 
-#: Gtk/BackupBox.vala:89 Gtk/RestoreBox.vala:126
+#: Gtk/RestoreBox.vala:127 Gtk/BackupBox.vala:89
 msgid "Changed items:"
 msgstr "Elements modificats:"
 
-#: Core/Main.vala:2574
+#: Gtk/RestoreWindow.vala:104
+msgid "Checking Restore Actions (Dry Run)"
+msgstr ""
+
+#: Core/Main.vala:2732
 msgid "Checking file systems for errors..."
 msgstr "Buscant errors en els archius de sistema..."
 
-#: Gtk/BackupBox.vala:92 Gtk/RestoreBox.vala:129
+#: Gtk/RsyncLogBox.vala:390 Gtk/RestoreBox.vala:130 Gtk/BackupBox.vala:92
+#, c-format
 msgid "Checksum"
 msgstr "Suma de verificació"
 
-#: Core/Main.vala:2242
+#: Core/Main.vala:2388
 msgid "Cleaning up..."
 msgstr "Netejant"
 
-#: Gtk/ExcludeBox.vala:265
-msgid ""
-"Click an item to edit the pattern.\n"
-"Drag and drop items with mouse to re-order."
-msgstr ""
-"Fer clic en un element per a editar el patró.\n"
-"Arrastrar y soltar elements en el ratolí per a ficarlos en ordre."
-
-#: Gtk/ExcludeBox.vala:80 Gtk/UsersBox.vala:85
+#: Gtk/UsersBox.vala:92 Gtk/ExcludeBox.vala:84
 msgid "Click to edit. Drag and drop to re-order."
 msgstr "Fer clic per a editar. Arrastrar y soltar per a ordenar."
 
-#: Gtk/RestoreWindow.vala:63
+#: Gtk/ExcludeBox.vala:59
+#, fuzzy
+msgid "Click to edit. Drag-drop to re-order."
+msgstr "Fer clic per a editar. Arrastrar y soltar per a ordenar."
+
+#: Gtk/RestoreWindow.vala:69
 msgid "Clone System"
 msgstr "Clonar el sistema"
 
-#: Console/AppConsole.vala:362
+#: Console/AppConsole.vala:364
 msgid "Clone current system"
 msgstr "Clonar el sistema actual"
 
-#: Gtk/RestoreFinishBox.vala:61
+#: Gtk/RestoreFinishBox.vala:68
 msgid "Cloning"
 msgstr "Clonant"
 
-#: Gtk/RestoreBox.vala:73
-msgid "Cloning System..."
-msgstr "Clonant sistema..."
-
-#: Core/Main.vala:2619
+#: Core/Main.vala:2782
 msgid "Cloning system..."
 msgstr "Clonant sistema"
 
-#: Utility/Gtk/AboutWindow.vala:302 Gtk/BootOptionsWindow.vala:105
-#: Gtk/DeleteWindow.vala:167 Gtk/SettingsWindow.vala:85
-#: Gtk/RestoreWindow.vala:176 Gtk/RsyncLogWindow.vala:247
-#: Gtk/BackupWindow.vala:164
+#: Utility/Gtk/AboutWindow.vala:326 Utility/Gtk/DonationWindow.vala:121
+#: Gtk/RsyncLogBox.vala:266 Gtk/BackupWindow.vala:168
+#: Gtk/BootOptionsWindow.vala:106 Gtk/DeleteWindow.vala:170
+#: Gtk/RestoreWindow.vala:508
 msgid "Close"
 msgstr "Tancar"
 
-#: Utility/Gtk/DonationWindow.vala:117
-msgid "Close Window"
-msgstr ""
-
-#: Gtk/FinishBox.vala:100 Gtk/DeleteFinishBox.vala:71
-#: Gtk/BackupFinishBox.vala:70 Gtk/RestoreFinishBox.vala:90
+#: Gtk/RestoreFinishBox.vala:106 Gtk/BackupFinishBox.vala:70
+#: Gtk/FinishBox.vala:101 Gtk/DeleteFinishBox.vala:71
 msgid "Close window to exit"
 msgstr "Tancar finestra per a eixir"
 
-#: Core/Main.vala:339
+#: Utility/Gtk/AboutWindow.vala:425
+#, fuzzy
+msgid "Code Contributions"
+msgstr "Contribucions"
+
+#: Core/Main.vala:347
 msgid "Commands listed below are not available on this system"
 msgstr ""
 "Els comandos listats a continuació no estàn disponibles en este sistema"
@@ -428,49 +418,58 @@ msgstr ""
 msgid "Comments"
 msgstr "Comentaris"
 
-#: Gtk/DeleteFinishBox.vala:50 Gtk/BackupFinishBox.vala:50
-#: Gtk/RestoreFinishBox.vala:50 Gtk/RestoreFinishBox.vala:68
+#: Core/Main.vala:2775 Gtk/RestoreBox.vala:74 Gtk/RestoreBox.vala:187
+msgid "Comparing Files (Dry Run)..."
+msgstr ""
+
+#: Core/Main.vala:2541
+msgid "Comparing files with rsync..."
+msgstr ""
+
+#: Gtk/RestoreFinishBox.vala:50 Gtk/RestoreFinishBox.vala:75
+#: Gtk/BackupFinishBox.vala:50 Gtk/DeleteFinishBox.vala:50
 msgid "Completed"
 msgstr "Completat"
 
-#: Gtk/RestoreFinishBox.vala:71
+#: Gtk/RestoreFinishBox.vala:78
 msgid "Completed With Errors"
 msgstr "Completat en errors"
 
-#: Console/AppConsole.vala:1066
+#: Gtk/RsyncLogBox.vala:87 Gtk/RestoreWindow.vala:109
+#, fuzzy
+msgid "Confirm Actions"
+msgstr "Contribucions"
+
+#: Console/AppConsole.vala:1068
 #, c-format
 msgid "Continue with restore? (y/n): "
 msgstr "Continuar en la restauració? (y/n): "
 
-#: Utility/Gtk/AboutWindow.vala:328
-#, c-format
-msgid "Contributions"
-msgstr "Contribucions"
-
-#: Console/AppConsole.vala:832 Console/AppConsole.vala:963
+#: Console/AppConsole.vala:834 Console/AppConsole.vala:965
 msgid "Could not find device"
 msgstr ""
 
-#: Utility/Device.vala:1119
+#: Utility/Device.vala:1187
 #, c-format
 msgid "Could not find file"
 msgstr "Archiu no trobat"
 
-#: Console/AppConsole.vala:729
+#: Console/AppConsole.vala:731
 msgid "Could not find snapshot"
 msgstr "No es troba la image"
 
-#: Core/Main.vala:2820
+#: Core/Main.vala:2946
 msgid "Could not find system subvolume"
 msgstr "No es troba el subvolumen del sistema"
 
-#: Core/Main.vala:2848
+#: Core/Main.vala:2974
 msgid "Could not find system subvolumes for creating pre-restore snapshot"
 msgstr ""
 "No es troben subvolumens del sistema per a crear una image de pre-"
 "restauració."
 
-#: Gtk/MainWindow.vala:138
+#: Gtk/RsyncLogBox.vala:366 Gtk/RsyncLogBox.vala:571 Gtk/MainWindow.vala:141
+#, c-format
 msgid "Create"
 msgstr "Crear"
 
@@ -478,39 +477,39 @@ msgstr "Crear"
 msgid "Create Snapshot"
 msgstr "Crear image"
 
-#: Gtk/ScheduleBox.vala:133
+#: Gtk/ScheduleBox.vala:136
 msgid "Create one per boot"
 msgstr "Crear un per arranque"
 
-#: Gtk/ScheduleBox.vala:97
+#: Gtk/ScheduleBox.vala:100
 msgid "Create one per day"
 msgstr "Crear un per dia"
 
-#: Gtk/ScheduleBox.vala:115
+#: Gtk/ScheduleBox.vala:118
 msgid "Create one per hour"
 msgstr "Crear un per hora"
 
-#: Gtk/ScheduleBox.vala:61
+#: Gtk/ScheduleBox.vala:64
 msgid "Create one per month"
 msgstr "Crear un per mes"
 
-#: Gtk/ScheduleBox.vala:79
+#: Gtk/ScheduleBox.vala:82
 msgid "Create one per week"
 msgstr "Crear un per setmana"
 
-#: Console/AppConsole.vala:356
+#: Console/AppConsole.vala:358
 msgid "Create snapshot (even if not scheduled)"
 msgstr "Crear image (encara que no estiga programada)"
 
-#: Console/AppConsole.vala:355
+#: Console/AppConsole.vala:357
 msgid "Create snapshot if scheduled"
 msgstr "Crear image si està programada"
 
-#: Gtk/MainWindow.vala:139
+#: Gtk/MainWindow.vala:142
 msgid "Create snapshot of current system"
 msgstr "Crear image del sistema actual"
 
-#: Gtk/MainWindow.vala:1044
+#: Gtk/MainWindow.vala:1074
 msgid ""
 "Create snapshots manually or enable scheduled snapshots to protect your "
 "system"
@@ -518,31 +517,34 @@ msgstr ""
 "Crear images manualment o permetre images programaes per a protegir el "
 "sistema"
 
-#: Gtk/SnapshotBackendBox.vala:96
-msgid "Create snapshots using RSYNC"
+#: Gtk/SnapshotBackendBox.vala:95
+#, fuzzy
+msgid "Create snapshots using BTRFS"
 msgstr "Crear images usant RSYNC"
 
-#: Gtk/SnapshotBackendBox.vala:79
+#: Gtk/SnapshotBackendBox.vala:78
 msgid "Create snapshots using RSYNC tool and hard-links"
 msgstr "Crear images usant la ferramenta RSYNC i hard-links"
 
-#: Gtk/BackupBox.vala:85 Gtk/RestoreBox.vala:122
+#: Gtk/RsyncLogBox.vala:366 Gtk/RsyncLogBox.vala:571 Gtk/RsyncLogBox.vala:592
+#: Gtk/RestoreBox.vala:123 Gtk/BackupBox.vala:85
+#, c-format
 msgid "Created"
 msgstr "Creat"
 
-#: Core/Snapshot.vala:360
+#: Core/Snapshot.vala:430
 msgid "Created control file"
 msgstr "Archiu de control creat"
 
-#: Utility/TeeJee.FileSystem.vala:325
+#: Utility/TeeJee.FileSystem.vala:351
 msgid "Created directory"
 msgstr "Directori creat"
 
-#: Core/Main.vala:2870
+#: Core/Main.vala:2996
 msgid "Created pre-restore snapshot"
 msgstr "Image de pre-restauració creada"
 
-#: Core/Main.vala:1389
+#: Core/Main.vala:1499
 msgid "Created subvolume snapshot"
 msgstr "Subvolume de image creat"
 
@@ -550,23 +552,23 @@ msgstr "Subvolume de image creat"
 msgid "Creating Snapshot..."
 msgstr "Creant image..."
 
-#: Core/Main.vala:1343
+#: Core/Main.vala:1437
 msgid "Creating new backup..."
 msgstr "Creant nova copia de seguretat"
 
-#: Core/Main.vala:1191
+#: Core/Main.vala:1283
 msgid "Creating new snapshot..."
 msgstr "Creant nova image"
 
-#: Core/Main.vala:2798
+#: Core/Main.vala:2924
 msgid "Creating pre-restore snapshot from system subvolumes..."
 msgstr "Creant image de pre-restauració dels subvolumens del sistema..."
 
-#: Utility/Gtk/AboutWindow.vala:282 Utility/Gtk/AboutWindow.vala:297
+#: Utility/Gtk/AboutWindow.vala:321 Utility/Gtk/AboutWindow.vala:387
 msgid "Credits"
 msgstr "Crèdits"
 
-#: Core/Main.vala:3379
+#: Core/Main.vala:3518
 msgid "Critical Error"
 msgstr "Error critic"
 
@@ -582,24 +584,26 @@ msgstr "Eliminada tarea cron"
 msgid "Cron task exists"
 msgstr "La tarea cron existe"
 
-#: Gtk/ScheduleBox.vala:97
+#: Gtk/ScheduleBox.vala:100 Gtk/SnapshotListBox.vala:300
 msgid "Daily"
 msgstr "A diari"
 
-#: Core/Main.vala:985
+#: Core/Main.vala:1077
 msgid "Daily snapshot failed!"
 msgstr "La image diaria ha fallat!"
 
-#: Core/Main.vala:966
+#: Core/Main.vala:1058
 msgid "Daily snapshots are enabled"
 msgstr "Images diaries actives"
 
-#: Core/Main.vala:1983
+#: Core/Main.vala:2111
 msgid "Data will be modified on following devices:"
 msgstr "Es modificaràn els datos en els següents dispositius"
 
-#: Console/AppConsole.vala:368 Gtk/DeleteWindow.vala:96 Gtk/MainWindow.vala:158
-#: Gtk/SnapshotListBox.vala:292
+#: Console/AppConsole.vala:370 Gtk/RsyncLogBox.vala:370
+#: Gtk/RsyncLogBox.vala:575 Gtk/MainWindow.vala:161
+#: Gtk/SnapshotListBox.vala:322 Gtk/DeleteWindow.vala:98
+#, c-format
 msgid "Delete"
 msgstr "Eliminar"
 
@@ -607,89 +611,105 @@ msgstr "Eliminar"
 msgid "Delete Snapshots"
 msgstr "Eliminar images"
 
-#: Console/AppConsole.vala:370
+#: Console/AppConsole.vala:372
 msgid "Delete all snapshots"
 msgstr "Eliminar totes les images"
 
-#: Gtk/MainWindow.vala:159
+#: Gtk/MainWindow.vala:162
 msgid "Delete selected snapshot"
 msgstr "Eliminar la image seleccionada"
 
-#: Console/AppConsole.vala:369
+#: Console/AppConsole.vala:371
 msgid "Delete snapshot"
 msgstr "Eliminar image"
 
-#: Gtk/BackupBox.vala:86 Gtk/RestoreBox.vala:123
+#: Gtk/RsyncLogBox.vala:370 Gtk/RsyncLogBox.vala:575 Gtk/RsyncLogBox.vala:596
+#: Gtk/RestoreBox.vala:124 Gtk/BackupBox.vala:86
+#, c-format
 msgid "Deleted"
 msgstr "Eliminat"
 
-#: Utility/TeeJee.FileSystem.vala:355
+#: Utility/TeeJee.FileSystem.vala:381
 msgid "Deleted directory"
 msgstr "Direcotori eliminat"
 
-#: Core/Subvolume.vala:102
+#: Core/Subvolume.vala:154 Core/Main.vala:2903 Core/Main.vala:2907
+#, c-format
 msgid "Deleted subvolume"
 msgstr "Subvolume eliminat"
 
-#: Core/Main.vala:2778 Core/Main.vala:2781
-msgid "Deleted system subvolumes"
-msgstr ""
-
-#: Gtk/DeleteBox.vala:59
+#: Gtk/DeleteBox.vala:58
 msgid "Deleting Snapshots..."
 msgstr "Eliminant images..."
 
-#: Core/Subvolume.vala:89
+#: Core/Subvolume.vala:141
+#, c-format
 msgid "Deleting subvolume"
 msgstr "Eliminant subvolume"
 
-#: Gtk/RestoreExcludeBox.vala:130
+#: Gtk/RestoreExcludeBox.vala:105
 msgid "Deluge, Transmission"
 msgstr "Deluge, Transmission"
 
-#: Console/AppConsole.vala:425 Console/AppConsole.vala:540
+#: Console/AppConsole.vala:427 Console/AppConsole.vala:542
 msgid "Description"
 msgstr "Descripció"
 
-#: Core/Subvolume.vala:116
+#: Core/Subvolume.vala:168
+#, c-format
 msgid "Destroyed qgroup"
 msgstr "Qgroup destruit"
 
-#: Core/Subvolume.vala:106
+#: Core/Subvolume.vala:158
+#, c-format
 msgid "Destroying qgroup"
 msgstr "Destruint qgroup"
 
-#: Console/AppConsole.vala:452 Console/AppConsole.vala:491
-#: Console/AppConsole.vala:539 Core/Main.vala:1986 Core/Main.vala:2014
-#: Core/SnapshotRepo.vala:49 Core/SnapshotRepo.vala:639
-#: Core/SnapshotRepo.vala:642 Utility/Device.vala:1742 Utility/Device.vala:1752
-#: Gtk/RestoreDeviceBox.vala:97
+#: Utility/Device.vala:1810 Utility/Device.vala:1820
+#: Console/AppConsole.vala:454 Console/AppConsole.vala:493
+#: Console/AppConsole.vala:541 Core/SnapshotRepo.vala:76
+#: Core/SnapshotRepo.vala:683 Core/SnapshotRepo.vala:686 Core/Main.vala:2114
+#: Core/Main.vala:2146 Gtk/RestoreDeviceBox.vala:97
 #, c-format
 msgid "Device"
 msgstr "Dispositiu"
 
-#: Utility/Device.vala:1201
+#: Utility/Device.vala:1269
 msgid "Device is unlocked"
 msgstr "Dispositiu desbloquejat"
 
-#: Utility/Device.vala:1096 Utility/Device.vala:1158
+#: Utility/Device.vala:1164 Utility/Device.vala:1226
 msgid "Device name is empty!"
 msgstr "Nombre de dispositiu buit!"
 
-#: Console/AppConsole.vala:661 Core/Main.vala:3095 Core/SnapshotRepo.vala:516
+#: Console/AppConsole.vala:663 Core/SnapshotRepo.vala:560 Core/Main.vala:3232
 msgid "Device not found"
 msgstr "Dispositiu no trobat"
+
+#: Gtk/BackupDeviceBox.vala:97
+#, fuzzy, c-format
+msgid "Devices displayed above have BTRFS file systems."
+msgstr "Dispositius en sistemes d'archius Linux"
+
+#: Gtk/BackupDeviceBox.vala:104
+#, fuzzy, c-format
+msgid "Devices displayed above have Linux file systems."
+msgstr "Dispositius en sistemes d'archius Linux"
 
 #: Gtk/RestoreDeviceBox.vala:84
 msgid "Devices from which snapshot was created are pre-selected."
 msgstr ""
 "Els dispositius des dels que es crearen les images están preseleccionats."
 
-#: Console/AppConsole.vala:324
+#: Console/AppConsole.vala:326
 msgid "Devices with Linux file systems"
 msgstr "Dispositius en sistemes d'archius Linux"
 
-#: Utility/Gtk/DonationWindow.vala:57
+#: Gtk/BackupDeviceBox.vala:105
+msgid "Devices with Windows file systems are not supported (NTFS, FAT, etc)."
+msgstr ""
+
+#: Utility/Gtk/DonationWindow.vala:61
 msgid ""
 "Did you find this software useful?\n"
 "\n"
@@ -721,75 +741,74 @@ msgstr ""
 "Tony George\n"
 "(teejeetech@gmail.com)"
 
-#: Utility/TeeJee.FileSystem.vala:492
+#: Utility/TeeJee.FileSystem.vala:518
 msgid "Dir not found"
 msgstr "Dir no trobat"
 
-#: Core/SnapshotRepo.vala:938
+#: Core/SnapshotRepo.vala:982
 msgid "Directory not found"
 msgstr "Directori no trobat"
 
-#: Core/Main.vala:2071 Gtk/RestoreSummaryBox.vala:64
+#: Core/Main.vala:2206 Gtk/RestoreSummaryBox.vala:64
 msgid "Disclaimer"
 msgstr "Avís legal"
 
-#: Gtk/BackupDeviceBox.vala:108
+#: Gtk/BackupDeviceBox.vala:127
 msgid "Disk"
 msgstr "Disc"
 
-#: Core/Main.vala:220
+#: Core/Main.vala:226
 msgid "Distribution"
 msgstr "Distribució"
 
-#: Utility/Gtk/AboutWindow.vala:360
-#, c-format
-msgid "Documenters"
-msgstr "Documentaors"
+#: Utility/Gtk/AboutWindow.vala:449
+#, fuzzy
+msgid "Documentation"
+msgstr "Donacions"
 
-#: Utility/Gtk/DonationWindow.vala:40 Gtk/MainWindow.vala:379
+#: Utility/Gtk/DonationWindow.vala:42 Gtk/MainWindow.vala:388
 msgid "Donate"
 msgstr "Donacions"
 
-#: Utility/Gtk/DonationWindow.vala:77
+#: Utility/Gtk/DonationWindow.vala:81
 msgid "Donate with PayPal"
 msgstr "Fer una donació en PayPal"
 
-#: Utility/Gtk/AboutWindow.vala:368
-#, c-format
+#: Utility/Gtk/AboutWindow.vala:465
 msgid "Donations"
 msgstr "Donacions"
 
-#: Gtk/ExcludeBox.vala:264
-msgid "Editing and Re-Ordering"
-msgstr "Editar i reordenar"
+#: Gtk/UsersBox.vala:357
+msgid "Enable BTRFS qgroups (recommended)"
+msgstr ""
 
-#: Gtk/MainWindow.vala:1038
+#: Gtk/MainWindow.vala:1068
 msgid "Enable scheduled snapshots to protect your system"
 msgstr "Activar les images programades per a protegir el teu sistema"
 
-#: Core/Main.vala:3878 Core/Main.vala:3911
+#: Core/Main.vala:4030 Core/Main.vala:4070
 msgid "Enabled subvolume quota support"
 msgstr "Suport de quota de subvolume activada"
 
-#: Utility/Device.vala:1265
+#: Utility/Device.vala:1333
 msgid "Encrypted Device"
 msgstr "Dispositiu encriptat"
 
-#: Gtk/UsersBox.vala:163
+#: Gtk/UsersBox.vala:236
 msgid "Encrypted Home Directory"
 msgstr ""
 
-#: Console/AppConsole.vala:882
+#: Console/AppConsole.vala:884
 #, c-format
 msgid "Enter device name or number"
 msgstr "Introduïga nombre o numero de dispositiu"
 
-#: Console/AppConsole.vala:680 Console/AppConsole.vala:1011
+#: Console/AppConsole.vala:682 Console/AppConsole.vala:1013
 #, c-format
 msgid "Enter device name or number (a=Abort)"
 msgstr "Introduïga nombre o numero de dispositiu (a=Cancelar)"
 
-#: Utility/Device.vala:1266
+#: Utility/Device.vala:1334
 #, c-format
 msgid "Enter passphrase to unlock '%s'"
 msgstr "Introduir la contrasenya per a desbloquejar '%s'"
@@ -798,20 +817,24 @@ msgstr "Introduir la contrasenya per a desbloquejar '%s'"
 msgid "Enter path or browse for directory"
 msgstr "Introduir la ruta o explorar per directori"
 
-#: Console/AppConsole.vala:752
+#: Console/AppConsole.vala:754
 #, c-format
 msgid "Enter snapshot number (a=Abort, p=Previous, n=Next)"
 msgstr "Introduir numero de image (a=Cancelar, p=Precedent, n=Següent)"
 
-#: Gtk/ExcludeBox.vala:229
+#: Gtk/ExcludeBox.vala:225
 msgid "Enter the pattern to exclude (Ex: *.mp3, *.bak)"
 msgstr "Introduir el patró a excluir (P.e.: *.mp3, *.bak)"
 
-#: Utility/GtkHelper.vala:18 Gtk/RestoreDeviceBox.vala:533
+#: Utility/GtkHelper.vala:18 Gtk/RestoreDeviceBox.vala:534
 msgid "Error"
 msgstr "Error"
 
-#: Gtk/SetupWizardWindow.vala:94 Gtk/BackupWindow.vala:79
+#: Gtk/RestoreWindow.vala:488
+msgid "Error running Rsync"
+msgstr ""
+
+#: Gtk/SetupWizardWindow.vala:99 Gtk/BackupWindow.vala:81
 msgid "Estimate"
 msgstr "Estimació"
 
@@ -819,39 +842,43 @@ msgstr "Estimació"
 msgid "Estimating System Size..."
 msgstr "Fent estimació del pes de l'archiu"
 
-#: Core/Main.vala:1187
+#: Core/Main.vala:1279
 msgid "Estimating system size..."
 msgstr "Fent estimació del pes del sistema..."
 
-#: Console/AppConsole.vala:384
+#: Console/AppConsole.vala:386
 msgid "Examples"
 msgstr "Exemples"
 
-#: Gtk/ExcludeAppsBox.vala:51 Gtk/RestoreExcludeBox.vala:80
+#: Gtk/UsersBox.vala:136
+msgid "Exclude All"
+msgstr ""
+
+#: Gtk/ExcludeAppsBox.vala:51 Gtk/RestoreExcludeBox.vala:55
 msgid "Exclude Application Settings"
 msgstr "Excluir opcions d'aplicació"
 
-#: Gtk/RestoreWindow.vala:91
+#: Gtk/RestoreWindow.vala:99
 msgid "Exclude Apps"
 msgstr ""
 
-#: Gtk/ExcludeMessageWindow.vala:77
+#: Gtk/ExcludeMessageWindow.vala:70
 msgid "Exclude List"
 msgstr ""
 
-#: Gtk/ExcludeListSummaryWindow.vala:48
+#: Gtk/ExcludeListSummaryWindow.vala:49
 msgid "Exclude List Summary"
 msgstr ""
 
-#: Gtk/ExcludeBox.vala:228
+#: Gtk/ExcludeBox.vala:224
 msgid "Exclude Pattern"
 msgstr ""
 
-#: Gtk/ExcludeMessageWindow.vala:55
+#: Gtk/ExcludeMessageWindow.vala:56
 msgid "Excluded Directories"
 msgstr ""
 
-#: Core/Main.vala:1457
+#: Core/Main.vala:1567
 msgid "Expected values: O, B, H, D, W, M"
 msgstr ""
 
@@ -863,27 +890,27 @@ msgstr ""
 msgid "Failed to copy file"
 msgstr ""
 
-#: Utility/TeeJee.FileSystem.vala:328 Utility/TeeJee.FileSystem.vala:336
+#: Utility/TeeJee.FileSystem.vala:354 Utility/TeeJee.FileSystem.vala:362
 msgid "Failed to create directory"
 msgstr ""
 
-#: Core/Main.vala:1313
+#: Core/Main.vala:1405
 msgid "Failed to create new snapshot"
 msgstr ""
 
-#: Core/Main.vala:1163
+#: Core/Main.vala:1255
 msgid "Failed to create snapshot"
 msgstr ""
 
-#: Core/Main.vala:1385
+#: Core/Main.vala:1495
 msgid "Failed to create subvolume snapshot"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:979
+#: Core/SnapshotRepo.vala:1023
 msgid "Failed to create symlinks"
 msgstr ""
 
-#: Utility/TeeJee.FileSystem.vala:358
+#: Utility/TeeJee.FileSystem.vala:384
 msgid "Failed to delete directory"
 msgstr ""
 
@@ -891,23 +918,23 @@ msgstr ""
 msgid "Failed to delete file"
 msgstr ""
 
-#: Core/Subvolume.vala:98
+#: Core/Subvolume.vala:150
 msgid "Failed to delete snapshot subvolume"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:1005
+#: Core/SnapshotRepo.vala:1049
 msgid "Failed to delete symlinks"
 msgstr ""
 
-#: Core/Subvolume.vala:112
+#: Core/Subvolume.vala:164
 msgid "Failed to destroy qgroup"
 msgstr ""
 
-#: Core/Main.vala:3898
+#: Core/Main.vala:4055
 msgid "Failed to enable subvolume quota"
 msgstr ""
 
-#: Core/Main.vala:3594 Core/Main.vala:3600
+#: Core/Main.vala:3733 Core/Main.vala:3739
 msgid "Failed to estimate system size"
 msgstr ""
 
@@ -915,17 +942,17 @@ msgstr ""
 msgid "Failed to export crontab file"
 msgstr ""
 
-#: Console/AppConsole.vala:695 Console/AppConsole.vala:759
-#: Console/AppConsole.vala:891 Console/AppConsole.vala:986
-#: Console/AppConsole.vala:1031 Console/AppConsole.vala:1072
+#: Console/AppConsole.vala:697 Console/AppConsole.vala:761
+#: Console/AppConsole.vala:893 Console/AppConsole.vala:988
+#: Console/AppConsole.vala:1033 Console/AppConsole.vala:1074
 msgid "Failed to get input from user in 3 attempts"
 msgstr ""
 
-#: Utility/Device.vala:559
+#: Utility/Device.vala:615
 msgid "Failed to get partition list"
 msgstr ""
 
-#: Core/Main.vala:3178
+#: Core/Main.vala:3315
 msgid "Failed to get partition list."
 msgstr ""
 
@@ -933,7 +960,7 @@ msgstr ""
 msgid "Failed to install crontab file"
 msgstr ""
 
-#: Gtk/RestoreDeviceBox.vala:534
+#: Gtk/RestoreDeviceBox.vala:535
 msgid "Failed to mount devices"
 msgstr ""
 
@@ -941,15 +968,15 @@ msgstr ""
 msgid "Failed to move file"
 msgstr ""
 
-#: Core/Main.vala:2835
+#: Core/Main.vala:2961
 msgid "Failed to move system subvolume to snapshot directory"
 msgstr ""
 
-#: Core/Main.vala:3717
+#: Core/Main.vala:3863
 msgid "Failed to query subvolume list"
 msgstr ""
 
-#: Core/Main.vala:3800
+#: Core/Main.vala:3947
 msgid "Failed to query subvolume quota"
 msgstr ""
 
@@ -961,7 +988,7 @@ msgstr ""
 msgid "Failed to read file"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:925
+#: Core/SnapshotRepo.vala:969
 msgid "Failed to remove"
 msgstr ""
 
@@ -969,32 +996,32 @@ msgstr ""
 msgid "Failed to remove cron job"
 msgstr ""
 
-#: Core/Snapshot.vala:446 Core/Snapshot.vala:457 Core/Snapshot.vala:464
+#: Core/Snapshot.vala:530 Core/Snapshot.vala:542 Core/Snapshot.vala:550
 msgid "Failed to remove snapshot"
 msgstr ""
 
-#: Core/Main.vala:3931
+#: Core/Main.vala:4094
 msgid "Failed to rescan subvolume quota"
 msgstr ""
 
-#: Core/Main.vala:2715
+#: Core/Subvolume.vala:202
 msgid "Failed to restore system subvolume"
 msgstr ""
 
-#: Core/Main.vala:1263
+#: Core/Main.vala:1355
 msgid "Failed to save exclude list"
 msgstr ""
 
-#: Utility/Device.vala:1192 Utility/Device.vala:1246 Utility/Device.vala:1271
-#: Utility/Device.vala:1292 Utility/Device.vala:1312
+#: Utility/Device.vala:1260 Utility/Device.vala:1314 Utility/Device.vala:1339
+#: Utility/Device.vala:1360 Utility/Device.vala:1380
 msgid "Failed to unlock device"
 msgstr ""
 
-#: Utility/Device.vala:1543
+#: Utility/Device.vala:1611
 msgid "Failed to unmount"
 msgstr ""
 
-#: Core/Main.vala:3380
+#: Core/Main.vala:3519
 msgid "Failed to unmount device!"
 msgstr ""
 
@@ -1002,7 +1029,17 @@ msgstr ""
 msgid "Failed to write file"
 msgstr ""
 
-#: Gtk/ExcludeMessageWindow.vala:105
+#: Gtk/RsyncLogBox.vala:122
+#, fuzzy
+msgid "File (snapshot)"
+msgstr "Eliminar image"
+
+#: Gtk/RsyncLogBox.vala:119
+#, fuzzy
+msgid "File (system)"
+msgstr "Clonar el sistema"
+
+#: Gtk/ExcludeMessageWindow.vala:98
 msgid "File Pattern"
 msgstr ""
 
@@ -1010,637 +1047,661 @@ msgstr ""
 msgid "File and directory counts:"
 msgstr ""
 
-#: Utility/TeeJee.FileSystem.vala:645 Utility/TeeJee.FileSystem.vala:694
+#: Utility/TeeJee.FileSystem.vala:671 Utility/TeeJee.FileSystem.vala:720
 msgid "File is missing"
 msgstr ""
 
-#: Utility/RsyncTask.vala:249 Utility/CronTab.vala:225
-#: Utility/TeeJee.FileSystem.vala:205 Utility/TeeJee.FileSystem.vala:521
+#: Utility/TeeJee.FileSystem.vala:205 Utility/TeeJee.FileSystem.vala:547
+#: Utility/CronTab.vala:225 Utility/RsyncTask.vala:296
 msgid "File not found"
 msgstr ""
 
-#: Gtk/ExcludeListSummaryWindow.vala:61
+#: Gtk/ExcludeListSummaryWindow.vala:62
 msgid ""
 "Files &amp; directories matching the patterns below will be excluded. "
 "Patterns starting with a + will include the item instead of excluding."
 msgstr ""
 
-#: Gtk/SnapshotBackendBox.vala:186
+#: Gtk/SnapshotBackendBox.vala:192
 msgid "Files and directories can be excluded to save disk space."
 msgstr ""
 
-#: Gtk/RestoreBox.vala:118
+#: Gtk/RestoreBox.vala:119
 msgid "Files and directory counts:"
 msgstr ""
 
-#: Gtk/ExcludeMessageWindow.vala:83
+#: Gtk/ExcludeMessageWindow.vala:76
 msgid "Files matching the following patterns will be excluded"
 msgstr ""
 
-#: Utility/Device.vala:1760
+#: Utility/Device.vala:1828
 #, c-format
 msgid "Filesystem"
 msgstr ""
 
-#: Gtk/SettingsWindow.vala:111
+#: Gtk/RsyncLogBox.vala:302
+msgid "Filter by name or path"
+msgstr ""
+
+#: Gtk/SettingsWindow.vala:100
 msgid "Filters"
 msgstr ""
 
-#: Gtk/DeleteWindow.vala:101 Gtk/SetupWizardWindow.vala:193
-#: Gtk/BackupWindow.vala:94
+#: Gtk/SetupWizardWindow.vala:205 Gtk/BackupWindow.vala:96
+#: Gtk/DeleteWindow.vala:103
 msgid "Finish"
 msgstr ""
 
-#: Gtk/SetupWizardWindow.vala:109 Gtk/RestoreWindow.vala:106
+#: Gtk/SetupWizardWindow.vala:120 Gtk/RestoreWindow.vala:130
 msgid "Finished"
 msgstr ""
 
-#: Gtk/RestoreExcludeBox.vala:103
+#: Gtk/RestoreExcludeBox.vala:78
 msgid "Firefox, Chromium, Chrome, Opera, Epiphany, Midori"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:623
+#: Core/SnapshotRepo.vala:667
 msgid "First snapshot requires:"
 msgstr ""
 
-#: Core/Main.vala:2768
+#: Core/Main.vala:2894
 msgid "Found existing pre-restore snapshot"
 msgstr ""
 
-#: Gtk/BackupDeviceBox.vala:198
+#: Gtk/BackupDeviceBox.vala:215
 msgid "Free"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:50 Core/SnapshotRepo.vala:118
+#: Core/SnapshotRepo.vala:77 Core/SnapshotRepo.vala:147
 msgid "Free space"
 msgstr ""
 
-#: Console/AppConsole.vala:1040
+#: Console/AppConsole.vala:1042
 msgid "GRUB Device"
 msgstr ""
 
-#: Gtk/RestoreDeviceBox.vala:510
+#: Gtk/RestoreDeviceBox.vala:511
 msgid "GRUB device not selected"
 msgstr ""
 
-#: Console/AppConsole.vala:1045
+#: Console/AppConsole.vala:1047
 msgid "GRUB will NOT be reinstalled"
 msgstr ""
 
-#: Core/Main.vala:2202
+#: Core/Main.vala:2348
 msgid "Generating initramfs..."
 msgstr ""
 
-#: Console/AppConsole.vala:372
+#: Console/AppConsole.vala:374
 msgid "Global"
 msgstr ""
 
-#: Gtk/BackupBox.vala:97 Gtk/RestoreBox.vala:134
+#: Gtk/RsyncLogBox.vala:400 Gtk/RestoreBox.vala:135 Gtk/BackupBox.vala:97
+#, c-format
 msgid "Group"
 msgstr ""
 
-#: Gtk/ExcludeMessageWindow.vala:136
+#: Gtk/ExcludeMessageWindow.vala:129
 msgid ""
 "Hidden files and folders are included by default since they contain user-"
 "specific configuration files."
 msgstr ""
 
-#: Gtk/DeleteWindow.vala:175
+#: Gtk/DeleteWindow.vala:178
 msgid "Hide"
 msgstr ""
 
-#: Console/AppConsole.vala:379
+#: Console/AppConsole.vala:381
 msgid "Hide rsync output"
 msgstr ""
 
-#: Gtk/DeleteWindow.vala:176
+#: Gtk/DeleteWindow.vala:179
 msgid "Hide this window (files will be deleted in background)"
 msgstr ""
 
-#: Gtk/UsersBox.vala:113
+#: Gtk/UsersBox.vala:120
 msgid "Home"
 msgstr ""
 
-#: Gtk/ExcludeMessageWindow.vala:123
+#: Gtk/ExcludeMessageWindow.vala:116
 msgid "Home Directory"
 msgstr ""
 
-#: Gtk/ScheduleBox.vala:115
+#: Gtk/ScheduleBox.vala:118 Gtk/SnapshotListBox.vala:299
 msgid "Hourly"
 msgstr ""
 
-#: Core/Main.vala:955
+#: Core/Main.vala:1047
 msgid "Hourly snapshot failed!"
 msgstr ""
 
-#: Core/Main.vala:936
+#: Core/Main.vala:1028
 msgid "Hourly snapshots are enabled"
 msgstr ""
 
-#: Gtk/RestoreFinishBox.vala:86
+#: Utility/Gtk/AboutWindow.vala:457
+msgid "Icon Themes & Utilities"
+msgstr ""
+
+#: Gtk/RestoreFinishBox.vala:102
 msgid ""
 "If the restored system fails to boot, then boot from the Live CD/USB, "
 "install Timeshift, and try restoring another snapshot."
 msgstr ""
 
-#: Core/Main.vala:2077
+#: Core/Main.vala:2212
 msgid ""
 "If these terms are not acceptable to you, please do not proceed beyond this "
 "point!"
 msgstr ""
 
-#: Gtk/ExcludeBox.vala:52
+#: Gtk/ExcludeBox.vala:54
 msgid "Include / Exclude Patterns"
 msgstr ""
 
-#: Gtk/UsersBox.vala:243
+#: Gtk/UsersBox.vala:340
 msgid "Include @home subvolume in backups"
 msgstr ""
 
-#: Gtk/UsersBox.vala:189
-msgid "Include everything"
+#: Gtk/UsersBox.vala:266
+msgid "Include All"
 msgstr ""
 
-#: Gtk/UsersBox.vala:128
-msgid "Include hidden items"
+#: Gtk/UsersBox.vala:194
+msgid "Include Hidden"
 msgstr ""
 
-#: Gtk/ExcludeBox.vala:262
-msgid "Info"
-msgstr ""
-
-#: Core/Main.vala:1900
+#: Core/Main.vala:2026
 msgid "Invalid Snapshot"
 msgstr ""
 
-#: Console/AppConsole.vala:249
+#: Console/AppConsole.vala:251
 #, c-format
 msgid "Invalid command line arguments"
 msgstr ""
 
-#: Gtk/MainWindow.vala:798
+#: Gtk/MainWindow.vala:824
 msgid "Invalid snapshot"
 msgstr ""
 
-#: Utility/Gtk/DonationWindow.vala:93
+#: Utility/Gtk/DonationWindow.vala:97
 msgid "Issue Tracker ~ Report Issues, Request Features, Ask Questions"
 msgstr ""
 
-#: Gtk/ExcludeBox.vala:278
+#: Gtk/ExcludeBox.vala:272
 msgid "Items Not Selected"
 msgstr ""
 
-#: Gtk/ScheduleBox.vala:263
+#: Gtk/ScheduleBox.vala:283
 msgid "Keep"
 msgstr ""
 
-#: Gtk/RestoreExcludeBox.vala:137
+#: Gtk/RestoreExcludeBox.vala:112
 msgid ""
 "Keep configuration files for bittorrent clients like Deluge, Transmission, "
 "etc. If un-checked, previous configuration files will be restored from "
 "snapshot."
 msgstr ""
 
-#: Gtk/RestoreExcludeBox.vala:110
+#: Gtk/RestoreExcludeBox.vala:85
 msgid ""
 "Keep configuration files for web browsers like Firefox and Chrome. If un-"
 "checked, previous configuration files will be restored from snapshot"
 msgstr ""
 
-#: Gtk/RestoreDeviceBox.vala:242
+#: Gtk/RestoreDeviceBox.vala:244
 msgid "Keep on Root Device"
 msgstr ""
 
-#: Gtk/RestoreDeviceBox.vala:227
+#: Gtk/RestoreDeviceBox.vala:229
 msgid "Keep this mount path on the root filesystem"
 msgstr ""
 
-#: Gtk/SnapshotListBox.vala:474
+#: Gtk/SnapshotListBox.vala:519
 msgid "LIVE"
 msgstr ""
 
-#: Console/AppConsole.vala:456 Console/AppConsole.vala:495
-#: Utility/Device.vala:1761
+#: Utility/Device.vala:1829 Console/AppConsole.vala:458
+#: Console/AppConsole.vala:497 Gtk/BackupDeviceBox.vala:254
 #, c-format
 msgid "Label"
 msgstr ""
 
-#: Core/Main.vala:918
+#: Core/Main.vala:1010
 #, c-format
 msgid "Last boot snapshot is %d hours old"
 msgstr ""
 
-#: Core/Main.vala:913
+#: Core/Main.vala:1005
 msgid "Last boot snapshot is older than system start time"
 msgstr ""
 
-#: Core/Main.vala:909
+#: Core/Main.vala:1001
 msgid "Last boot snapshot not found"
 msgstr ""
 
-#: Core/Main.vala:978
+#: Core/Main.vala:1070
 #, c-format
 msgid "Last daily snapshot is %d hours old"
 msgstr ""
 
-#: Core/Main.vala:973
+#: Core/Main.vala:1065
 msgid "Last daily snapshot is more than 1 day old"
 msgstr ""
 
-#: Core/Main.vala:969
+#: Core/Main.vala:1061
 msgid "Last daily snapshot not found"
 msgstr ""
 
-#: Core/Main.vala:948
+#: Core/Main.vala:1040
 #, c-format
 msgid "Last hourly snapshot is %d minutes old"
 msgstr ""
 
-#: Core/Main.vala:943
+#: Core/Main.vala:1035
 msgid "Last hourly snapshot is more than 1 hour old"
 msgstr ""
 
-#: Core/Main.vala:939
+#: Core/Main.vala:1031
 msgid "Last hourly snapshot not found"
 msgstr ""
 
-#: Core/Main.vala:1038
+#: Core/Main.vala:1130
 #, c-format
 msgid "Last monthly snapshot is %d days old"
 msgstr ""
 
-#: Core/Main.vala:1033
+#: Core/Main.vala:1125
 msgid "Last monthly snapshot is more than 1 month old"
 msgstr ""
 
-#: Core/Main.vala:1029
+#: Core/Main.vala:1121
 msgid "Last monthly snapshot not found"
 msgstr ""
 
-#: Core/Main.vala:1008
+#: Core/Main.vala:1100
 #, c-format
 msgid "Last weekly snapshot is %d days old"
 msgstr ""
 
-#: Core/Main.vala:1003
+#: Core/Main.vala:1095
 msgid "Last weekly snapshot is more than 1 week old"
 msgstr ""
 
-#: Core/Main.vala:999
+#: Core/Main.vala:1091
 msgid "Last weekly snapshot not found"
 msgstr ""
 
-#: Gtk/MainWindow.vala:1019
+#: Gtk/MainWindow.vala:1049
 #, c-format
 msgid "Latest snapshot"
 msgstr ""
 
-#: Core/Main.vala:1252
+#: Utility/Gtk/AboutWindow.vala:316 Utility/Gtk/AboutWindow.vala:356
+msgid "License"
+msgstr ""
+
+#: Core/Main.vala:1344
 #, c-format
 msgid "Linking from snapshot"
 msgstr ""
 
-#: Console/AppConsole.vala:350
+#: Console/AppConsole.vala:352
 msgid "List"
 msgstr ""
 
-#: Console/AppConsole.vala:352
+#: Console/AppConsole.vala:354
 msgid "List devices"
 msgstr ""
 
-#: Console/AppConsole.vala:351
+#: Console/AppConsole.vala:353
 msgid "List snapshots"
 msgstr ""
 
-#: Gtk/MainWindow.vala:970
+#: Gtk/MainWindow.vala:1000
 msgid "Live USB Mode (Restore Only)"
 msgstr ""
 
-#: Gtk/SettingsWindow.vala:100 Gtk/SetupWizardWindow.vala:99
-#: Gtk/BackupWindow.vala:84
+#: Gtk/SetupWizardWindow.vala:104 Gtk/BackupWindow.vala:86
+#: Gtk/SettingsWindow.vala:89
 msgid "Location"
 msgstr ""
 
-#: Gtk/RsyncLogWindow.vala:75
-msgid "Log Viewer"
-msgstr ""
-
-#: Gtk/MainWindow.vala:450
+#: Gtk/MainWindow.vala:459
 msgid "Main window closed by user"
 msgstr ""
 
-#: Gtk/SnapshotListBox.vala:299
+#: Gtk/SnapshotListBox.vala:329
 msgid "Mark for Deletion"
 msgstr ""
 
-#: Gtk/MainWindow.vala:626
+#: Gtk/MainWindow.vala:641
 msgid "Marked for deletion"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:667 Core/SnapshotRepo.vala:704
+#: Core/SnapshotRepo.vala:711 Core/SnapshotRepo.vala:748
 msgid "Maximum backups exceeded for backup level"
 msgstr ""
 
-#: Gtk/MainWindow.vala:205
+#: Gtk/MainWindow.vala:208
 msgid "Menu"
 msgstr ""
 
-#: Core/Main.vala:229
+#: Gtk/UsersBox.vala:354
+msgid "Miscellaneous"
+msgstr ""
+
+#: Core/Main.vala:235
 msgid "Missing Dependencies"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:645
+#: Core/SnapshotRepo.vala:689
 #, c-format
 msgid "Mode"
 msgstr ""
 
-#: Utility/Device.vala:1744
+#: Utility/Device.vala:1812
 #, c-format
 msgid "Model"
 msgstr ""
 
-#: Gtk/ScheduleBox.vala:61
+#: Gtk/ScheduleBox.vala:64 Gtk/SnapshotListBox.vala:302
 msgid "Monthly"
 msgstr ""
 
-#: Core/Main.vala:1026
+#: Core/Main.vala:1118
 msgid "Monthly snapshot are enabled"
 msgstr ""
 
-#: Core/Main.vala:1045
+#: Core/Main.vala:1137
 msgid "Monthly snapshot failed!"
 msgstr ""
 
-#: Core/Main.vala:1985 Core/Main.vala:2014
+#: Core/Main.vala:2113 Core/Main.vala:2146
 msgid "Mount"
 msgstr ""
 
-#: Core/Main.vala:2842
+#: Core/Main.vala:2968
 msgid "Moved system subvolume to snapshot directory"
 msgstr ""
 
-#: Gtk/MainWindow.vala:776
+#: Gtk/MainWindow.vala:800
 msgid "Multiple snapshots selected"
 msgstr ""
 
-#: Console/AppConsole.vala:423 Gtk/RsyncLogWindow.vala:284
+#: Console/AppConsole.vala:425 Gtk/RsyncLogBox.vala:492
+#: Gtk/BackupDeviceBox.vala:235
 msgid "Name"
 msgstr ""
 
-#: Gtk/DeleteWindow.vala:159 Gtk/SetupWizardWindow.vala:185
-#: Gtk/RestoreWindow.vala:168 Gtk/BackupWindow.vala:156
+#: Gtk/SetupWizardWindow.vala:197 Gtk/BackupWindow.vala:160
+#: Gtk/DeleteWindow.vala:162 Gtk/RestoreWindow.vala:198
 msgid "Next"
 msgstr ""
 
-#: Utility/Gtk/CustomMessageDialog.vala:178
+#: Utility/Gtk/CustomMessageDialog.vala:177
 msgid "No"
 msgstr ""
 
-#: Gtk/BackupBox.vala:84 Gtk/RestoreBox.vala:121
+#: Gtk/RestoreBox.vala:122 Gtk/BackupBox.vala:84
 msgid "No Change"
 msgstr ""
 
-#: Gtk/DeleteWindow.vala:331 Gtk/MainWindow.vala:603
+#: Gtk/MainWindow.vala:615 Gtk/DeleteWindow.vala:341
 msgid "No Snapshots Selected"
 msgstr ""
 
-#: Gtk/MainWindow.vala:1043
+#: Gtk/MainWindow.vala:1073
 msgid "No snapshots available"
 msgstr ""
 
-#: Console/AppConsole.vala:318 Core/SnapshotRepo.vala:854
-#: Gtk/MainWindow.vala:987
+#: Console/AppConsole.vala:320 Core/SnapshotRepo.vala:898
+#: Gtk/MainWindow.vala:1017
 msgid "No snapshots found"
 msgstr ""
 
-#: Console/AppConsole.vala:738
+#: Console/AppConsole.vala:740
 msgid "No snapshots found on device"
 msgstr ""
 
-#: Gtk/MainWindow.vala:544
+#: Gtk/MainWindow.vala:553
 msgid "No snapshots on device"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:621
+#: Core/SnapshotRepo.vala:665
 msgid "No snapshots on this device"
 msgstr ""
 
-#: Gtk/MainWindow.vala:769
+#: Gtk/MainWindow.vala:793
 msgid "No snapshots selected"
 msgstr ""
 
-#: Gtk/MainWindow.vala:1020 Gtk/MainWindow.vala:1022
+#: Gtk/MainWindow.vala:1050 Gtk/MainWindow.vala:1052
 msgid "None"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:639
+#: Core/Subvolume.vala:184
+#, fuzzy, c-format
+msgid "Not Found"
+msgstr "Dir no trobat"
+
+#: Core/SnapshotRepo.vala:683
 msgid "Not Selected"
 msgstr ""
 
-#: Core/Main.vala:370
+#: Core/Main.vala:379
 msgid "Not Supported"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:585 Core/SnapshotRepo.vala:612
+#: Core/SnapshotRepo.vala:629 Core/SnapshotRepo.vala:656
 msgid "Not enough disk space"
 msgstr ""
 
-#: Console/AppConsole.vala:395 Gtk/FinishBox.vala:54
+#: Console/AppConsole.vala:397 Gtk/FinishBox.vala:55
 msgid "Notes"
 msgstr ""
 
-#: Core/Main.vala:1055
+#: Core/Main.vala:1147
 msgid "Nothing to do!"
 msgstr ""
 
-#: Console/AppConsole.vala:421 Console/AppConsole.vala:450
-#: Console/AppConsole.vala:489 Console/AppConsole.vala:537
+#: Console/AppConsole.vala:423 Console/AppConsole.vala:452
+#: Console/AppConsole.vala:491 Console/AppConsole.vala:539
 msgid "Num"
 msgstr ""
 
-#: Gtk/ScheduleBox.vala:262
+#: Gtk/ScheduleBox.vala:282
 msgid ""
 "Number of snapshots to keep.\n"
 "Older snapshots will be removed once this limit is exceeded."
 msgstr ""
 
-#: Utility/Gtk/CustomMessageDialog.vala:168
-#: Utility/Gtk/CustomMessageDialog.vala:172 Utility/GtkHelper.vala:121
-#: Gtk/ExcludeListSummaryWindow.vala:85
+#: Utility/GtkHelper.vala:121 Utility/Gtk/CustomMessageDialog.vala:167
+#: Utility/Gtk/CustomMessageDialog.vala:171
+#: Gtk/ExcludeListSummaryWindow.vala:84
 msgid "OK"
 msgstr ""
 
-#: Gtk/SnapshotBackendBox.vala:173
+#: Gtk/SnapshotBackendBox.vala:179
 msgid ""
 "OS must be installed on a BTRFS partition with Ubuntu-type subvolume layout "
 "(@ and @home subvolumes). Other layouts are not supported."
 msgstr ""
 
-#: Core/Main.vala:4027
+#: Core/Main.vala:4201
 msgid "Older log files removed"
 msgstr ""
 
-#: Gtk/MainWindow.vala:1021
+#: Gtk/MainWindow.vala:1051
 msgid "Oldest snapshot"
 msgstr ""
 
-#: Core/Main.vala:368 Core/Main.vala:3293 Gtk/RestoreDeviceBox.vala:524
+#: Gtk/SnapshotListBox.vala:297
+msgid "On demand (manual)"
+msgstr ""
+
+#: Core/Main.vala:377 Core/Main.vala:3432 Gtk/RestoreDeviceBox.vala:525
 msgid ""
 "Only ubuntu-type layouts with @ and @home subvolumes are currently supported."
 msgstr ""
 
-#: Gtk/MainWindow.vala:206
+#: Gtk/MainWindow.vala:209
 msgid "Open Menu"
 msgstr ""
 
-#: Core/Main.vala:3077
+#: Core/Main.vala:3214
 msgid ""
 "Option --snapshot-device should not be specified for creating snapshots in "
 "BTRFS mode"
 msgstr ""
 
-#: Console/AppConsole.vala:348 Gtk/AppGtk.vala:112
+#: Console/AppConsole.vala:350 Gtk/AppGtk.vala:114
 msgid "Options"
 msgstr ""
 
-#: Gtk/RestoreExcludeBox.vala:143
+#: Gtk/RestoreExcludeBox.vala:118
 msgid "Other applications (next page)"
 msgstr ""
 
-#: Gtk/BackupBox.vala:96 Gtk/RestoreBox.vala:133
+#: Gtk/RsyncLogBox.vala:398 Gtk/RestoreBox.vala:134 Gtk/BackupBox.vala:96
+#, c-format
 msgid "Owner"
 msgstr ""
 
-#: Utility/Device.vala:1756
+#: Utility/Device.vala:1824
 #, c-format
 msgid "Parent Device"
 msgstr ""
 
-#: Core/Main.vala:1326 Core/Main.vala:2323 Core/Main.vala:2402
-#: Gtk/RsyncLogWindow.vala:121
+#: Core/Main.vala:2469 Core/Main.vala:2560 Gtk/RsyncLogBox.vala:222
 msgid "Parsing log file..."
 msgstr ""
 
-#: Gtk/RestoreDeviceBox.vala:523
+#: Gtk/RestoreDeviceBox.vala:524
 msgid "Partition has an unsupported subvolume layout."
 msgstr ""
 
-#: Core/SnapshotRepo.vala:644 Gtk/RestoreDeviceBox.vala:93
+#: Core/SnapshotRepo.vala:688 Gtk/RestoreDeviceBox.vala:93
 #, c-format
 msgid "Path"
 msgstr ""
 
-#: Gtk/ExcludeBox.vala:158
+#: Gtk/ExcludeBox.vala:162
 msgid "Pattern"
 msgstr ""
 
-#: Gtk/BackupBox.vala:95 Gtk/RestoreBox.vala:132
+#: Gtk/RsyncLogBox.vala:396 Gtk/RestoreBox.vala:133 Gtk/BackupBox.vala:95
+#, c-format
 msgid "Permissions"
 msgstr ""
 
-#: Core/Main.vala:248
+#: Core/Main.vala:254
 msgid "Please check if you have multiple windows open."
 msgstr ""
 
-#: Core/Main.vala:2109
+#: Core/Main.vala:2244
 msgid "Please do not interrupt the restore process!"
 msgstr ""
 
-#: Core/Main.vala:340
+#: Core/Main.vala:348
 msgid "Please install required packages and try running TimeShift again"
 msgstr ""
 
-#: Gtk/AppGtk.vala:125
+#: Gtk/AppGtk.vala:127
 msgid "Please re-run the application as admin (using 'sudo' or 'su')"
 msgstr ""
 
-#: Console/AppConsole.vala:101
+#: Console/AppConsole.vala:103
 msgid "Please run the application as admin (using 'sudo' or 'su')"
 msgstr ""
 
-#: Core/Main.vala:2059
+#: Core/Main.vala:2194
 msgid "Please save your work and close all applications."
 msgstr ""
 
-#: Gtk/MainWindow.vala:672
+#: Gtk/MainWindow.vala:695
 msgid "Please select a snapshot to view the log!"
 msgstr ""
 
-#: Gtk/RestoreDeviceBox.vala:511
+#: Gtk/RestoreDeviceBox.vala:512
 msgid "Please select the GRUB device"
 msgstr ""
 
-#: Core/Main.vala:244
+#: Core/Main.vala:250
 msgid "Please wait a few minutes and try again."
 msgstr ""
 
-#: Gtk/MainWindow.vala:740
+#: Gtk/MainWindow.vala:762
 msgid "Please wait for snapshots to be deleted."
 msgstr ""
 
-#: Gtk/RsyncLogWindow.vala:185
+#: Gtk/EstimateBox.vala:66
+msgid "Please wait..."
+msgstr ""
+
+#: Gtk/RsyncLogBox.vala:188
 msgid "Populating list..."
 msgstr ""
 
-#: Core/Main.vala:1469 Gtk/RsyncLogWindow.vala:131 Gtk/BackupBox.vala:111
-#: Gtk/RestoreBox.vala:87 Gtk/DeleteBox.vala:69
+#: Core/Main.vala:1579 Gtk/RsyncLogBox.vala:232 Gtk/DeleteBox.vala:68
+#: Gtk/RestoreBox.vala:88 Gtk/BackupBox.vala:114
 msgid "Preparing..."
 msgstr ""
 
-#: Gtk/DeleteWindow.vala:151 Gtk/SetupWizardWindow.vala:177
-#: Gtk/RestoreWindow.vala:160 Gtk/BackupWindow.vala:148
+#: Gtk/SetupWizardWindow.vala:189 Gtk/BackupWindow.vala:152
+#: Gtk/DeleteWindow.vala:154 Gtk/RestoreWindow.vala:190
 msgid "Previous"
 msgstr ""
 
-#: Gtk/AppGtk.vala:114
+#: Gtk/AppGtk.vala:116
 msgid "Print debug information"
 msgstr ""
 
-#: Core/Main.vala:3655
+#: Core/Main.vala:3794
 msgid "Query completed"
 msgstr ""
 
-#: Core/Main.vala:3638
+#: Core/Main.vala:3777
 msgid "Querying subvolume info..."
 msgstr ""
 
-#: Gtk/SnapshotBackendBox.vala:78
+#: Gtk/SnapshotBackendBox.vala:77
 msgid "RSYNC"
 msgstr ""
 
-#: Gtk/SnapshotBackendBox.vala:178
+#: Gtk/SnapshotBackendBox.vala:184
 msgid "RSYNC Snapshots"
 msgstr ""
 
-#: Gtk/BootOptionsBox.vala:138
+#: Gtk/BootOptionsBox.vala:137
 msgid ""
 "Re-generates initramfs for all installed kernels. This is generally not "
 "needed. Select this only if the restored system fails to boot."
 msgstr ""
 
-#: Console/AppConsole.vala:980
+#: Console/AppConsole.vala:982
 #, c-format
 msgid "Re-install GRUB2 bootloader?"
 msgstr ""
 
-#: Core/Main.vala:2161
+#: Core/Main.vala:2307
 msgid "Re-installing GRUB2 bootloader..."
 msgstr ""
 
-#: Gtk/BootOptionsBox.vala:121
+#: Gtk/BootOptionsBox.vala:120
 msgid "Re-installs the GRUB2 bootloader on the selected device."
 msgstr ""
 
-#: Gtk/RsyncLogWindow.vala:178
+#: Gtk/RsyncLogBox.vala:181
 #, c-format
 msgid "Read %'d of %'d lines..."
 msgstr ""
 
-#: Core/Main.vala:2254
+#: Core/Main.vala:2400
 msgid "Rebooting system..."
 msgstr ""
 
-#: Gtk/RestoreExcludeBox.vala:86 Gtk/RestoreExcludeBox.vala:116
+#: Gtk/RestoreExcludeBox.vala:61 Gtk/RestoreExcludeBox.vala:91
 #, c-format
 msgid "Recommended"
 msgstr ""
@@ -1649,16 +1710,16 @@ msgstr ""
 msgid "Refresh"
 msgstr ""
 
-#: Gtk/MainWindow.vala:355
-msgid "Refresh Snapshot List"
+#: Gtk/BackupDeviceBox.vala:106
+msgid "Remote and network locations are not supported."
 msgstr ""
 
-#: Gtk/ExcludeBox.vala:257
+#: Gtk/ExcludeBox.vala:253
 msgid "Remove"
 msgstr ""
 
-#: Core/Main.vala:1507 Core/Main.vala:1518 Core/Snapshot.vala:426
-#: Core/SnapshotRepo.vala:931
+#: Core/SnapshotRepo.vala:975 Core/Main.vala:1617 Core/Main.vala:1628
+#: Core/Main.vala:4197 Core/Snapshot.vala:509
 #, c-format
 msgid "Removed"
 msgstr ""
@@ -1667,82 +1728,94 @@ msgstr ""
 msgid "Removed cron task"
 msgstr ""
 
-#: Core/Main.vala:3443
+#: Core/Main.vala:3582
 #, c-format
 msgid "Removed mount directory: '%s'"
 msgstr ""
 
-#: Core/Snapshot.vala:469
+#: Core/Snapshot.vala:555
 msgid "Removed snapshot"
 msgstr ""
 
-#: Core/Snapshot.vala:401
+#: Core/Snapshot.vala:484
 msgid "Removing"
 msgstr ""
 
-#: Core/Snapshot.vala:438
+#: Core/Snapshot.vala:521
 msgid "Removing snapshot"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:787 Core/SnapshotRepo.vala:806
-#: Core/SnapshotRepo.vala:824 Core/SnapshotRepo.vala:838
+#: Core/SnapshotRepo.vala:831 Core/SnapshotRepo.vala:850
+#: Core/SnapshotRepo.vala:868 Core/SnapshotRepo.vala:882
 #, c-format
 msgid "Removing snapshots"
 msgstr ""
 
-#: Console/AppConsole.vala:360 Gtk/RestoreWindow.vala:101
-#: Gtk/MainWindow.vala:148 Gtk/RestoreFinishBox.vala:64
+#: Gtk/UsersBox.vala:360
+msgid ""
+"Required for displaying shared and unshared size for snapshots in the main "
+"window"
+msgstr ""
+
+#: Console/AppConsole.vala:362 Gtk/RestoreFinishBox.vala:71
+#: Gtk/RsyncLogBox.vala:377 Gtk/RsyncLogBox.vala:567 Gtk/MainWindow.vala:151
+#: Gtk/RestoreWindow.vala:125
 msgid "Restore"
 msgstr ""
 
-#: Gtk/RestoreWindow.vala:81
+#: Gtk/UsersBox.vala:329
+#, fuzzy
+msgid "Restore @home subvolume"
+msgstr "Subvolume eliminat"
+
+#: Gtk/RestoreWindow.vala:89
 msgid "Restore Device"
 msgstr ""
 
-#: Gtk/RestoreWindow.vala:86
+#: Gtk/RestoreWindow.vala:94
 msgid "Restore Exclude"
 msgstr ""
 
-#: Gtk/RestoreWindow.vala:63
+#: Gtk/RestoreWindow.vala:69
 msgid "Restore Snapshot"
 msgstr ""
 
-#: Core/Main.vala:2644 Core/Main.vala:2727
+#: Core/Main.vala:2809 Core/Main.vala:2851
 msgid "Restore completed"
 msgstr ""
 
-#: Gtk/MainWindow.vala:149
+#: Gtk/MainWindow.vala:152
 msgid "Restore selected snapshot"
 msgstr ""
 
-#: Console/AppConsole.vala:361
+#: Console/AppConsole.vala:363
 msgid "Restore snapshot"
 msgstr ""
 
-#: Gtk/RestoreFinishBox.vala:80
+#: Gtk/RestoreFinishBox.vala:96
 msgid "Restored subvolumes will become active after system is restarted."
 msgstr ""
 
-#: Core/Main.vala:2722
+#: Core/Subvolume.vala:206
 msgid "Restored system subvolume"
 msgstr ""
 
-#: Gtk/RestoreBox.vala:76
+#: Gtk/RestoreBox.vala:77 Gtk/RestoreBox.vala:190
 msgid "Restoring Snapshot..."
 msgstr ""
 
-#: Gtk/FinishBox.vala:84
+#: Gtk/FinishBox.vala:85
 msgid ""
 "Restoring a snapshot will replace system subvolumes, and system subvolumes "
 "currently in use will be preserved as a new snapshot. If required, this "
 "snapshot can be restored later to 'undo' the restore."
 msgstr ""
 
-#: Core/Main.vala:2616
+#: Core/Main.vala:2778
 msgid "Restoring snapshot..."
 msgstr ""
 
-#: Gtk/FinishBox.vala:87
+#: Gtk/FinishBox.vala:88
 msgid ""
 "Restoring snapshots only replaces system files and settings. Non-hidden "
 "files and directories in user home directories will not be touched. This "
@@ -1751,35 +1824,39 @@ msgid ""
 "is restored."
 msgstr ""
 
-#: Utility/Device.vala:1746
+#: Utility/Device.vala:1814
 #, c-format
 msgid "Revision"
 msgstr ""
 
-#: Gtk/RestoreDeviceBox.vala:449
+#: Gtk/RestoreDeviceBox.vala:452
 msgid "Root device not selected"
 msgstr ""
 
-#: Gtk/AppGtk.vala:117
+#: Gtk/RsyncLogWindow.vala:49
+msgid "Rsync Log Viewer"
+msgstr ""
+
+#: Gtk/AppGtk.vala:119
 #, c-format
 msgid "Run 'timeshift' for the command-line version of this tool"
 msgstr ""
 
-#: Console/AppConsole.vala:380
+#: Console/AppConsole.vala:382
 msgid "Run in non-interactive mode"
 msgstr ""
 
-#: Core/Main.vala:180
+#: Core/Main.vala:186
 msgid "Running"
 msgstr ""
 
-#: Gtk/FinishBox.vala:94
+#: Gtk/FinishBox.vala:95
 msgid ""
 "Save snapshots to an external disk instead of the system disk to guard "
 "against drive failures."
 msgstr ""
 
-#: Gtk/FinishBox.vala:96
+#: Gtk/FinishBox.vala:97
 msgid ""
 "Saving snapshots to a non-system disk allows you to format and re-install "
 "the OS on the system disk without losing snapshots stored on it. You can "
@@ -1787,50 +1864,46 @@ msgid ""
 "distribution by restoring a snapshot."
 msgstr ""
 
-#: Core/Main.vala:1193 Core/Main.vala:1345 Core/Main.vala:1347
+#: Core/Main.vala:1285 Core/Main.vala:1439 Core/Main.vala:1441
 msgid "Saving to device"
 msgstr ""
 
-#: Gtk/SettingsWindow.vala:103 Gtk/SetupWizardWindow.vala:104
+#: Gtk/SetupWizardWindow.vala:109 Gtk/SettingsWindow.vala:92
 msgid "Schedule"
 msgstr ""
 
-#: Core/Main.vala:251
+#: Core/Main.vala:257
 msgid "Scheduled snapshot in progress..."
 msgstr ""
 
-#: Core/Main.vala:1055 Gtk/ScheduleBox.vala:288 Gtk/MainWindow.vala:1037
+#: Core/Main.vala:1147 Gtk/MainWindow.vala:1067 Gtk/ScheduleBox.vala:312
 msgid "Scheduled snapshots are disabled"
 msgstr ""
 
-#: Gtk/FinishBox.vala:77
+#: Gtk/FinishBox.vala:78
 msgid "Scheduled snapshots are disabled. It's recommended to enable it."
 msgstr ""
 
-#: Gtk/ScheduleBox.vala:283
+#: Gtk/ScheduleBox.vala:305
 msgid "Scheduled snapshots are enabled"
 msgstr ""
 
-#: Gtk/FinishBox.vala:74
+#: Gtk/FinishBox.vala:75
 msgid ""
 "Scheduled snapshots are enabled. Snapshots will be created automatically for "
 "selected levels."
 msgstr ""
 
-#: Gtk/ScheduleBox.vala:149
-msgid "Scheduled task runs once every hour"
-msgstr ""
-
-#: Console/AppConsole.vala:868
+#: Console/AppConsole.vala:870
 #, c-format
 msgid "Select '%s' device (default = %s)"
 msgstr ""
 
-#: Console/AppConsole.vala:687 Core/SnapshotRepo.vala:549
+#: Console/AppConsole.vala:689 Core/SnapshotRepo.vala:593
 msgid "Select BTRFS system disk with root subvolume (@)"
 msgstr ""
 
-#: Console/AppConsole.vala:996
+#: Console/AppConsole.vala:998
 msgid "Select GRUB device"
 msgstr ""
 
@@ -1838,11 +1911,11 @@ msgstr ""
 msgid "Select Path"
 msgstr ""
 
-#: Gtk/MainWindow.vala:671
+#: Gtk/MainWindow.vala:694
 msgid "Select Snapshot"
 msgstr ""
 
-#: Gtk/ScheduleBox.vala:54
+#: Gtk/ScheduleBox.vala:57
 msgid "Select Snapshot Levels"
 msgstr ""
 
@@ -1850,11 +1923,11 @@ msgstr ""
 msgid "Select Snapshot Location"
 msgstr ""
 
-#: Gtk/SnapshotBackendBox.vala:63
+#: Gtk/SnapshotBackendBox.vala:62
 msgid "Select Snapshot Type"
 msgstr ""
 
-#: Gtk/DeleteWindow.vala:83
+#: Gtk/DeleteWindow.vala:85
 msgid "Select Snapshots"
 msgstr ""
 
@@ -1862,56 +1935,56 @@ msgstr ""
 msgid "Select Target Device"
 msgstr ""
 
-#: Gtk/BackupDeviceBox.vala:319
+#: Gtk/BackupDeviceBox.vala:392
 #, c-format
 msgid "Select a partition on this disk"
 msgstr ""
 
-#: Gtk/MainWindow.vala:777
+#: Gtk/MainWindow.vala:801
 msgid "Select a single snapshot to restore"
 msgstr ""
 
-#: Gtk/RestoreDeviceBox.vala:478
+#: Gtk/RestoreDeviceBox.vala:481
 msgid "Select another device for root file system (/)"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:588 Core/SnapshotRepo.vala:615
+#: Core/SnapshotRepo.vala:632 Core/SnapshotRepo.vala:659
 msgid "Select another device or free up some space"
 msgstr ""
 
-#: Gtk/MainWindow.vala:538 Gtk/MainWindow.vala:545
+#: Gtk/MainWindow.vala:547 Gtk/MainWindow.vala:554
 msgid "Select another device to delete snasphots"
 msgstr ""
 
-#: Gtk/MainWindow.vala:472
+#: Gtk/MainWindow.vala:481
 msgid "Select another device?"
 msgstr ""
 
-#: Gtk/RestoreExcludeBox.vala:82
+#: Gtk/RestoreExcludeBox.vala:57
 msgid "Select applications to exclude from restore"
 msgstr ""
 
-#: Console/AppConsole.vala:670
+#: Console/AppConsole.vala:672
 msgid "Select backup device"
 msgstr ""
 
-#: Gtk/ExcludeBox.vala:429
+#: Gtk/ExcludeBox.vala:433
 msgid "Select directory"
 msgstr ""
 
-#: Gtk/ExcludeBox.vala:409
+#: Gtk/ExcludeBox.vala:406
 msgid "Select file(s)"
 msgstr ""
 
-#: Console/AppConsole.vala:744
+#: Console/AppConsole.vala:746
 msgid "Select snapshot"
 msgstr ""
 
-#: Gtk/DeleteWindow.vala:332
+#: Gtk/DeleteWindow.vala:342
 msgid "Select snapshots to delete"
 msgstr ""
 
-#: Gtk/RestoreDeviceBox.vala:450
+#: Gtk/RestoreDeviceBox.vala:453
 msgid "Select the device for root file system (/)"
 msgstr ""
 
@@ -1919,27 +1992,27 @@ msgstr ""
 msgid "Select the devices where files will be restored."
 msgstr ""
 
-#: Gtk/ScheduleBox.vala:289
+#: Gtk/ScheduleBox.vala:313
 msgid "Select the intervals for creating snapshots"
 msgstr ""
 
-#: Gtk/ExcludeBox.vala:279
+#: Gtk/ExcludeBox.vala:273
 msgid "Select the items to be removed from the list"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:509
+#: Core/SnapshotRepo.vala:553
 msgid "Select the snapshot device"
 msgstr ""
 
-#: Gtk/MainWindow.vala:770
+#: Gtk/MainWindow.vala:794
 msgid "Select the snapshot to restore"
 msgstr ""
 
-#: Gtk/DeleteWindow.vala:85
+#: Gtk/DeleteWindow.vala:87
 msgid "Select the snapshots to be deleted"
 msgstr ""
 
-#: Gtk/MainWindow.vala:604
+#: Gtk/MainWindow.vala:616
 msgid "Select the snapshots to mark for deletion"
 msgstr ""
 
@@ -1947,102 +2020,99 @@ msgstr ""
 msgid "Select the target devices where system will be cloned."
 msgstr ""
 
-#: Core/Main.vala:3105
+#: Core/Main.vala:3242
 msgid "Selected default snapshot device"
 msgstr ""
 
-#: Core/Main.vala:3056 Core/Main.vala:3060
+#: Core/Main.vala:3193 Core/Main.vala:3197
 msgid "Selected default snapshot type"
 msgstr ""
 
-#: Gtk/BackupDeviceBox.vala:300
+#: Gtk/BackupDeviceBox.vala:373
 msgid "Selected device does not have BTRFS partition"
 msgstr ""
 
-#: Gtk/BackupDeviceBox.vala:298
+#: Gtk/BackupDeviceBox.vala:371
 msgid "Selected device does not have Linux partition"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:117
+#: Core/SnapshotRepo.vala:146
 msgid "Selected snapshot device"
 msgstr ""
 
-#: Console/AppConsole.vala:686 Core/SnapshotRepo.vala:548
+#: Console/AppConsole.vala:688 Core/SnapshotRepo.vala:592
 msgid "Selected snapshot device is not a system disk"
 msgstr ""
 
-#: Core/Main.vala:1901
+#: Core/Main.vala:2027
 msgid "Selected snapshot is marked for deletion"
 msgstr ""
 
-#: Gtk/MainWindow.vala:799
+#: Gtk/MainWindow.vala:825
 msgid "Selected snapshot is marked for deletion and cannot be restored"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:43
-msgid "Selected snapshot path"
-msgstr ""
-
-#: Gtk/UsersBox.vala:165
+#: Gtk/UsersBox.vala:238
 msgid ""
 "Selected user has an encrypted home directory. It's not possible to include "
 "only hidden files."
 msgstr ""
 
-#: Utility/Device.vala:1745
+#: Utility/Device.vala:1813
 #, c-format
 msgid "Serial"
 msgstr ""
 
-#: Core/Main.vala:208
+#: Core/Main.vala:214
 msgid "Session log file"
 msgstr ""
 
-#: Console/AppConsole.vala:357
+#: Console/AppConsole.vala:359
 msgid "Set snapshot description"
 msgstr ""
 
-#: Gtk/SettingsWindow.vala:55 Gtk/MainWindow.vala:178 Gtk/MainWindow.vala:179
+#: Gtk/MainWindow.vala:181 Gtk/MainWindow.vala:182 Gtk/SettingsWindow.vala:55
 msgid "Settings"
 msgstr ""
 
-#: Gtk/MainWindow.vala:189
+#: Gtk/MainWindow.vala:192
 msgid "Settings wizard"
 msgstr ""
 
-#: Gtk/FinishBox.vala:57
+#: Gtk/FinishBox.vala:58
 msgid "Setup Complete"
 msgstr ""
 
-#: Gtk/SetupWizardWindow.vala:62
+#: Gtk/SetupWizardWindow.vala:64
 msgid "Setup Wizard"
 msgstr ""
 
-#: Console/AppConsole.vala:377
+#: Console/AppConsole.vala:379
 msgid "Show additional debug messages"
 msgstr ""
 
-#: Console/AppConsole.vala:381 Gtk/AppGtk.vala:115
+#: Console/AppConsole.vala:383 Gtk/AppGtk.vala:117
 msgid "Show all options"
 msgstr ""
 
-#: Gtk/RestoreExcludeBox.vala:146
+#: Gtk/RestoreExcludeBox.vala:121
 msgid "Show more applications to exclude on the next page"
 msgstr ""
 
-#: Console/AppConsole.vala:378
+#: Console/AppConsole.vala:380
 msgid "Show rsync output (default)"
 msgstr ""
 
-#: Console/AppConsole.vala:454 Console/AppConsole.vala:493
-#: Utility/Device.vala:1748 Utility/Device.vala:1763
-#: Gtk/BackupDeviceBox.vala:185 Gtk/RsyncLogWindow.vala:306
-#: Gtk/BackupBox.vala:93 Gtk/RestoreBox.vala:130 Gtk/SnapshotListBox.vala:174
+#: Utility/Device.vala:1816 Utility/Device.vala:1831
+#: Console/AppConsole.vala:456 Console/AppConsole.vala:495
+#: Gtk/RsyncLogBox.vala:392 Gtk/RestoreBox.vala:131
+#: Gtk/BackupDeviceBox.vala:202 Gtk/BackupBox.vala:93
+#: Gtk/SnapshotListBox.vala:174
 #, c-format
 msgid "Size"
 msgstr ""
 
-#: Gtk/SnapshotBackendBox.vala:171
+#: Gtk/SnapshotBackendBox.vala:177
 msgid ""
 "Size of BTRFS snapshots are initially zero. As system files gradually change "
 "with time, data gets written to new data blocks which take up disk space "
@@ -2050,17 +2120,17 @@ msgid ""
 "blocks."
 msgstr ""
 
-#: Console/AppConsole.vala:366
+#: Console/AppConsole.vala:368
 msgid "Skip GRUB2 reinstall"
 msgstr ""
 
-#: Core/Main.vala:1906 Core/SnapshotRepo.vala:670 Core/SnapshotRepo.vala:708
+#: Core/SnapshotRepo.vala:714 Core/SnapshotRepo.vala:752 Core/Main.vala:2032
 #: Gtk/SnapshotListBox.vala:95
 #, c-format
 msgid "Snapshot"
 msgstr ""
 
-#: Gtk/MainWindow.vala:555
+#: Gtk/MainWindow.vala:564
 #, c-format
 msgid ""
 "Snapshot '%s' is being used by the system and cannot be deleted. Restart the "
@@ -2071,37 +2141,42 @@ msgstr ""
 msgid "Snapshot Created"
 msgstr ""
 
-#: Gtk/MainWindow.vala:739
+#: Gtk/SnapshotListBox.vala:296
+#, fuzzy, c-format
+msgid "Snapshot Levels"
+msgstr "Images BTRFS"
+
+#: Gtk/MainWindow.vala:761
 msgid "Snapshot deletion in progress..."
 msgstr ""
 
-#: Core/SnapshotRepo.vala:426
+#: Core/SnapshotRepo.vala:470
 #, c-format
 msgid "Snapshot device"
 msgstr ""
 
-#: Console/AppConsole.vala:660 Core/SnapshotRepo.vala:515
+#: Console/AppConsole.vala:662 Core/SnapshotRepo.vala:559
 msgid "Snapshot device not available"
 msgstr ""
 
-#: Console/AppConsole.vala:656 Core/SnapshotRepo.vala:508
+#: Console/AppConsole.vala:658 Core/SnapshotRepo.vala:552
 msgid "Snapshot device not selected"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:430
+#: Core/SnapshotRepo.vala:474
 #, c-format
 msgid "Snapshot location"
 msgstr ""
 
-#: Core/Main.vala:1160
+#: Core/Main.vala:1252
 msgid "Snapshot saved successfully"
 msgstr ""
 
-#: Core/Main.vala:1896
+#: Core/Main.vala:2022
 msgid "Snapshot to restore not specified!"
 msgstr ""
 
-#: Core/Main.vala:2731
+#: Core/Main.vala:2855
 msgid "Snapshot will become active after system is rebooted."
 msgstr ""
 
@@ -2109,98 +2184,115 @@ msgstr ""
 msgid "Snapshot(s) Deleted"
 msgstr ""
 
-#: Gtk/DeleteWindow.vala:87 Gtk/MainWindow.vala:298
+#: Gtk/MainWindow.vala:310 Gtk/DeleteWindow.vala:89
 msgid "Snapshots"
 msgstr ""
 
-#: Gtk/SnapshotBackendBox.vala:163
+#: Gtk/SnapshotBackendBox.vala:169
 msgid ""
 "Snapshots are created and restored instantly. Snapshot creation is an atomic "
 "transaction at the file system level."
 msgstr ""
 
-#: Gtk/SnapshotBackendBox.vala:180
+#: Gtk/SnapshotBackendBox.vala:186
 msgid ""
 "Snapshots are created by creating copies of system files using rsync, and "
 "hard-linking unchanged files from previous snapshot."
 msgstr ""
 
-#: Gtk/SnapshotBackendBox.vala:161
+#: Gtk/SnapshotBackendBox.vala:167
 msgid ""
 "Snapshots are created using the built-in features of the BTRFS file system."
 msgstr ""
 
-#: Gtk/SnapshotBackendBox.vala:167
+#: Gtk/ScheduleBox.vala:167
+#, c-format
+msgid "Snapshots are not scheduled at fixed times."
+msgstr ""
+
+#: Gtk/SnapshotBackendBox.vala:173
 msgid ""
 "Snapshots are perfect, byte-for-byte copies of the system. Nothing is "
 "excluded."
 msgstr ""
 
-#: Gtk/SnapshotBackendBox.vala:165
+#: Gtk/SnapshotBackendBox.vala:171
 msgid ""
 "Snapshots are restored by replacing system subvolumes. Since files are never "
 "copied, deleted or overwritten, there is no risk of data loss. The existing "
 "system is preserved as a new snapshot after restore."
 msgstr ""
 
-#: Gtk/SnapshotBackendBox.vala:169
+#: Gtk/SnapshotBackendBox.vala:175
 msgid ""
 "Snapshots are saved on the same disk from which they are created (system "
 "disk). Storage on other disks is not supported. If system disk fails then "
 "snapshots stored on it will be lost along with the system."
 msgstr ""
 
-#: Gtk/MainWindow.vala:982
+#: Gtk/BackupDeviceBox.vala:107
+msgid ""
+"Snapshots are saved to /timeshift on selected partition. Other locations are "
+"not supported."
+msgstr ""
+
+#: Gtk/BackupDeviceBox.vala:99
+msgid ""
+"Snapshots are saved to /timeshift-btrfs on selected partition. Other "
+"locations are not supported."
+msgstr ""
+
+#: Gtk/MainWindow.vala:1012
 msgid "Snapshots available for restore"
 msgstr ""
 
-#: Gtk/SnapshotBackendBox.vala:184
+#: Gtk/SnapshotBackendBox.vala:190
 msgid ""
 "Snapshots can be saved to any disk formatted with a Linux file system. "
 "Saving snapshots to non-system or external disk allows the system to be "
 "restored even if system disk is damaged or re-formatted."
 msgstr ""
 
-#: Console/AppConsole.vala:281
+#: Console/AppConsole.vala:283
 msgid "Snapshots cannot be created in Live CD mode"
 msgstr ""
 
-#: Gtk/MainWindow.vala:1029
+#: Gtk/MainWindow.vala:1059
 msgid "Snapshots will be created at selected intervals"
 msgstr ""
 
-#: Gtk/ScheduleBox.vala:284
+#: Gtk/ScheduleBox.vala:306
 msgid ""
 "Snapshots will be created at selected intervals if snapshot disk has enough "
 "space (> 1 GB)"
 msgstr ""
 
-#: Gtk/MainWindow.vala:627
+#: Gtk/MainWindow.vala:642
 msgid "Snapshots will be removed during the next scheduled run"
 msgstr ""
 
-#: Console/AppConsole.vala:373
+#: Console/AppConsole.vala:375
 msgid "Specify backup device (default: config)"
 msgstr ""
 
-#: Console/AppConsole.vala:365
+#: Console/AppConsole.vala:367
 msgid "Specify device for installing GRUB2 bootloader"
 msgstr ""
 
-#: Console/AppConsole.vala:363
+#: Console/AppConsole.vala:365
 msgid "Specify snapshot to restore"
 msgstr ""
 
-#: Console/AppConsole.vala:364
+#: Console/AppConsole.vala:366
 msgid "Specify target device"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:436
+#: Core/SnapshotRepo.vala:480 Gtk/RsyncLogBox.vala:472
 #, c-format
 msgid "Status"
 msgstr ""
 
-#: Gtk/ScheduleBox.vala:162
+#: Gtk/ScheduleBox.vala:154
 msgid "Stop cron emails for scheduled tasks"
 msgstr ""
 
@@ -2208,169 +2300,181 @@ msgstr ""
 msgid "Stopped"
 msgstr ""
 
-#: Gtk/ExcludeAppsBox.vala:133 Gtk/RestoreWindow.vala:96
-#: Gtk/ExcludeBox.vala:210
+#: Core/Subvolume.vala:189
+#, c-format
+msgid "Subvolume exists at destination"
+msgstr ""
+
+#: Gtk/SnapshotListBox.vala:275
+#, c-format
+msgid "Subvolumes"
+msgstr ""
+
+#: Gtk/ExcludeAppsBox.vala:135 Gtk/ExcludeBox.vala:258
+#: Gtk/RestoreWindow.vala:120
 msgid "Summary"
 msgstr ""
 
-#: Console/AppConsole.vala:375
+#: Console/AppConsole.vala:377
 msgid "Switch to BTRFS mode (default: config)"
 msgstr ""
 
-#: Console/AppConsole.vala:376
+#: Console/AppConsole.vala:378
 msgid "Switch to RSYNC mode (default: config)"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:985
+#: Core/SnapshotRepo.vala:1029
 msgid "Symlinks updated"
 msgstr ""
 
-#: Core/Main.vala:2236
+#: Core/Main.vala:2382
 msgid "Synching file systems..."
 msgstr ""
 
-#: Core/Main.vala:1269 Core/Main.vala:2391 Core/Main.vala:2622
+#: Core/Main.vala:1361 Core/Main.vala:2544 Core/Main.vala:2785
 msgid "Synching files with rsync..."
 msgstr ""
 
-#: Gtk/AppGtk.vala:110
+#: Gtk/AppGtk.vala:112
 msgid "Syntax"
 msgstr ""
 
-#: Utility/Device.vala:1769 Gtk/SnapshotListBox.vala:127
+#: Utility/Device.vala:1837 Gtk/SnapshotListBox.vala:127
 #, c-format
 msgid "System"
 msgstr ""
 
-#: Gtk/MainWindow.vala:927
+#: Gtk/MainWindow.vala:957
 msgid "System Restore Utility"
 msgstr ""
 
-#: Gtk/FinishBox.vala:81
+#: Gtk/FinishBox.vala:82
 msgid "System can be rolled-back to a previous date by restoring a snapshot."
 msgstr ""
 
-#: Core/Main.vala:2110
+#: Core/Main.vala:2245
 msgid "System will reboot after files are restored"
 msgstr ""
 
-#: Core/Main.vala:2060
+#: Core/Main.vala:2195
 msgid "System will reboot after files are restored."
 msgstr ""
 
-#: Core/Main.vala:1129 Core/Main.vala:1170
+#: Core/Main.vala:1221 Core/Main.vala:1262
 msgid "Tagged snapshot"
 msgstr ""
 
-#: Console/AppConsole.vala:424 Gtk/SnapshotListBox.vala:151
+#: Console/AppConsole.vala:426 Gtk/SnapshotListBox.vala:151
 msgid "Tags"
 msgstr ""
 
-#: Core/Main.vala:1931
+#: Core/Main.vala:2057
 msgid "Target device is not mounted"
 msgstr ""
 
-#: Gtk/RestoreDeviceBox.vala:477
+#: Gtk/RestoreDeviceBox.vala:480
 msgid "Target device is same as system device"
 msgstr ""
 
-#: Core/Main.vala:1925
+#: Core/Main.vala:2051
 msgid "Target device not specified!"
 msgstr ""
 
-#: Gtk/SnapshotBackendBox.vala:117
+#: Gtk/SnapshotBackendBox.vala:118
 msgid ""
 "The 'btrfs' command is not available on your system. Install the 'btrfs-"
 "tools' package and try again."
 msgstr ""
 
-#: Gtk/ScheduleBox.vala:164
+#: Gtk/ScheduleBox.vala:156
 msgid ""
 "The cron service sends the output of scheduled tasks as an email to the "
 "current user. Select this option to suppress the emails for cron tasks "
 "created by Timeshift."
 msgstr ""
 
-#: Core/Main.vala:367
+#: Core/Main.vala:376
 msgid "The system partition has an unsupported subvolume layout."
 msgstr ""
 
-#: Core/Main.vala:3292
+#: Core/Main.vala:3431
 msgid "The target partition has an unsupported subvolume layout."
 msgstr ""
 
-#: Gtk/BackupDeviceBox.vala:417
+#: Gtk/BackupDeviceBox.vala:494
 #, c-format
 msgid "There are no snapshots on this device"
 msgstr ""
 
-#: Utility/Gtk/AboutWindow.vala:336
-#, c-format
-msgid "Third Party Tools"
-msgstr ""
-
-#: Utility/Device.vala:1191
+#: Utility/Device.vala:1259
 msgid "This device is not encrypted"
 msgstr ""
 
-#: Core/Main.vala:2076
+#: Core/Main.vala:2211
 msgid ""
 "This software comes without absolutely NO warranty and the author takes no "
 "responsibility for any damage arising from the use of this program."
 msgstr ""
 
-#: Gtk/MainWindow.vala:1017 Gtk/MainWindow.vala:1028
+#: Gtk/MainWindow.vala:1047 Gtk/MainWindow.vala:1058
 msgid "Timeshift is active"
 msgstr ""
 
-#: Gtk/BackupBox.vala:94 Gtk/RestoreBox.vala:131
+#: Gtk/MainWindow.vala:948
+msgid ""
+"Timeshift is powered by the following tools and components. Please visit the "
+"links for more information."
+msgstr ""
+
+#: Gtk/RsyncLogBox.vala:394 Gtk/RestoreBox.vala:132 Gtk/BackupBox.vala:94
+#, c-format
 msgid "Timestamp"
 msgstr ""
 
-#: Console/AppConsole.vala:609
+#: Console/AppConsole.vala:611
 #, c-format
 msgid "To restore with default options, press the ENTER key for all prompts!"
 msgstr ""
 
-#: Utility/Gtk/AboutWindow.vala:352
-#, c-format
-msgid "Translators"
-msgstr ""
+#: Utility/Gtk/AboutWindow.vala:441
+#, fuzzy
+msgid "Translations"
+msgstr "Donacions"
 
-#: Console/AppConsole.vala:455 Console/AppConsole.vala:494
-#: Utility/Device.vala:1759 Gtk/SettingsWindow.vala:97
-#: Gtk/BackupDeviceBox.vala:173
+#: Utility/Device.vala:1827 Console/AppConsole.vala:457
+#: Console/AppConsole.vala:496 Gtk/BackupDeviceBox.vala:190
+#: Gtk/SettingsWindow.vala:86
 #, c-format
 msgid "Type"
 msgstr ""
 
-#: Utility/Device.vala:1758
+#: Utility/Device.vala:1826
 #, c-format
 msgid "UUID"
 msgstr ""
 
-#: Gtk/AppGtk.vala:97
+#: Gtk/AppGtk.vala:99
 msgid "Unknown option"
 msgstr ""
 
-#: Core/Main.vala:1111
+#: Core/Main.vala:1203
 msgid "Unknown snapshot type"
 msgstr ""
 
-#: Core/Main.vala:1456
+#: Core/Main.vala:1566
 msgid "Unknown value specified for option --tags"
 msgstr ""
 
-#: Utility/Device.vala:1202 Utility/Device.vala:1318
+#: Utility/Device.vala:1270 Utility/Device.vala:1386
 #, c-format
 msgid "Unlocked device is mapped to '%s'"
 msgstr ""
 
-#: Utility/Device.vala:1317
+#: Utility/Device.vala:1385
 msgid "Unlocked successfully"
 msgstr ""
 
-#: Utility/Device.vala:1532
+#: Utility/Device.vala:1600
 msgid "Unmounting from"
 msgstr ""
 
@@ -2378,173 +2482,173 @@ msgstr ""
 msgid "Unshared"
 msgstr ""
 
-#: Core/Main.vala:3296 Gtk/RestoreDeviceBox.vala:521
+#: Core/Main.vala:3435 Gtk/RestoreDeviceBox.vala:522
 msgid "Unsupported Subvolume Layout"
 msgstr ""
 
-#: Gtk/BootOptionsBox.vala:151
+#: Gtk/BootOptionsBox.vala:150
 msgid "Update GRUB menu"
 msgstr ""
 
-#: Gtk/BootOptionsBox.vala:136
+#: Gtk/BootOptionsBox.vala:135
 msgid "Update initramfs"
 msgstr ""
 
-#: Core/Main.vala:2566
+#: Core/Main.vala:2724
 msgid "Updated /etc/crypttab on target device"
 msgstr ""
 
-#: Core/Main.vala:2486
+#: Core/Main.vala:2644
 msgid "Updated /etc/fstab on target device"
 msgstr ""
 
-#: Gtk/BootOptionsBox.vala:153
+#: Gtk/BootOptionsBox.vala:152
 msgid ""
 "Updates the GRUB menu entries (recommended). This is safe to run and should "
 "be left selected."
 msgstr ""
 
-#: Core/Main.vala:2219
+#: Core/Main.vala:2365
 msgid "Updating GRUB menu..."
 msgstr ""
 
-#: Core/Main.vala:2410
+#: Core/Main.vala:2568
 msgid "Updating bootloader configuration..."
 msgstr ""
 
-#: Utility/Device.vala:1766
+#: Utility/Device.vala:1834
 #, c-format
 msgid "Used"
 msgstr ""
 
-#: Gtk/UsersBox.vala:98
+#: Gtk/SetupWizardWindow.vala:114 Gtk/UsersBox.vala:105
 msgid "User"
 msgstr ""
 
-#: Gtk/UsersBox.vala:58
+#: Gtk/UsersBox.vala:63
 msgid "User Home Directories"
 msgstr ""
 
-#: Utility/Device.vala:1272
+#: Utility/Device.vala:1340
 msgid "User cancelled the password prompt"
 msgstr ""
 
-#: Gtk/UsersBox.vala:65
+#: Gtk/UsersBox.vala:67
 msgid ""
 "User home directories are excluded by default unless you enable them here"
 msgstr ""
 
-#: Gtk/SettingsWindow.vala:109
+#: Gtk/SettingsWindow.vala:98
 msgid "Users"
 msgstr ""
 
-#: Utility/Device.vala:1743
+#: Gtk/RestoreWindow.vala:114
+msgid "Users Home"
+msgstr ""
+
+#: Utility/Device.vala:1811
 #, c-format
 msgid "Vendor"
 msgstr ""
 
-#: Gtk/SnapshotListBox.vala:313
-msgid "View Log for Create"
+#: Gtk/SnapshotListBox.vala:343
+msgid "View Rsync Log for Create"
 msgstr ""
 
-#: Gtk/SnapshotListBox.vala:320
-msgid "View Log for Restore"
+#: Gtk/SnapshotListBox.vala:350
+msgid "View Rsync Log for Restore"
 msgstr ""
 
-#: Gtk/MainWindow.vala:369
+#: Gtk/MainWindow.vala:378
 msgid "View TimeShift Logs"
-msgstr ""
-
-#: Gtk/RsyncLogWindow.vala:209
-msgid "View:"
 msgstr ""
 
 #: Gtk/RestoreDeviceBox.vala:101
 msgid "Volume"
 msgstr ""
 
-#: Core/Main.vala:1978 Gtk/RestoreSummaryBox.vala:53
+#: Core/Main.vala:2106 Gtk/RestoreSummaryBox.vala:53
 msgid "Warning"
 msgstr ""
 
-#: Gtk/RestoreExcludeBox.vala:86
+#: Gtk/RestoreExcludeBox.vala:61
 msgid "Web Browsers"
 msgstr ""
 
-#: Utility/Gtk/DonationWindow.vala:109
+#: Utility/Gtk/DonationWindow.vala:113
 #, c-format
 msgid "Website"
 msgstr ""
 
-#: Gtk/ScheduleBox.vala:79
+#: Gtk/ScheduleBox.vala:82 Gtk/SnapshotListBox.vala:301
 msgid "Weekly"
 msgstr ""
 
-#: Core/Main.vala:1015
+#: Core/Main.vala:1107
 msgid "Weekly snapshot failed!"
 msgstr ""
 
-#: Core/Main.vala:996
+#: Core/Main.vala:1088
 msgid "Weekly snapshots are enabled"
 msgstr ""
 
-#: Utility/Gtk/DonationWindow.vala:101
+#: Utility/Gtk/DonationWindow.vala:105
 msgid "Wiki ~ Documentation & Help"
 msgstr ""
 
-#: Gtk/DeleteFinishBox.vala:63 Gtk/BackupFinishBox.vala:63
+#: Gtk/BackupFinishBox.vala:63 Gtk/DeleteFinishBox.vala:63
 msgid "With Errors"
 msgstr ""
 
-#: Gtk/MainWindow.vala:188
+#: Gtk/MainWindow.vala:191
 msgid "Wizard"
 msgstr ""
 
-#: Utility/Device.vala:1245 Utility/Device.vala:1291
+#: Utility/Device.vala:1313 Utility/Device.vala:1359
 msgid "Wrong password"
 msgstr ""
 
-#: Utility/Gtk/CustomMessageDialog.vala:177
+#: Utility/Gtk/CustomMessageDialog.vala:176
 msgid "Yes"
 msgstr ""
 
-#: Gtk/RestoreFinishBox.vala:82
+#: Gtk/RestoreFinishBox.vala:98
 msgid ""
 "You can continue working on the current system. After restart, the current "
 "system will be visible as a new snapshot. This snapshot can be restored "
 "later if required, to 'undo' the restore."
 msgstr ""
 
-#: Gtk/RestoreDeviceBox.vala:411
+#: Gtk/RestoreDeviceBox.vala:413
 msgid ""
 "[Advanced Users Only] Change these settings only if the restored system "
 "fails to boot."
 msgstr ""
 
-#: Console/AppConsole.vala:1008
+#: Console/AppConsole.vala:1010
 #, c-format
 msgid "[ENTER = Default (%s), a = Abort]"
 msgstr ""
 
-#: Console/AppConsole.vala:879
+#: Console/AppConsole.vala:881
 #, c-format
 msgid "[ENTER = Default (%s), r = Root device, a = Abort]"
 msgstr ""
 
-#: Utility/AppLock.vala:55
+#: Utility/AppLock.vala:54
 msgid "[Warning] Deleted invalid lock"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:838
+#: Core/SnapshotRepo.vala:882
 msgid "all"
 msgstr ""
 
-#: Core/Main.vala:1384 Core/Main.vala:2714 Core/Main.vala:3716
-#: Core/Main.vala:3799 Core/Main.vala:3897 Core/Main.vala:3930
+#: Core/Subvolume.vala:201 Core/Main.vala:1494 Core/Main.vala:3862
+#: Core/Main.vala:3946 Core/Main.vala:4054 Core/Main.vala:4093
 msgid "btrfs returned an error"
 msgstr ""
 
-#: Core/Main.vala:1301 Core/Snapshot.vala:417
+#: Core/Main.vala:1393 Core/Snapshot.vala:500
 msgid "complete"
 msgstr ""
 
@@ -2556,27 +2660,71 @@ msgstr ""
 msgid "crontab file installed"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:824
+#: Core/SnapshotRepo.vala:868
 msgid "incomplete"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:806
+#: Core/SnapshotRepo.vala:850
 msgid "marked for deletion"
 msgstr ""
 
-#: Core/Main.vala:1193 Core/Main.vala:1345 Core/Main.vala:1347
+#: Core/Main.vala:1285 Core/Main.vala:1439 Core/Main.vala:1441
 msgid "mounted at path"
 msgstr ""
 
-#: Core/Main.vala:1301 Core/Snapshot.vala:418
+#: Core/Main.vala:1393 Core/Snapshot.vala:501 Gtk/DeleteBox.vala:149
+#: Gtk/RestoreBox.vala:237 Gtk/BackupBox.vala:234
 msgid "remaining"
 msgstr ""
 
-#: Core/Main.vala:1312
+#: Core/Main.vala:1404
 msgid "rsync returned an error"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:670 Core/SnapshotRepo.vala:708
-#: Core/SnapshotRepo.vala:787
+#: Core/SnapshotRepo.vala:714 Core/SnapshotRepo.vala:752
+#: Core/SnapshotRepo.vala:831
 msgid "un-tagged"
 msgstr ""
+
+#~ msgid ""
+#~ "<b>Backup Levels</b>\n"
+#~ "\n"
+#~ "O\tOn demand (manual)\n"
+#~ "B\tBoot\n"
+#~ "H\tHourly\n"
+#~ "D\tDaily\n"
+#~ "W\tWeekly\n"
+#~ "M\tMonthly"
+#~ msgstr ""
+#~ "<b>Backup Levels</b>\n"
+#~ "\n"
+#~ "O\tBaix demanda (manual)\n"
+#~ "B\tArranque\n"
+#~ "H\tHorari\n"
+#~ "D\tDiari\n"
+#~ "W\tSemanal\n"
+#~ "M\tMensual"
+
+#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
+#~ msgstr ""
+#~ "<b>Data de la captura de pantalla:</b> Data en que va crearse la captura "
+#~ "de pantalla"
+
+#~ msgid "<b>System:</b> Installed Linux distribution"
+#~ msgstr "<b>Sistema:</b> Distribució Linux instalada"
+
+#~ msgid ""
+#~ "Click an item to edit the pattern.\n"
+#~ "Drag and drop items with mouse to re-order."
+#~ msgstr ""
+#~ "Fer clic en un element per a editar el patró.\n"
+#~ "Arrastrar y soltar elements en el ratolí per a ficarlos en ordre."
+
+#~ msgid "Cloning System..."
+#~ msgstr "Clonant sistema..."
+
+#~ msgid "Documenters"
+#~ msgstr "Documentaors"
+
+#~ msgid "Editing and Re-Ordering"
+#~ msgstr "Editar i reordenar"

--- a/po/timeshift-cs.po
+++ b/po/timeshift-cs.po
@@ -1,13 +1,8 @@
-# Czech translation for timeshift
-# Copyright (c) 2015 Rosetta Contributors and Canonical Ltd 2015
-# This file is distributed under the same license as the timeshift package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: timeshift\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
 "PO-Revision-Date: 2017-11-05 08:47+0000\n"
 "Last-Translator: Pavel Borecki <Unknown>\n"
 "Language-Team: Czech <cs@li.org>\n"
@@ -15,10 +10,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:01+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -219,14 +212,6 @@ msgstr "Vývojáři"
 msgid "Available"
 msgstr "K dispozici"
 
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
-"BTRFS zachycené stavy jsou ukládány na systémový oddíl. Jiné oddíly nejsou "
-"podporované."
-
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr "BTRFS"
@@ -242,6 +227,15 @@ msgstr "Nebyly nalezeny BTRFS nástroje"
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
 msgstr "BTRFS zařízení není připojeno"
+
+#: Gtk/BackupDeviceBox.vala:98
+#, fuzzy
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
+msgstr ""
+"BTRFS zachycené stavy jsou ukládány na systémový oddíl. Jiné oddíly nejsou "
+"podporované."
 
 #: Gtk/FinishBox.vala:92
 msgid ""
@@ -2826,35 +2820,6 @@ msgstr "nástroj rsync oznámil chybu"
 msgid "un-tagged"
 msgstr "bez příznaku"
 
-#, fuzzy
-#~ msgid "Click to edit and drag-drop to re-order"
-#~ msgstr "Upravte kliknutím. Pořadí změňte přetažením."
-
-#~ msgid ""
-#~ "Click an item to edit the pattern.\n"
-#~ "Drag and drop items with mouse to re-order."
-#~ msgstr ""
-#~ "Vzor upravíte kliknutím na položku.\n"
-#~ "Pořadí položek je možné změnit jejich přetažením."
-
-#~ msgid "Editing and Re-Ordering"
-#~ msgstr "Úprava a přeuspořádání"
-
-#~ msgid "Info"
-#~ msgstr "Informace"
-
-#~ msgid "Deleted system subvolumes"
-#~ msgstr "Smazané systémové dílčí svazky"
-
-#~ msgid "<b>System:</b> Installed Linux distribution"
-#~ msgstr "<b>Systém:</b> Nainstalovaná distribuce GNU/Linux"
-
-#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
-#~ msgstr "<b>Datum zachycení stavu:</b> Kdy byl daný zachycený stav pořízen"
-
-#~ msgid "Selected snapshot path"
-#~ msgstr "Popis umístění označeného zachyceného stavu"
-
 #~ msgid ""
 #~ "<b>Backup Levels</b>\n"
 #~ "\n"
@@ -2874,6 +2839,19 @@ msgstr "bez příznaku"
 #~ "W\ttýdenní\n"
 #~ "M\tměsíční"
 
+#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
+#~ msgstr "<b>Datum zachycení stavu:</b> Kdy byl daný zachycený stav pořízen"
+
+#~ msgid "<b>System:</b> Installed Linux distribution"
+#~ msgstr "<b>Systém:</b> Nainstalovaná distribuce GNU/Linux"
+
+#~ msgid ""
+#~ "Click an item to edit the pattern.\n"
+#~ "Drag and drop items with mouse to re-order."
+#~ msgstr ""
+#~ "Vzor upravíte kliknutím na položku.\n"
+#~ "Pořadí položek je možné změnit jejich přetažením."
+
 #~ msgid "Cloning System..."
 #~ msgstr "Klonování systému…"
 
@@ -2883,14 +2861,26 @@ msgstr "bez příznaku"
 #~ msgid "Contributions"
 #~ msgstr "Do vývoje se dále zapojili"
 
+#~ msgid "Create snapshots using RSYNC"
+#~ msgstr "Pořizovat zachycené stavy pomocí nástroje RSYNC"
+
+#~ msgid "Deleted system subvolumes"
+#~ msgstr "Smazané systémové dílčí svazky"
+
 #~ msgid "Documenters"
 #~ msgstr "Dokumentace"
+
+#~ msgid "Editing and Re-Ordering"
+#~ msgstr "Úprava a přeuspořádání"
 
 #~ msgid "Include everything"
 #~ msgstr "Zahrnout vše"
 
 #~ msgid "Include hidden items"
 #~ msgstr "Včetně skrytých položek"
+
+#~ msgid "Info"
+#~ msgstr "Informace"
 
 #~ msgid "Log Viewer"
 #~ msgstr "Prohlížeč záznamu událostí"
@@ -2900,6 +2890,9 @@ msgstr "bez příznaku"
 
 #~ msgid "Scheduled task runs once every hour"
 #~ msgstr "Naplánovaná úloha bude zkoušena každou hodinu"
+
+#~ msgid "Selected snapshot path"
+#~ msgstr "Popis umístění označeného zachyceného stavu"
 
 #~ msgid "Third Party Tools"
 #~ msgstr "Nástroje třetích stran"
@@ -2915,6 +2908,10 @@ msgstr "bez příznaku"
 
 #~ msgid "View:"
 #~ msgstr "Zobrazit:"
+
+#, fuzzy
+#~ msgid "Click to edit and drag-drop to re-order"
+#~ msgstr "Upravte kliknutím. Pořadí změňte přetažením."
 
 #~ msgid "Change"
 #~ msgstr "Změněno"

--- a/po/timeshift-da.po
+++ b/po/timeshift-da.po
@@ -1,24 +1,17 @@
-# Danish translation for linuxmint
-# Copyright (c) 2017 Rosetta Contributors and Canonical Ltd 2017
-# This file is distributed under the same license as the linuxmint package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
-"PO-Revision-Date: 2017-11-03 17:47+0000\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
+"PO-Revision-Date: 2017-12-02 14:47+0000\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: Danish <dansk@dansk-gruppen.dk>\n"
 "Language: da\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:00+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -215,12 +208,6 @@ msgstr "Forfattere"
 msgid "Available"
 msgstr "Tilgængelig"
 
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
-
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr "BTRFS"
@@ -236,6 +223,13 @@ msgstr "BTRFS-værktøjer kunne ikke findes"
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
 msgstr "BTRFS-enhed er ikke monteret"
+
+#: Gtk/BackupDeviceBox.vala:98
+#, fuzzy
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
+msgstr "Andre programmer (næste side)"
 
 #: Gtk/FinishBox.vala:92
 msgid ""
@@ -595,9 +589,7 @@ msgstr "Cron-opgave findes"
 
 #: Gtk/ScheduleBox.vala:100 Gtk/SnapshotListBox.vala:300
 msgid "Daily"
-msgstr ""
-"Daglig\n"
-"Dagligt"
+msgstr "Daglig"
 
 #: Core/Main.vala:1077
 msgid "Daily snapshot failed!"
@@ -886,7 +878,6 @@ msgstr "Udeladelsesmønster"
 msgid "Excluded Directories"
 msgstr "Udeladte mapper"
 
-# Se streng, der begynder med <b>Backup Levels</b>
 #: Core/Main.vala:1567
 msgid "Expected values: O, B, H, D, W, M"
 msgstr "Forventede værdier: E, B, T, D, U, M"
@@ -1869,7 +1860,6 @@ msgstr ""
 "filer. Inkluderede filer vil blive sikkerhedskopieret, når øjebliksbilledet "
 "oprettes, og erstattet, når øjebliksbilledet gendannes."
 
-# Der er tale om en disk. Andre strenge relateret til denne er: "Device", "Vendor", "Model" og "Serial"
 #: Utility/Device.vala:1814
 #, c-format
 msgid "Revision"
@@ -2267,9 +2257,7 @@ msgid ""
 msgstr ""
 "Øjebliksbilleder oprettes ved at oprette kopier af systemfiler med brug af "
 "rsync og ved at lave hårde links til uændrede filer i tidligere "
-"øjebliksbilleder.\n"
-"Øjebliksbilleder oprettes ved at kopier af systemfiler med brug af rsync og "
-"ved at lave hårde links til uændrede filer i tidligere øjebliksbilleder."
+"øjebliksbilleder."
 
 #: Gtk/SnapshotBackendBox.vala:167
 msgid ""
@@ -2755,7 +2743,6 @@ msgstr "alle"
 msgid "btrfs returned an error"
 msgstr "btrfs returnerede en fejl"
 
-# Hvor langt programmet er i opgaven (i %)
 #: Core/Main.vala:1393 Core/Snapshot.vala:500
 msgid "complete"
 msgstr "færdigt"
@@ -2794,38 +2781,6 @@ msgstr "rsync returnerede en fejl"
 msgid "un-tagged"
 msgstr "umærket"
 
-#, fuzzy
-#~ msgid "Click to edit and drag-drop to re-order"
-#~ msgstr "Klik for at redigere. Træk-og-slip for at omarrangere."
-
-#~ msgid ""
-#~ "Click an item to edit the pattern.\n"
-#~ "Drag and drop items with mouse to re-order."
-#~ msgstr ""
-#~ "Klik på et element for at redigere mønsteret.\n"
-#~ "Træk-og-slip elementer med musen for at omarrangere."
-
-#~ msgid "Editing and Re-Ordering"
-#~ msgstr "Redigering og omarrangering"
-
-#~ msgid "Info"
-#~ msgstr "Info"
-
-#~ msgid "Deleted system subvolumes"
-#~ msgstr "Slettede systemets underdiskenheder"
-
-#~ msgid "<b>System:</b> Installed Linux distribution"
-#~ msgstr "<b>System:</b> Installeret Linux-distribution"
-
-#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
-#~ msgstr ""
-#~ "<b>Dato for øjebliksbillede:</b> Dato for oprettelse af øjebliksbilledet\n"
-#~ "<b>Dato for øjebliksbillede:</b> Datoen for oprettelsen af "
-#~ "øjebliksbilledet"
-
-#~ msgid "Selected snapshot path"
-#~ msgstr "Valgt sti til øjebliksbillede"
-
 #~ msgid ""
 #~ "<b>Backup Levels</b>\n"
 #~ "\n"
@@ -2843,15 +2798,21 @@ msgstr "umærket"
 #~ "T\tHver time\n"
 #~ "D\tDaglig\n"
 #~ "U\tUgentlig\n"
-#~ "M\tMånedlig\n"
-#~ "<b>Niveauer af sikkerhedskopiering</b>\n"
-#~ "\n"
-#~ "E\tEfter behov (manuelt)\n"
-#~ "B\tBoot\n"
-#~ "T\tHver time\n"
-#~ "D\tDagligt\n"
-#~ "U\tUgentligt\n"
-#~ "M\tMånedligt"
+#~ "M\tMånedlig"
+
+#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
+#~ msgstr ""
+#~ "<b>Dato for øjebliksbillede:</b> Dato for oprettelse af øjebliksbilledet"
+
+#~ msgid "<b>System:</b> Installed Linux distribution"
+#~ msgstr "<b>System:</b> Installeret Linux-distribution"
+
+#~ msgid ""
+#~ "Click an item to edit the pattern.\n"
+#~ "Drag and drop items with mouse to re-order."
+#~ msgstr ""
+#~ "Klik på et element for at redigere mønsteret.\n"
+#~ "Træk-og-slip elementer med musen for at omarrangere."
 
 #~ msgid "Cloning System..."
 #~ msgstr "Kloner systemet …"
@@ -2862,14 +2823,26 @@ msgstr "umærket"
 #~ msgid "Contributions"
 #~ msgstr "Bidrag"
 
+#~ msgid "Create snapshots using RSYNC"
+#~ msgstr "Opret øjebliksbilleder med brug af RSYNC"
+
+#~ msgid "Deleted system subvolumes"
+#~ msgstr "Slettede systemets underdiskenheder"
+
 #~ msgid "Documenters"
 #~ msgstr "Udarbejdelse af dokumentation"
+
+#~ msgid "Editing and Re-Ordering"
+#~ msgstr "Redigering og omarrangering"
 
 #~ msgid "Include everything"
 #~ msgstr "Medtag alt"
 
 #~ msgid "Include hidden items"
 #~ msgstr "Medtag skjulte elementer"
+
+#~ msgid "Info"
+#~ msgstr "Info"
 
 #~ msgid "Log Viewer"
 #~ msgstr "Logfremviser"
@@ -2879,6 +2852,9 @@ msgstr "umærket"
 
 #~ msgid "Scheduled task runs once every hour"
 #~ msgstr "Planlagte opgaver kører én gang i timen"
+
+#~ msgid "Selected snapshot path"
+#~ msgstr "Valgt sti til øjebliksbillede"
 
 #~ msgid "Third Party Tools"
 #~ msgstr "Tredjepartsværktøjer"
@@ -2894,6 +2870,10 @@ msgstr "umærket"
 
 #~ msgid "View:"
 #~ msgstr "Vis:"
+
+#, fuzzy
+#~ msgid "Click to edit and drag-drop to re-order"
+#~ msgstr "Klik for at redigere. Træk-og-slip for at omarrangere."
 
 #~ msgid "Change"
 #~ msgstr "Ændret"

--- a/po/timeshift-de.po
+++ b/po/timeshift-de.po
@@ -1,24 +1,17 @@
-# German translation for linuxmint
-# Copyright (c) 2017 Rosetta Contributors and Canonical Ltd 2017
-# This file is distributed under the same license as the linuxmint package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
-"PO-Revision-Date: 2018-04-16 23:51+0200\n"
-"Last-Translator: Tobias Bannert <tobannert@gmail.com>\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
+"PO-Revision-Date: 2018-04-14 13:32+0000\n"
+"Last-Translator: Niko Krause <nikokrause@gmx.de>\n"
 "Language-Team: German <de@li.org>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Poedit 2.0.4\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:01+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -70,7 +63,7 @@ msgstr "/home wurde dem Gerät zugeordnet"
 
 #: Gtk/SnapshotListBox.vala:290
 msgid "<b>Comments</b> (double-click to edit)"
-msgstr "<b>Kommentare</b> (Doppelklicken zum Bearbeiten)"
+msgstr "<b>Kommentare</b> (Doppeklicken zum Bearbeiten)"
 
 #: Gtk/ScheduleBox.vala:168
 msgid ""
@@ -147,8 +140,9 @@ msgid ""
 "snapshot if available."
 msgstr ""
 "Alle Dateien werden beim Erstellen des ersten Schnappschusses kopiert. "
-"Nachfolgende Schnappschüsse sind inkrementell. Unveränderte Dateien werden "
-"aus dem vorherigen Schnappschuss, falls verfügbar, direkt verknüpft."
+"Nachfolgende Schnappschüsse sind schrittweise zunehmend. Unveränderte "
+"Dateien werden aus dem vorherigen Schnappschuss, falls verfügbar, direkt "
+"verknüpft."
 
 #: Gtk/ExcludeMessageWindow.vala:130
 msgid "All other files and folders are excluded."
@@ -176,7 +170,7 @@ msgstr "Eine andere Instanz von Timeshift erstellt einen Schnappschuss."
 
 #: Utility/AppLock.vala:49
 msgid "Another instance of this application is running"
-msgstr "Eine andere Instanz dieser Anwendung läuft gerade"
+msgstr "Eine andere Instanz dieser Anwendung läuft gerade!"
 
 #: Core/Main.vala:253
 msgid "Another instance of timeshift is currently running!"
@@ -196,7 +190,7 @@ msgstr "Anwendungskonfiguration gespeichert"
 
 #: Console/AppConsole.vala:102
 msgid "Application needs admin access."
-msgstr "Anwendung benötigt Systemverwaltungszugriff."
+msgstr "Anwendung benötigt Systemverwaltungszugriff"
 
 #: Core/Main.vala:3519
 msgid "Application will exit"
@@ -218,14 +212,6 @@ msgstr "Autoren"
 msgid "Available"
 msgstr "Verfügbar"
 
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
-"BRTFS-Snapshots werden auf der Systempartition gespeichert. Andere "
-"Partitionen werden nicht unterstützt."
-
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr "BTRFS"
@@ -241,6 +227,15 @@ msgstr "BTRFS-Werkzeuge nicht gefunden"
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
 msgstr "BTRFS-Gerät ist nicht eingehängt"
+
+#: Gtk/BackupDeviceBox.vala:98
+#, fuzzy
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
+msgstr ""
+"BRTFS-Snapshots werden auf der Systempartition gespeichert. Andere "
+"Partitionen werden nicht unterstützt."
 
 #: Gtk/FinishBox.vala:92
 msgid ""
@@ -396,19 +391,19 @@ msgstr "Zum Bearbeiten klicken. Zum Neuordnen ziehen und verschieben."
 
 #: Gtk/RestoreWindow.vala:69
 msgid "Clone System"
-msgstr "System klonen"
+msgstr "System nachbilden"
 
 #: Console/AppConsole.vala:364
 msgid "Clone current system"
-msgstr "Aktuelles System klonen"
+msgstr "Aktuelles System nachbilden"
 
 #: Gtk/RestoreFinishBox.vala:68
 msgid "Cloning"
-msgstr "Klonen"
+msgstr "wird nachgebildet"
 
 #: Core/Main.vala:2782
 msgid "Cloning system..."
-msgstr "System wird geklont …"
+msgstr "System wird nachgebildet …"
 
 #: Utility/Gtk/AboutWindow.vala:326 Utility/Gtk/DonationWindow.vala:121
 #: Gtk/RsyncLogBox.vala:266 Gtk/BackupWindow.vala:168
@@ -428,7 +423,7 @@ msgstr "Beitragende"
 
 #: Core/Main.vala:347
 msgid "Commands listed below are not available on this system"
-msgstr "Unten aufgelisteten Befehle sind auf diesem System nicht verfügbar"
+msgstr "Unten aufgelisteten Befehle sind nicht verfügbar auf diesem System"
 
 #: Gtk/SnapshotListBox.vala:224
 msgid "Comments"
@@ -696,7 +691,7 @@ msgstr "Gerät ist entsperrt"
 
 #: Utility/Device.vala:1164 Utility/Device.vala:1226
 msgid "Device name is empty!"
-msgstr "Gerätename ist leer!"
+msgstr "Gerätname ist leer!"
 
 #: Console/AppConsole.vala:663 Core/SnapshotRepo.vala:560 Core/Main.vala:3232
 msgid "Device not found"
@@ -714,11 +709,11 @@ msgstr "Oben angezeigte Geräte haben ein Linux-Dateisystem."
 
 #: Gtk/RestoreDeviceBox.vala:84
 msgid "Devices from which snapshot was created are pre-selected."
-msgstr "Geräte, von denen der Schnappschuss erstellt wurde, sind ausgewählt."
+msgstr "Geräte von denen der Schnappschuss erstellt wurde sind ausgewählt."
 
 #: Console/AppConsole.vala:326
 msgid "Devices with Linux file systems"
-msgstr "Geräte mit Linux-Dateisystemen"
+msgstr "Geräte mit Linuxdateisystem"
 
 #: Gtk/BackupDeviceBox.vala:105
 msgid "Devices with Windows file systems are not supported (NTFS, FAT, etc)."
@@ -774,7 +769,7 @@ msgstr "Datenträger"
 
 #: Core/Main.vala:226
 msgid "Distribution"
-msgstr "Vertrieb"
+msgstr "Distribution"
 
 #: Utility/Gtk/AboutWindow.vala:449
 msgid "Documentation"
@@ -854,11 +849,11 @@ msgstr "Schätzen"
 
 #: Gtk/EstimateBox.vala:56
 msgid "Estimating System Size..."
-msgstr "Abschätzen der Systemgröße …"
+msgstr "Systemgröße wird geschätzt …"
 
 #: Core/Main.vala:1279
 msgid "Estimating system size..."
-msgstr "Abschätzen der Systemgröße …"
+msgstr "Systemgröße wird geschätzt …"
 
 #: Console/AppConsole.vala:386
 msgid "Examples"
@@ -960,7 +955,7 @@ msgstr "Exportieren der Crontab-Datei ist fehlgeschlagen"
 #: Console/AppConsole.vala:893 Console/AppConsole.vala:988
 #: Console/AppConsole.vala:1033 Console/AppConsole.vala:1074
 msgid "Failed to get input from user in 3 attempts"
-msgstr "Keine Benutzereingabe nach 3 Versuchen erhalten"
+msgstr "Keine Benutzereingabe in 3 Versuchen erhalten"
 
 #: Utility/Device.vala:615
 msgid "Failed to get partition list"
@@ -1091,7 +1086,7 @@ msgstr "Datei- und Verzeichniszählungen:"
 
 #: Gtk/ExcludeMessageWindow.vala:76
 msgid "Files matching the following patterns will be excluded"
-msgstr "Dateien, welche folgendem Muster entsprechen, werden ausgeschlossen"
+msgstr "Dateien welche folgendem Muster entsprechen werden ausgeschlossen"
 
 #: Utility/Device.vala:1828
 #, c-format
@@ -1194,7 +1189,7 @@ msgstr "Stündlich"
 
 #: Core/Main.vala:1047
 msgid "Hourly snapshot failed!"
-msgstr "Stündlicher Schnappschuss ist fehlgeschlagen!"
+msgstr "Stündlicher Schnappschuss ist fehlgeschlagen"
 
 #: Core/Main.vala:1028
 msgid "Hourly snapshots are enabled"
@@ -1209,7 +1204,7 @@ msgid ""
 "If the restored system fails to boot, then boot from the Live CD/USB, "
 "install Timeshift, and try restoring another snapshot."
 msgstr ""
-"Wenn das wiederhergestellte System nicht startet, bitte ein Livesystem "
+"Wenn das wiederhergestellte Systems fehlschlägt, bitte ein Livesystem "
 "starten, Timeshift installieren und versuchen einen anderen Schnappschuss "
 "wiederherzustellen."
 
@@ -1281,7 +1276,7 @@ msgid ""
 msgstr ""
 "Konfigurationsdateien für Internet-Browser wie Firefox und Chrome behalten. "
 "Wenn nicht ausgewählt, werden die vorherigen Konfigurationsdateien aus dem "
-"Schnappschuss wiederhergestellt"
+"Schnappschuss wiederhergestellt."
 
 #: Gtk/RestoreDeviceBox.vala:244
 msgid "Keep on Root Device"
@@ -1394,7 +1389,7 @@ msgstr "Schnappschüsse auflisten"
 
 #: Gtk/MainWindow.vala:1000
 msgid "Live USB Mode (Restore Only)"
-msgstr "Live-USB-Modus (nur Wiederherstellung)"
+msgstr "Live-USB-Modus (nue Wiederherstellung)"
 
 #: Gtk/SetupWizardWindow.vala:104 Gtk/BackupWindow.vala:86
 #: Gtk/SettingsWindow.vala:89
@@ -1449,7 +1444,7 @@ msgstr "Monatlicher Schnappschuss aktiviert"
 
 #: Core/Main.vala:1137
 msgid "Monthly snapshot failed!"
-msgstr "Monatlicher Schnappschuss ist fehlgeschlagen!"
+msgstr "Monatlischer Schnappschuss ist fehlgeschlagen"
 
 #: Core/Main.vala:2113 Core/Main.vala:2146
 msgid "Mount"
@@ -1512,7 +1507,7 @@ msgstr "Keine Schnappschüsse ausgewählt"
 
 #: Gtk/MainWindow.vala:1050 Gtk/MainWindow.vala:1052
 msgid "None"
-msgstr "Keine"
+msgstr "keine"
 
 #: Core/Subvolume.vala:184
 #, fuzzy, c-format
@@ -1537,7 +1532,7 @@ msgstr "Bemerkungen"
 
 #: Core/Main.vala:1147
 msgid "Nothing to do!"
-msgstr "Nichts zu tun!"
+msgstr "Nichts zu erledigen!"
 
 #: Console/AppConsole.vala:423 Console/AppConsole.vala:452
 #: Console/AppConsole.vala:491 Console/AppConsole.vala:539
@@ -1640,7 +1635,7 @@ msgstr "Zugriffsrechte"
 
 #: Core/Main.vala:254
 msgid "Please check if you have multiple windows open."
-msgstr "Bitte überprüfen Sie, ob Sie mehrere Fenster geöffnet haben."
+msgstr "Bitte überprüfen Sie, ob Sie mehrere Fenstere geöffnet haben."
 
 #: Core/Main.vala:2244
 msgid "Please do not interrupt the restore process!"
@@ -1650,7 +1645,7 @@ msgstr "Bitte unterbrechen Sie den Wiederherstellungsprozess nicht!"
 msgid "Please install required packages and try running TimeShift again"
 msgstr ""
 "Bitte installieren Sie die erforderlichen Pakete und starten Sie TimeShift "
-"erneut"
+"erneut."
 
 #: Gtk/AppGtk.vala:127
 msgid "Please re-run the application as admin (using 'sudo' or 'su')"
@@ -1704,7 +1699,7 @@ msgstr "Zurück"
 
 #: Gtk/AppGtk.vala:116
 msgid "Print debug information"
-msgstr "Debug-Informationen anzeigen"
+msgstr "Fehlersuchinformationen anzeigen"
 
 #: Core/Main.vala:3794
 msgid "Query completed"
@@ -1904,7 +1899,7 @@ msgstr "Protokollbetrachter"
 #, c-format
 msgid "Run 'timeshift' for the command-line version of this tool"
 msgstr ""
-"Für die Befehlszeilenversion dieses Programms bitte »timeshift« ausführen"
+"Für die Befehlszeilenversion dieses Programms bitte »timeshift« ausführen."
 
 #: Console/AppConsole.vala:382
 msgid "Run in non-interactive mode"
@@ -2034,7 +2029,7 @@ msgstr "Ein anderes Gerät auswählen, um Schnappschüsse zu löschen"
 
 #: Gtk/MainWindow.vala:481
 msgid "Select another device?"
-msgstr "Ein anderes Gerät auswählen?"
+msgstr "Ein anderes Gerät auswählen"
 
 #: Gtk/RestoreExcludeBox.vala:57
 msgid "Select applications to exclude from restore"
@@ -2071,7 +2066,7 @@ msgstr ""
 
 #: Gtk/ScheduleBox.vala:313
 msgid "Select the intervals for creating snapshots"
-msgstr "Wählen Sie die Intervalle für die Erstellung von Snapshots aus"
+msgstr "Den Abstand in dem Schnappschüsse gemacht werden sollen auswählen"
 
 #: Gtk/ExcludeBox.vala:273
 msgid "Select the items to be removed from the list"
@@ -2079,7 +2074,7 @@ msgstr "Einträge auswählen, welche aus der Liste entfernt werden sollen"
 
 #: Core/SnapshotRepo.vala:553
 msgid "Select the snapshot device"
-msgstr "Schnappschussgerät auswählen"
+msgstr "Schnappschuss auswählen"
 
 #: Gtk/MainWindow.vala:794
 msgid "Select the snapshot to restore"
@@ -2095,15 +2090,15 @@ msgstr "Schnappschüsse zum Löschen markieren"
 
 #: Gtk/RestoreDeviceBox.vala:79
 msgid "Select the target devices where system will be cloned."
-msgstr "Bitte Zielgerät für die Kopie des Systems auswählen."
+msgstr "Bitte Zielgerät für die Nachbildung des Systems auswählen."
 
 #: Core/Main.vala:3242
 msgid "Selected default snapshot device"
-msgstr "Standard Schnappschussgerät auswählen"
+msgstr "Vorgegebenes Schnappschussgerät auswählen"
 
 #: Core/Main.vala:3193 Core/Main.vala:3197
 msgid "Selected default snapshot type"
-msgstr "Standard Schnappschusstyp auswählen"
+msgstr "Vorgegebenen Schnappschusstyp auswählen"
 
 #: Gtk/BackupDeviceBox.vala:373
 msgid "Selected device does not have BTRFS partition"
@@ -2170,7 +2165,7 @@ msgstr "Einrichtungsassistent"
 
 #: Console/AppConsole.vala:379
 msgid "Show additional debug messages"
-msgstr "Zusätzliche Debug-Informationen anzeigen"
+msgstr "Zusätzliche Fehlersuchinformationen anzeigen"
 
 #: Console/AppConsole.vala:383 Gtk/AppGtk.vala:117
 msgid "Show all options"
@@ -2182,7 +2177,7 @@ msgstr "Mehr Anwendungen zum Ausschließen auf der nächsten Seite anzeigen"
 
 #: Console/AppConsole.vala:380
 msgid "Show rsync output (default)"
-msgstr "rsync-Ausgabe anzeigen (Standard)"
+msgstr "rsync-Ausgabe anzeigen (Vorgabe)"
 
 #: Utility/Device.vala:1816 Utility/Device.vala:1831
 #: Console/AppConsole.vala:456 Console/AppConsole.vala:495
@@ -2407,7 +2402,7 @@ msgstr "Bitte Zielgerät festlegen"
 #: Core/SnapshotRepo.vala:480 Gtk/RsyncLogBox.vala:472
 #, c-format
 msgid "Status"
-msgstr "Status"
+msgstr "Zustand"
 
 #: Gtk/ScheduleBox.vala:154
 msgid "Stop cron emails for scheduled tasks"
@@ -2474,7 +2469,7 @@ msgstr ""
 #: Core/Main.vala:2245
 msgid "System will reboot after files are restored"
 msgstr ""
-"Das System wird neu gestartet, nachdem die Dateien wiederhergestellt wurden"
+"Das System wird neu gestartet, nachdem die Dateien wiederhergestellt wurden."
 
 #: Core/Main.vala:2195
 msgid "System will reboot after files are restored."
@@ -2567,7 +2562,7 @@ msgstr "Zeitstempel"
 msgid "To restore with default options, press the ENTER key for all prompts!"
 msgstr ""
 "Um mit den vorgegebenen Optionen wiederherzustellen, bitte bei jeder "
-"Rückfrage die EINGABETASTE betätigen!"
+"Rückfrage die EINGABETASTE betätigen."
 
 #: Utility/Gtk/AboutWindow.vala:441
 msgid "Translations"
@@ -2672,7 +2667,7 @@ msgid ""
 "User home directories are excluded by default unless you enable them here"
 msgstr ""
 "Die persönlichen Ordner sind standardmäßig ausgeschlossen, sofern sie hier "
-"nicht aktiviert werden"
+"nicht aktiviert werden."
 
 #: Gtk/SettingsWindow.vala:98
 msgid "Users"
@@ -2723,7 +2718,7 @@ msgstr "Wöchentlich"
 
 #: Core/Main.vala:1107
 msgid "Weekly snapshot failed!"
-msgstr "Wöchentlicher Schnappschuss ist fehlgeschlagen"
+msgstr "Wöchentlischer Schnappschuss ist fehlgeschlagen"
 
 #: Core/Main.vala:1088
 msgid "Weekly snapshots are enabled"
@@ -2829,36 +2824,6 @@ msgstr "rsync lieferte einen Fehler zurück"
 msgid "un-tagged"
 msgstr "Nicht verschlagwortet"
 
-#, fuzzy
-#~ msgid "Click to edit and drag-drop to re-order"
-#~ msgstr "Zum Bearbeiten klicken. Zum Neuordnen ziehen und verschieben."
-
-#~ msgid ""
-#~ "Click an item to edit the pattern.\n"
-#~ "Drag and drop items with mouse to re-order."
-#~ msgstr ""
-#~ "Bitte Einträge auswählen, um das Muster zu ändern.\n"
-#~ "Einträge mit der Maus ziehen und ablegen, um sie neu anzuordnen."
-
-#~ msgid "Editing and Re-Ordering"
-#~ msgstr "Bearbeiten und Umsortieren"
-
-#~ msgid "Info"
-#~ msgstr "Information"
-
-#~ msgid "Deleted system subvolumes"
-#~ msgstr "Gelöschtes Systemunterlaufwerk"
-
-#~ msgid "<b>System:</b> Installed Linux distribution"
-#~ msgstr "<b>System:</b> Installierte Linux-Distribution"
-
-#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
-#~ msgstr ""
-#~ "<b>Schnappschussdatum:</b> Datum, an dem der Schnappschuss erstellt wurde"
-
-#~ msgid "Selected snapshot path"
-#~ msgstr "Ausgewählter Schnappschusspfad"
-
 #~ msgid ""
 #~ "<b>Backup Levels</b>\n"
 #~ "\n"
@@ -2878,8 +2843,22 @@ msgstr "Nicht verschlagwortet"
 #~ "W\tWöchentlich\n"
 #~ "M\tMonatlich"
 
+#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
+#~ msgstr ""
+#~ "<b>Schnappschussdatum:</b> Datum, an dem der Schnappschuss erstellt wurde"
+
+#~ msgid "<b>System:</b> Installed Linux distribution"
+#~ msgstr "<b>System:</b> Installierte Linux-Distribution"
+
+#~ msgid ""
+#~ "Click an item to edit the pattern.\n"
+#~ "Drag and drop items with mouse to re-order."
+#~ msgstr ""
+#~ "Bitte Einträge auswählen, um das Muster zu ändern.\n"
+#~ "Einträge mit der Maus ziehen und ablegen, um sie neu anzuordnen."
+
 #~ msgid "Cloning System..."
-#~ msgstr "System wird geklont …"
+#~ msgstr "System wird nachgebildet …"
 
 #~ msgid "Close Window"
 #~ msgstr "Fenster schließen"
@@ -2887,14 +2866,26 @@ msgstr "Nicht verschlagwortet"
 #~ msgid "Contributions"
 #~ msgstr "Beitragende"
 
+#~ msgid "Create snapshots using RSYNC"
+#~ msgstr "Schnappschüsse mit rsync erstellen"
+
+#~ msgid "Deleted system subvolumes"
+#~ msgstr "Gelöschtes Systemunterlaufwerk"
+
 #~ msgid "Documenters"
 #~ msgstr "Dokumentatoren"
+
+#~ msgid "Editing and Re-Ordering"
+#~ msgstr "Bearbeiten und Umsortieren"
 
 #~ msgid "Include everything"
 #~ msgstr "Alles einschließen"
 
 #~ msgid "Include hidden items"
 #~ msgstr "Versteckte Einträge einschließen"
+
+#~ msgid "Info"
+#~ msgstr "Information"
 
 #~ msgid "Log Viewer"
 #~ msgstr "Protokollbetrachter"
@@ -2904,6 +2895,9 @@ msgstr "Nicht verschlagwortet"
 
 #~ msgid "Scheduled task runs once every hour"
 #~ msgstr "Die geplante Aufgabe läuft einmal pro Stunde"
+
+#~ msgid "Selected snapshot path"
+#~ msgstr "Ausgewählter Schnappschusspfad"
 
 #~ msgid "Third Party Tools"
 #~ msgstr "Programme von Dritten"
@@ -2919,6 +2913,10 @@ msgstr "Nicht verschlagwortet"
 
 #~ msgid "View:"
 #~ msgstr "Ansicht:"
+
+#, fuzzy
+#~ msgid "Click to edit and drag-drop to re-order"
+#~ msgstr "Zum Bearbeiten klicken. Zum Neuordnen ziehen und verschieben."
 
 #~ msgid "Change"
 #~ msgstr "Geändert"

--- a/po/timeshift-el.po
+++ b/po/timeshift-el.po
@@ -1,13 +1,8 @@
-# Greek translation for linuxmint
-# Copyright (c) 2017 Rosetta Contributors and Canonical Ltd 2017
-# This file is distributed under the same license as the linuxmint package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
 "PO-Revision-Date: 2017-09-30 17:08+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Greek <el@li.org>\n"
@@ -15,10 +10,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:01+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -203,12 +196,6 @@ msgstr ""
 msgid "Available"
 msgstr ""
 
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
-
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr ""
@@ -223,6 +210,12 @@ msgstr ""
 
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
+msgstr ""
+
+#: Gtk/BackupDeviceBox.vala:98
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
 msgstr ""
 
 #: Gtk/FinishBox.vala:92

--- a/po/timeshift-en_GB.po
+++ b/po/timeshift-en_GB.po
@@ -1,13 +1,8 @@
-# English (United Kingdom) translation for linuxmint
-# Copyright (c) 2017 Rosetta Contributors and Canonical Ltd 2017
-# This file is distributed under the same license as the linuxmint package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
 "PO-Revision-Date: 2017-11-06 15:44+0000\n"
 "Last-Translator: Eilidh Martin <Unknown>\n"
 "Language-Team: English (United Kingdom) <en_GB@li.org>\n"
@@ -15,10 +10,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:00+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -214,12 +207,6 @@ msgstr "Authors"
 msgid "Available"
 msgstr "Available"
 
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
-
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr "BTRFS"
@@ -235,6 +222,13 @@ msgstr "BTRFS Tools Not Found"
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
 msgstr "BTRFS device is not mounted"
+
+#: Gtk/BackupDeviceBox.vala:98
+#, fuzzy
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
+msgstr "Other applications (next page)"
 
 #: Gtk/FinishBox.vala:92
 msgid ""
@@ -2762,53 +2756,37 @@ msgstr "rsync returned an error"
 msgid "un-tagged"
 msgstr "un-tagged"
 
-#, fuzzy
-#~ msgid "Click to edit and drag-drop to re-order"
-#~ msgstr "Click to edit. Drag and drop to re-order."
-
 #~ msgid ""
-#~ "Click an item to edit the pattern.\n"
-#~ "Drag and drop items with mouse to re-order."
+#~ "<b>Backup Levels</b>\n"
+#~ "\n"
+#~ "O\tOn demand (manual)\n"
+#~ "B\tBoot\n"
+#~ "H\tHourly\n"
+#~ "D\tDaily\n"
+#~ "W\tWeekly\n"
+#~ "M\tMonthly"
 #~ msgstr ""
-#~ "Click an item to edit the pattern.\n"
-#~ "Drag and drop items with mouse to re-order."
-
-#~ msgid "Editing and Re-Ordering"
-#~ msgstr "Editing and Re-Ordering"
-
-#~ msgid "Info"
-#~ msgstr "Info"
-
-#~ msgid "Deleted system subvolumes"
-#~ msgstr "Deleted system subvolumes"
-
-#~ msgid "<b>System:</b> Installed Linux distribution"
-#~ msgstr "<b>System:</b> Installed Linux distribution"
+#~ "<b>Backup Levels</b>\n"
+#~ "\n"
+#~ "O\tOn demand (manual)\n"
+#~ "B\tBoot\n"
+#~ "H\tHourly\n"
+#~ "D\tDaily\n"
+#~ "W\tWeekly\n"
+#~ "M\tMonthly"
 
 #~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
 #~ msgstr "<b>Snapshot Date:</b> Date on which snapshot was created"
 
-#~ msgid "Selected snapshot path"
-#~ msgstr "Selected snapshot path"
+#~ msgid "<b>System:</b> Installed Linux distribution"
+#~ msgstr "<b>System:</b> Installed Linux distribution"
 
 #~ msgid ""
-#~ "<b>Backup Levels</b>\n"
-#~ "\n"
-#~ "O\tOn demand (manual)\n"
-#~ "B\tBoot\n"
-#~ "H\tHourly\n"
-#~ "D\tDaily\n"
-#~ "W\tWeekly\n"
-#~ "M\tMonthly"
+#~ "Click an item to edit the pattern.\n"
+#~ "Drag and drop items with mouse to re-order."
 #~ msgstr ""
-#~ "<b>Backup Levels</b>\n"
-#~ "\n"
-#~ "O\tOn demand (manual)\n"
-#~ "B\tBoot\n"
-#~ "H\tHourly\n"
-#~ "D\tDaily\n"
-#~ "W\tWeekly\n"
-#~ "M\tMonthly"
+#~ "Click an item to edit the pattern.\n"
+#~ "Drag and drop items with mouse to re-order."
 
 #~ msgid "Cloning System..."
 #~ msgstr "Cloning System..."
@@ -2819,14 +2797,26 @@ msgstr "un-tagged"
 #~ msgid "Contributions"
 #~ msgstr "Contributions"
 
+#~ msgid "Create snapshots using RSYNC"
+#~ msgstr "Create snapshots using RSYNC"
+
+#~ msgid "Deleted system subvolumes"
+#~ msgstr "Deleted system subvolumes"
+
 #~ msgid "Documenters"
 #~ msgstr "Documenters"
+
+#~ msgid "Editing and Re-Ordering"
+#~ msgstr "Editing and Re-Ordering"
 
 #~ msgid "Include everything"
 #~ msgstr "Include everything"
 
 #~ msgid "Include hidden items"
 #~ msgstr "Include hidden items"
+
+#~ msgid "Info"
+#~ msgstr "Info"
 
 #~ msgid "Log Viewer"
 #~ msgstr "Log Viewer"
@@ -2836,6 +2826,9 @@ msgstr "un-tagged"
 
 #~ msgid "Scheduled task runs once every hour"
 #~ msgstr "Scheduled task runs once every hour"
+
+#~ msgid "Selected snapshot path"
+#~ msgstr "Selected snapshot path"
 
 #~ msgid "Third Party Tools"
 #~ msgstr "Third Party Tools"
@@ -2851,6 +2844,10 @@ msgstr "un-tagged"
 
 #~ msgid "View:"
 #~ msgstr "View:"
+
+#, fuzzy
+#~ msgid "Click to edit and drag-drop to re-order"
+#~ msgstr "Click to edit. Drag and drop to re-order."
 
 #~ msgid "Change"
 #~ msgstr "Changed"

--- a/po/timeshift-en_GB.po
+++ b/po/timeshift-en_GB.po
@@ -1204,7 +1204,7 @@ msgstr "Include @home subvolume in backups"
 
 #: Gtk/UsersBox.vala:266
 msgid "Include All"
-msgstr "Exclude Apps"
+msgstr "Include All"
 
 #: Gtk/UsersBox.vala:194
 msgid "Include Hidden"

--- a/po/timeshift-es.po
+++ b/po/timeshift-es.po
@@ -1,13 +1,8 @@
-# Spanish translation for timeshift
-# Copyright (c) 2014 Rosetta Contributors and Canonical Ltd 2014
-# This file is distributed under the same license as the timeshift package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: timeshift\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
 "PO-Revision-Date: 2017-11-04 21:14+0000\n"
 "Last-Translator: Isidro Pisa <isidro@utils.info>\n"
 "Language-Team: Spanish <es@li.org>\n"
@@ -15,10 +10,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:00+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -216,12 +209,6 @@ msgstr "Autores"
 msgid "Available"
 msgstr "Disponible"
 
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
-
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr "BTRFS"
@@ -237,6 +224,13 @@ msgstr "No se encuentran las utilidades BTRFS"
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
 msgstr "El dispositivo BTRFS no está montado"
+
+#: Gtk/BackupDeviceBox.vala:98
+#, fuzzy
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
+msgstr "Otras aplicaciones (página siguiente)"
 
 #: Gtk/FinishBox.vala:92
 msgid ""
@@ -2798,35 +2792,6 @@ msgstr "rsync ha devuelto un error"
 msgid "un-tagged"
 msgstr "no etiquetado"
 
-#, fuzzy
-#~ msgid "Click to edit and drag-drop to re-order"
-#~ msgstr "Haga clic para editar. Arrastre y suelte para reordenar."
-
-#~ msgid ""
-#~ "Click an item to edit the pattern.\n"
-#~ "Drag and drop items with mouse to re-order."
-#~ msgstr ""
-#~ "Haga clic en un elemento para editar el patrón.\n"
-#~ "Arrastre y suelte elementos con el ratón para reordenarlos."
-
-#~ msgid "Editing and Re-Ordering"
-#~ msgstr "Editar y reordenar"
-
-#~ msgid "Info"
-#~ msgstr "Información"
-
-#~ msgid "Deleted system subvolumes"
-#~ msgstr "Subvolúmenes del sistema borrados"
-
-#~ msgid "<b>System:</b> Installed Linux distribution"
-#~ msgstr "<b>Sistema:</b> Distribución de Linux instalada"
-
-#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
-#~ msgstr "<b>Fecha de la instantánea:</b> Fecha en que se creó la instantánea"
-
-#~ msgid "Selected snapshot path"
-#~ msgstr "Ruta de la instantánea seleccionada"
-
 #~ msgid ""
 #~ "<b>Backup Levels</b>\n"
 #~ "\n"
@@ -2846,6 +2811,19 @@ msgstr "no etiquetado"
 #~ "W\tSemanal\n"
 #~ "M\tMensual"
 
+#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
+#~ msgstr "<b>Fecha de la instantánea:</b> Fecha en que se creó la instantánea"
+
+#~ msgid "<b>System:</b> Installed Linux distribution"
+#~ msgstr "<b>Sistema:</b> Distribución de Linux instalada"
+
+#~ msgid ""
+#~ "Click an item to edit the pattern.\n"
+#~ "Drag and drop items with mouse to re-order."
+#~ msgstr ""
+#~ "Haga clic en un elemento para editar el patrón.\n"
+#~ "Arrastre y suelte elementos con el ratón para reordenarlos."
+
 #~ msgid "Cloning System..."
 #~ msgstr "Clonando sistema..."
 
@@ -2855,14 +2833,26 @@ msgstr "no etiquetado"
 #~ msgid "Contributions"
 #~ msgstr "Contribuciones"
 
+#~ msgid "Create snapshots using RSYNC"
+#~ msgstr "Crear instantáneas usando RSYNC"
+
+#~ msgid "Deleted system subvolumes"
+#~ msgstr "Subvolúmenes del sistema borrados"
+
 #~ msgid "Documenters"
 #~ msgstr "Documentadores"
+
+#~ msgid "Editing and Re-Ordering"
+#~ msgstr "Editar y reordenar"
 
 #~ msgid "Include everything"
 #~ msgstr "Incluirlo todo"
 
 #~ msgid "Include hidden items"
 #~ msgstr "Incluir elementos ocultos"
+
+#~ msgid "Info"
+#~ msgstr "Información"
 
 #~ msgid "Log Viewer"
 #~ msgstr "Visor del registro"
@@ -2872,6 +2862,9 @@ msgstr "no etiquetado"
 
 #~ msgid "Scheduled task runs once every hour"
 #~ msgstr "La tarea programada se ejecuta cada hora"
+
+#~ msgid "Selected snapshot path"
+#~ msgstr "Ruta de la instantánea seleccionada"
 
 #~ msgid "Third Party Tools"
 #~ msgstr "Herramientas de terceros"
@@ -2887,6 +2880,10 @@ msgstr "no etiquetado"
 
 #~ msgid "View:"
 #~ msgstr "Ver:"
+
+#, fuzzy
+#~ msgid "Click to edit and drag-drop to re-order"
+#~ msgstr "Haga clic para editar. Arrastre y suelte para reordenar."
 
 #~ msgid "Change"
 #~ msgstr "Modificado"

--- a/po/timeshift-et.po
+++ b/po/timeshift-et.po
@@ -1,24 +1,17 @@
-# Estonian translation for linuxmint
-# Copyright (c) 2017 Rosetta Contributors and Canonical Ltd 2017
-# This file is distributed under the same license as the linuxmint package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
-"PO-Revision-Date: 2017-09-21 08:31+0000\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
+"PO-Revision-Date: 2018-02-26 08:05+0000\n"
+"Last-Translator: mahfiaz <mahfiaz@gmail.com>\n"
 "Language-Team: Estonian <et@li.org>\n"
 "Language: et\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:00+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -26,49 +19,51 @@ msgid ""
 "\n"
 "Press ENTER to continue..."
 msgstr ""
+"\n"
+"Vajuta sisestusklahvi (Enter), et jätkata..."
 
 #: Core/SnapshotRepo.vala:641
 #, c-format
 msgid "%d snapshots, %s free"
-msgstr ""
+msgstr "%d salvestust, %s vaba"
 
 #: Console/AppConsole.vala:914
 #, c-format
 msgid "'%s' will be on '%s'"
-msgstr ""
+msgstr "'%s' läheb  '%s' peale"
 
 #: Console/AppConsole.vala:911
 #, c-format
 msgid "'%s' will be on root device"
-msgstr ""
+msgstr "'%s' läheb juurkettale"
 
 #: Gtk/BootOptionsBox.vala:118
 msgid "(Re)install GRUB2 on:"
-msgstr ""
+msgstr "(Taas)paigalda alglaadur GRUB2 seadmele:"
 
 #: Core/Main.vala:362
 msgid "** Uninstalled Timeshift BTRFS **"
-msgstr ""
+msgstr "** BTFRS Timeshift eemaldatud **"
 
 #: Core/Main.vala:3342
 msgid "/ is mapped to device"
-msgstr ""
+msgstr "/ on seostatud seadmega (kettaga)"
 
 #: Core/Main.vala:3364
 msgid "/boot is mapped to device"
-msgstr ""
+msgstr "/boot on seostatud seadmega"
 
 #: Core/Main.vala:3375
 msgid "/boot/efi is mapped to device"
-msgstr ""
+msgstr "/boot/efi on seostatud seadmega"
 
 #: Core/Main.vala:3353
 msgid "/home is mapped to device"
-msgstr ""
+msgstr "/home kodukataloog on seostatud seadmega"
 
 #: Gtk/SnapshotListBox.vala:290
 msgid "<b>Comments</b> (double-click to edit)"
-msgstr ""
+msgstr "<b>Kommentaarid</b> (redigeerimine topeltklõpsuga)"
 
 #: Gtk/ScheduleBox.vala:168
 msgid ""
@@ -203,12 +198,6 @@ msgstr ""
 msgid "Available"
 msgstr ""
 
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
-
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr ""
@@ -223,6 +212,12 @@ msgstr ""
 
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
+msgstr ""
+
+#: Gtk/BackupDeviceBox.vala:98
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
 msgstr ""
 
 #: Gtk/FinishBox.vala:92
@@ -2643,3 +2638,34 @@ msgstr ""
 #: Core/SnapshotRepo.vala:831
 msgid "un-tagged"
 msgstr ""
+
+#~ msgid ""
+#~ "<b>Backup Levels</b>\n"
+#~ "\n"
+#~ "O\tOn demand (manual)\n"
+#~ "B\tBoot\n"
+#~ "H\tHourly\n"
+#~ "D\tDaily\n"
+#~ "W\tWeekly\n"
+#~ "M\tMonthly"
+#~ msgstr ""
+#~ "<b>Turvakoopia ajakava valik</b>\n"
+#~ "\n"
+#~ "\n"
+#~ "O\tOmal soovil (kasutaja soovil)\n"
+#~ "\n"
+#~ "A\tAlglaadimisel\n"
+#~ "\n"
+#~ "H\tKord tunnis\n"
+#~ "\n"
+#~ "P\tIga päev\n"
+#~ "\n"
+#~ "N\tKord nädalas\n"
+#~ "\n"
+#~ "K\tKord kuus"
+
+#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
+#~ msgstr "<b>Turvakoopia kuupäev:</b> Kuupäev, mil turvakoopia loodi"
+
+#~ msgid "<b>System:</b> Installed Linux distribution"
+#~ msgstr "<b>Süsteem:</b> Paigaldatud Linuxi distributsioon"

--- a/po/timeshift-eu.po
+++ b/po/timeshift-eu.po
@@ -1,24 +1,17 @@
-# Basque translation for linuxmint
-# Copyright (c) 2017 Rosetta Contributors and Canonical Ltd 2017
-# This file is distributed under the same license as the linuxmint package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
-"PO-Revision-Date: 2017-11-03 18:43+0000\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
+"PO-Revision-Date: 2018-01-02 20:15+0000\n"
 "Last-Translator: Asier Iturralde Sarasola <Unknown>\n"
 "Language-Team: Basque <eu@li.org>\n"
 "Language: eu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:00+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -216,12 +209,6 @@ msgstr "Egileak"
 msgid "Available"
 msgstr "Erabilgarri"
 
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
-
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr "BTRFS"
@@ -237,6 +224,13 @@ msgstr "BTRFS tresnak ez dira aurkitu"
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
 msgstr "BTRFS gailua ez dago muntatuta"
+
+#: Gtk/BackupDeviceBox.vala:98
+#, fuzzy
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
+msgstr "Beste aplikazioak (hurrengo orria)"
 
 #: Gtk/FinishBox.vala:92
 msgid ""
@@ -2785,35 +2779,6 @@ msgstr "rsync-ek errore bat itzuli du"
 msgid "un-tagged"
 msgstr "etiketa kenduta"
 
-#, fuzzy
-#~ msgid "Click to edit and drag-drop to re-order"
-#~ msgstr "Klikatu editatzeko. Arrastatu eta jaregin berrantolatzeko."
-
-#~ msgid ""
-#~ "Click an item to edit the pattern.\n"
-#~ "Drag and drop items with mouse to re-order."
-#~ msgstr ""
-#~ "Klikatu elementu bat eredua editatzeko.\n"
-#~ "Arrastatu eta jaregin elementuak saguarekin berrantolatzeko."
-
-#~ msgid "Editing and Re-Ordering"
-#~ msgstr "Editatzea eta berrantolatzea"
-
-#~ msgid "Info"
-#~ msgstr "Informazioa"
-
-#~ msgid "Deleted system subvolumes"
-#~ msgstr "Sistemaren azpi-bolumenak ezabatuta"
-
-#~ msgid "<b>System:</b> Installed Linux distribution"
-#~ msgstr "<b>Sistema:</b> Instalatutako Linux banaketa"
-
-#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
-#~ msgstr "<b>Argazkiaren data:</b> Argazkia sortutako data"
-
-#~ msgid "Selected snapshot path"
-#~ msgstr "Hautatutako argazkiaren bidea"
-
 #~ msgid ""
 #~ "<b>Backup Levels</b>\n"
 #~ "\n"
@@ -2833,6 +2798,19 @@ msgstr "etiketa kenduta"
 #~ "W\tAstero\n"
 #~ "M\tHilabetero"
 
+#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
+#~ msgstr "<b>Argazkiaren data:</b> Argazkia sortutako data"
+
+#~ msgid "<b>System:</b> Installed Linux distribution"
+#~ msgstr "<b>Sistema:</b> Instalatutako Linux banaketa"
+
+#~ msgid ""
+#~ "Click an item to edit the pattern.\n"
+#~ "Drag and drop items with mouse to re-order."
+#~ msgstr ""
+#~ "Klikatu elementu bat eredua editatzeko.\n"
+#~ "Arrastatu eta jaregin elementuak saguarekin berrantolatzeko."
+
 #~ msgid "Cloning System..."
 #~ msgstr "Sistema klonatzen..."
 
@@ -2842,14 +2820,26 @@ msgstr "etiketa kenduta"
 #~ msgid "Contributions"
 #~ msgstr "Ekarpenak"
 
+#~ msgid "Create snapshots using RSYNC"
+#~ msgstr "Sortu argazkiak RSYNC erabiliz"
+
+#~ msgid "Deleted system subvolumes"
+#~ msgstr "Sistemaren azpi-bolumenak ezabatuta"
+
 #~ msgid "Documenters"
 #~ msgstr "Dokumentatzaileak"
+
+#~ msgid "Editing and Re-Ordering"
+#~ msgstr "Editatzea eta berrantolatzea"
 
 #~ msgid "Include everything"
 #~ msgstr "Guztia barne hartu"
 
 #~ msgid "Include hidden items"
 #~ msgstr "Ezkutuko elementuak barne hartu"
+
+#~ msgid "Info"
+#~ msgstr "Informazioa"
 
 #~ msgid "Log Viewer"
 #~ msgstr "Erregistroen ikustailea"
@@ -2858,9 +2848,10 @@ msgstr "etiketa kenduta"
 #~ msgstr "Freskatu argazki zerrenda"
 
 #~ msgid "Scheduled task runs once every hour"
-#~ msgstr ""
-#~ "Programatutako ataza orduero exekutatzen da\n"
-#~ "Programatutako ataza orduero exekutatzend a"
+#~ msgstr "Programatutako ataza orduero exekutatzen da"
+
+#~ msgid "Selected snapshot path"
+#~ msgstr "Hautatutako argazkiaren bidea"
 
 #~ msgid "Third Party Tools"
 #~ msgstr "Hirugarrengoen tresnak"
@@ -2876,6 +2867,10 @@ msgstr "etiketa kenduta"
 
 #~ msgid "View:"
 #~ msgstr "Ikusi:"
+
+#, fuzzy
+#~ msgid "Click to edit and drag-drop to re-order"
+#~ msgstr "Klikatu editatzeko. Arrastatu eta jaregin berrantolatzeko."
 
 #~ msgid "Change"
 #~ msgstr "Aldatua"

--- a/po/timeshift-fi.po
+++ b/po/timeshift-fi.po
@@ -1,24 +1,17 @@
-# Finnish translation for linuxmint
-# Copyright (c) 2017 Rosetta Contributors and Canonical Ltd 2017
-# This file is distributed under the same license as the linuxmint package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-02-03 19:50+0530\n"
-"PO-Revision-Date: 2017-11-21 17:25+0000\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
+"PO-Revision-Date: 2018-06-07 12:58+0000\n"
 "Last-Translator: Ari Ervasti <ari.ervasti87@gmail.com>\n"
 "Language-Team: Finnish <fi@li.org>\n"
 "Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:01+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -29,7 +22,7 @@ msgstr ""
 "\n"
 "Paina ENTER jatkaaksesi..."
 
-#: Core/SnapshotRepo.vala:623
+#: Core/SnapshotRepo.vala:641
 #, c-format
 msgid "%d snapshots, %s free"
 msgstr "%d tilannekuva, %s vapaana"
@@ -48,39 +41,31 @@ msgstr "'%s' tulee olemaan juuriasemalla"
 msgid "(Re)install GRUB2 on:"
 msgstr "(Uudelleen)asenna GRUB2 sijaintiin:"
 
-#: Core/Main.vala:359
+#: Core/Main.vala:362
 msgid "** Uninstalled Timeshift BTRFS **"
 msgstr "** Poistettu Timeshift BTRFS **"
 
-#: Core/Main.vala:3296
+#: Core/Main.vala:3342
 msgid "/ is mapped to device"
 msgstr "/ on kartoitettu laitteelle"
 
-#: Core/Main.vala:3318
+#: Core/Main.vala:3364
 msgid "/boot is mapped to device"
 msgstr "/boot on kartoitettu laitteelle"
 
-#: Core/Main.vala:3329
+#: Core/Main.vala:3375
 msgid "/boot/efi is mapped to device"
 msgstr "/boot/efi on kartoitettu laitteelle"
 
-#: Core/Main.vala:3307
+#: Core/Main.vala:3353
 msgid "/home is mapped to device"
 msgstr "/home on kartoitettu laitteelle"
 
-#: Gtk/SnapshotListBox.vala:266
+#: Gtk/SnapshotListBox.vala:290
 msgid "<b>Comments</b> (double-click to edit)"
 msgstr "<b>Kommentit</b> (kaksoisnapsauta muokataksesi)"
 
-#: Gtk/SnapshotListBox.vala:262
-msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
-msgstr "<b>Tilannekuvan päiväys:</b> Päivämäärä jolloin tilannekuva luotiin"
-
-#: Gtk/SnapshotListBox.vala:270
-msgid "<b>System:</b> Installed Linux distribution"
-msgstr "<b>Järjestelmä:</b> Asennettu Linux–jakeluversio"
-
-#: Gtk/ScheduleBox.vala:152
+#: Gtk/ScheduleBox.vala:168
 msgid ""
 "A maintenance task runs once every hour and creates snapshots as needed."
 msgstr ""
@@ -88,7 +73,7 @@ msgstr ""
 #: Console/AppConsole.vala:698 Console/AppConsole.vala:762
 #: Console/AppConsole.vala:894 Console/AppConsole.vala:989
 #: Console/AppConsole.vala:1034 Console/AppConsole.vala:1075
-#: Console/AppConsole.vala:1092
+#: Console/AppConsole.vala:1093
 msgid "Aborted."
 msgstr "Peruutettu."
 
@@ -101,27 +86,27 @@ msgstr "Tietoja"
 msgid "Action"
 msgstr "Sijainti"
 
-#: Gtk/ExcludeBox.vala:226
+#: Gtk/ExcludeBox.vala:219
 msgid "Add"
 msgstr "Lisää"
 
-#: Gtk/ExcludeBox.vala:240
+#: Gtk/ExcludeBox.vala:233
 msgid "Add Files"
 msgstr "Lisää tiedostoja"
 
-#: Gtk/ExcludeBox.vala:246
+#: Gtk/ExcludeBox.vala:239
 msgid "Add Folders"
 msgstr "Lisää kansioita"
 
-#: Gtk/ExcludeBox.vala:226
+#: Gtk/ExcludeBox.vala:219
 msgid "Add custom pattern"
 msgstr "Lisää muokattu kaava"
 
-#: Gtk/ExcludeBox.vala:246
+#: Gtk/ExcludeBox.vala:239
 msgid "Add directories"
 msgstr "Lisää sanakirjoja"
 
-#: Gtk/ExcludeBox.vala:240
+#: Gtk/ExcludeBox.vala:233
 msgid "Add files"
 msgstr "Lisää tiedostoja"
 
@@ -148,7 +133,7 @@ msgstr ""
 msgid "All Files"
 msgstr "Lisää tiedostoja"
 
-#: Gtk/SnapshotBackendBox.vala:183
+#: Gtk/SnapshotBackendBox.vala:188
 msgid ""
 "All files are copied when first snapshot is created. Subsequent snapshots "
 "are incremental. Unchanged files will be hard-linked from the previous "
@@ -177,7 +162,7 @@ msgstr ""
 "Valitse joko salaamaton laite käynnistyshakemistolle tai valitse salaamaton "
 "laite juuritiedostojärjestelmälle."
 
-#: Core/Main.vala:246
+#: Core/Main.vala:249
 msgid "Another instance of Timeshift is creating a snapshot."
 msgstr "Toinen käynnissä oleva Timeshift on luomassa tilannekuvaa."
 
@@ -185,7 +170,7 @@ msgstr "Toinen käynnissä oleva Timeshift on luomassa tilannekuvaa."
 msgid "Another instance of this application is running"
 msgstr "Toinen tämän sovelluksen instanssi on käynnissä"
 
-#: Core/Main.vala:250
+#: Core/Main.vala:253
 msgid "Another instance of timeshift is currently running!"
 msgstr "Toinen timeshift instanssi on tällä hetkellä käynnissä!"
 
@@ -193,11 +178,11 @@ msgstr "Toinen timeshift instanssi on tällä hetkellä käynnissä!"
 msgid "Answer YES to all confirmation prompts"
 msgstr "Vastaa KYLLÄ kaikkiin varmistuskyselyihin"
 
-#: Core/Main.vala:3135
+#: Core/Main.vala:3179
 msgid "App config loaded"
 msgstr "Sovelluksen asetukset ladattu"
 
-#: Core/Main.vala:3041
+#: Core/Main.vala:3076
 msgid "App config saved"
 msgstr "Sovelluksen asetukset tallennettu"
 
@@ -205,19 +190,19 @@ msgstr "Sovelluksen asetukset tallennettu"
 msgid "Application needs admin access."
 msgstr "Sovellus tarvitsee ylläpidon oikeudet."
 
-#: Core/Main.vala:3473
+#: Core/Main.vala:3519
 msgid "Application will exit"
 msgstr "Sovellus sulkeutuu"
 
-#: Core/Main.vala:375
+#: Core/Main.vala:378
 msgid "Application will exit."
 msgstr "Sovellus sulkeutuu."
 
-#: Utility/Gtk/AboutWindow.vala:428
+#: Utility/Gtk/AboutWindow.vala:433
 msgid "Artists"
 msgstr "Artistit"
 
-#: Utility/Gtk/AboutWindow.vala:412
+#: Utility/Gtk/AboutWindow.vala:417
 msgid "Authors"
 msgstr "Tekijät"
 
@@ -225,17 +210,11 @@ msgstr "Tekijät"
 msgid "Available"
 msgstr "Saatavilla"
 
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
-
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr "BTRFS"
 
-#: Gtk/SnapshotBackendBox.vala:160
+#: Gtk/SnapshotBackendBox.vala:165
 msgid "BTRFS Snapshots"
 msgstr "BTRFS–tilannekuvat"
 
@@ -243,9 +222,15 @@ msgstr "BTRFS–tilannekuvat"
 msgid "BTRFS Tools Not Found"
 msgstr "BTRFS–työkaluja ei löytynyt"
 
-#: Core/Main.vala:1987 Core/Main.vala:1991
+#: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
 msgstr "BTRFS–laitetta ei ole liitetty"
+
+#: Gtk/BackupDeviceBox.vala:98
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
+msgstr ""
 
 #: Gtk/FinishBox.vala:92
 msgid ""
@@ -259,23 +244,23 @@ msgstr ""
 "tilannekuvat erilliselle ulkoiselle tallennuslaitteelle RSYNC–tilassa "
 "suojautuaksesi levyn hajoamisilta."
 
-#: Utility/Gtk/AboutWindow.vala:344 Utility/Gtk/AboutWindow.vala:376
+#: Utility/Gtk/AboutWindow.vala:349 Utility/Gtk/AboutWindow.vala:381
 msgid "Back"
 msgstr "Takaisin"
 
-#: Gtk/SetupWizardWindow.vala:90
+#: Gtk/SetupWizardWindow.vala:94
 msgid "Backend"
 msgstr "Taustajärjestelmä"
 
-#: Console/AppConsole.vala:356 Gtk/BackupWindow.vala:89
+#: Console/AppConsole.vala:356 Gtk/BackupWindow.vala:91
 msgid "Backup"
 msgstr "Varmuuskopio"
 
-#: Core/Main.vala:1963
+#: Core/Main.vala:2017
 msgid "Backup Device"
 msgstr "Varmuuskopiointilaite"
 
-#: Core/Main.vala:1958
+#: Core/Main.vala:2012
 msgid "Backup device not specified!"
 msgstr "Varmuuskopiointilaitetta ei ole määritetty!"
 
@@ -287,7 +272,7 @@ msgstr "Tule tukijaksi"
 msgid "Bittorrent Clients"
 msgstr "Bittorrent–asiakkaat"
 
-#: Gtk/ScheduleBox.vala:134 Gtk/SnapshotListBox.vala:278
+#: Gtk/ScheduleBox.vala:136 Gtk/SnapshotListBox.vala:298
 msgid "Boot"
 msgstr "Käynnistys"
 
@@ -295,11 +280,11 @@ msgstr "Käynnistys"
 msgid "Boot device not selected"
 msgstr "Käynnistysasemaa ei ole valittu"
 
-#: Core/Main.vala:979
+#: Core/Main.vala:1017
 msgid "Boot snapshot failed!"
 msgstr "Käynnistettävä tilannekuva epäonnistui!"
 
-#: Gtk/ScheduleBox.vala:153
+#: Gtk/ScheduleBox.vala:169
 #, fuzzy
 msgid ""
 "Boot snapshots are created with a delay of 10 minutes after system startup."
@@ -307,7 +292,7 @@ msgstr ""
 "Tilannekuvat luodaan käyttäen sisäänrakennettuja BTRFS–tiedostojärjestelmän "
 "ominaisuuksia."
 
-#: Core/Main.vala:960
+#: Core/Main.vala:998
 msgid "Boot snapshots are enabled"
 msgstr "Käynnistettävät tilannekuvat ovat käytössä"
 
@@ -323,7 +308,7 @@ msgstr "Käynnistyslataimen asetukset (Lisävalinnat)"
 msgid "Browse"
 msgstr "Selaa"
 
-#: Gtk/SnapshotListBox.vala:316
+#: Gtk/SnapshotListBox.vala:336
 msgid "Browse Files"
 msgstr "Selaa tiedostoja"
 
@@ -331,21 +316,22 @@ msgstr "Selaa tiedostoja"
 msgid "Browse selected snapshot"
 msgstr "Selaa valittua tilannekuvaa"
 
-#: Core/Main.vala:2438
+#: Core/Main.vala:2499
 msgid "Building file list..."
 msgstr "Rakennetaan tiedostolista..."
 
-#: Gtk/SetupWizardWindow.vala:204 Gtk/RestoreWindow.vala:204
-#: Gtk/BackupWindow.vala:175 Gtk/DeleteWindow.vala:185
 #: Utility/GtkHelper.vala:122 Utility/Gtk/CustomMessageDialog.vala:172
+#: Gtk/SetupWizardWindow.vala:214 Gtk/BackupWindow.vala:177
+#: Gtk/DeleteWindow.vala:187 Gtk/RestoreWindow.vala:206
+#: Gtk/RestoreWindow.vala:215
 msgid "Cancel"
 msgstr "Peru"
 
-#: Gtk/RestoreWindow.vala:210
+#: Gtk/RestoreWindow.vala:221
 msgid "Cancel restore?"
 msgstr "Peruuta palautus?"
 
-#: Gtk/RestoreWindow.vala:212
+#: Gtk/RestoreWindow.vala:223
 msgid ""
 "Cancelling the restore process will leave the target system in an "
 "inconsistent state. The system may fail to boot or you may run into various "
@@ -362,8 +348,8 @@ msgstr ""
 msgid "Cannot Delete Live Snapshot"
 msgstr "Live–tilannekuvaa ei voitu poistaa"
 
-#: Gtk/RestoreBox.vala:125 Gtk/BackupBox.vala:87 Gtk/RsyncLogBox.vala:380
-#: Gtk/RsyncLogBox.vala:383 Gtk/RsyncLogBox.vala:567 Gtk/RsyncLogBox.vala:588
+#: Gtk/RsyncLogBox.vala:380 Gtk/RsyncLogBox.vala:383 Gtk/RsyncLogBox.vala:567
+#: Gtk/RsyncLogBox.vala:588 Gtk/RestoreBox.vala:125 Gtk/BackupBox.vala:87
 msgid "Changed"
 msgstr "Muutettu"
 
@@ -371,38 +357,37 @@ msgstr "Muutettu"
 msgid "Changed items:"
 msgstr "Muutetut kohteet:"
 
-#: Gtk/RestoreWindow.vala:101
+#: Gtk/RestoreWindow.vala:104
 msgid "Checking Restore Actions (Dry Run)"
 msgstr ""
 
-#: Core/Main.vala:2671
+#: Core/Main.vala:2732
 msgid "Checking file systems for errors..."
 msgstr "Tarkistetaan tiedostojärjestelmää virheiden varalta..."
 
-#: Gtk/RestoreBox.vala:130 Gtk/BackupBox.vala:92 Gtk/RsyncLogBox.vala:390
+#: Gtk/RsyncLogBox.vala:390 Gtk/RestoreBox.vala:130 Gtk/BackupBox.vala:92
 #, c-format
 msgid "Checksum"
 msgstr "Tarkastussumma"
 
-#: Core/Main.vala:2327
+#: Core/Main.vala:2388
 msgid "Cleaning up..."
 msgstr "Puhdistetaan..."
 
-#: Gtk/ExcludeBox.vala:268
-msgid ""
-"Click an item to edit the pattern.\n"
-"Drag and drop items with mouse to re-order."
-msgstr ""
-"Napsauta kohdetta muokataksesi kaavaa.\n"
-"Vedä ja pudota kohteita hiirellä järjestääksesi uudelleen."
-
-#: Gtk/ExcludeBox.vala:82 Gtk/UsersBox.vala:85
+#: Gtk/UsersBox.vala:92 Gtk/ExcludeBox.vala:84
 msgid "Click to edit. Drag and drop to re-order."
 msgstr ""
 "Napsauta muokataksesi. Vedä ja pudota kohteita hiirellä järjestääksesi "
 "uudelleen."
 
-#: Gtk/RestoreWindow.vala:68
+#: Gtk/ExcludeBox.vala:59
+#, fuzzy
+msgid "Click to edit. Drag-drop to re-order."
+msgstr ""
+"Napsauta muokataksesi. Vedä ja pudota kohteita hiirellä järjestääksesi "
+"uudelleen."
+
+#: Gtk/RestoreWindow.vala:69
 msgid "Clone System"
 msgstr "Kloonaa järjestelmä"
 
@@ -414,28 +399,28 @@ msgstr "Kloonaa nykyinen järjestelmä"
 msgid "Cloning"
 msgstr "Kloonataan"
 
-#: Core/Main.vala:2721
+#: Core/Main.vala:2782
 msgid "Cloning system..."
 msgstr "Kloonataan järjestelmää..."
 
-#: Gtk/RestoreWindow.vala:195 Gtk/BackupWindow.vala:166
-#: Gtk/BootOptionsWindow.vala:106 Gtk/DeleteWindow.vala:168
-#: Gtk/RsyncLogBox.vala:266 Gtk/SettingsWindow.vala:85
-#: Utility/Gtk/DonationWindow.vala:121
+#: Utility/Gtk/AboutWindow.vala:326 Utility/Gtk/DonationWindow.vala:121
+#: Gtk/RsyncLogBox.vala:266 Gtk/BackupWindow.vala:168
+#: Gtk/BootOptionsWindow.vala:106 Gtk/DeleteWindow.vala:170
+#: Gtk/RestoreWindow.vala:508
 msgid "Close"
 msgstr "Sulje"
 
-#: Gtk/DeleteFinishBox.vala:71 Gtk/RestoreFinishBox.vala:106
-#: Gtk/FinishBox.vala:101 Gtk/BackupFinishBox.vala:70
+#: Gtk/RestoreFinishBox.vala:106 Gtk/BackupFinishBox.vala:70
+#: Gtk/FinishBox.vala:101 Gtk/DeleteFinishBox.vala:71
 msgid "Close window to exit"
 msgstr "Sulje ikkuna poistuaksesi"
 
-#: Utility/Gtk/AboutWindow.vala:420
+#: Utility/Gtk/AboutWindow.vala:425
 #, fuzzy
 msgid "Code Contributions"
 msgstr "Lahjoitukset"
 
-#: Core/Main.vala:344
+#: Core/Main.vala:347
 msgid "Commands listed below are not available on this system"
 msgstr "Alla listatut komennot eivät ole saatavilla tässä järjestelmässä"
 
@@ -443,17 +428,17 @@ msgstr "Alla listatut komennot eivät ole saatavilla tässä järjestelmässä"
 msgid "Comments"
 msgstr "Kommentit"
 
-#: Core/Main.vala:2714 Gtk/RestoreBox.vala:74 Gtk/RestoreBox.vala:187
+#: Core/Main.vala:2775 Gtk/RestoreBox.vala:74 Gtk/RestoreBox.vala:187
 msgid "Comparing Files (Dry Run)..."
 msgstr ""
 
-#: Core/Main.vala:2480
+#: Core/Main.vala:2541
 #, fuzzy
 msgid "Comparing files with rsync..."
 msgstr "Synkronoidaan tiedostoja rsyncillä..."
 
-#: Gtk/DeleteFinishBox.vala:50 Gtk/RestoreFinishBox.vala:50
-#: Gtk/RestoreFinishBox.vala:75 Gtk/BackupFinishBox.vala:50
+#: Gtk/RestoreFinishBox.vala:50 Gtk/RestoreFinishBox.vala:75
+#: Gtk/BackupFinishBox.vala:50 Gtk/DeleteFinishBox.vala:50
 msgid "Completed"
 msgstr "Valmis"
 
@@ -461,7 +446,7 @@ msgstr "Valmis"
 msgid "Completed With Errors"
 msgstr "Valmis virheiden kanssa"
 
-#: Gtk/RestoreWindow.vala:106 Gtk/RsyncLogBox.vala:87
+#: Gtk/RsyncLogBox.vala:87 Gtk/RestoreWindow.vala:109
 #, fuzzy
 msgid "Confirm Actions"
 msgstr "Lahjoitukset"
@@ -475,7 +460,7 @@ msgstr "Jatketaanko palautusta (y/n): "
 msgid "Could not find device"
 msgstr "Laitetta ei löytynyt"
 
-#: Utility/Device.vala:1175
+#: Utility/Device.vala:1187
 #, c-format
 msgid "Could not find file"
 msgstr "Tiedostoa ei löytynyt"
@@ -484,15 +469,15 @@ msgstr "Tiedostoa ei löytynyt"
 msgid "Could not find snapshot"
 msgstr "Tilannekuvaa ei löytynyt"
 
-#: Core/Main.vala:2913
+#: Core/Main.vala:2946
 msgid "Could not find system subvolume"
 msgstr "Ei löydetty järjestelmän alitaltiota"
 
-#: Core/Main.vala:2941
+#: Core/Main.vala:2974
 msgid "Could not find system subvolumes for creating pre-restore snapshot"
-msgstr ""
+msgstr "Ei löydetty järjestelmän alitaltioita esipalautusvedoksen luomiseen."
 
-#: Gtk/MainWindow.vala:141 Gtk/RsyncLogBox.vala:366 Gtk/RsyncLogBox.vala:571
+#: Gtk/RsyncLogBox.vala:366 Gtk/RsyncLogBox.vala:571 Gtk/MainWindow.vala:141
 #, c-format
 msgid "Create"
 msgstr "Luo"
@@ -501,23 +486,23 @@ msgstr "Luo"
 msgid "Create Snapshot"
 msgstr "Luo tilannekuva"
 
-#: Gtk/ScheduleBox.vala:134
+#: Gtk/ScheduleBox.vala:136
 msgid "Create one per boot"
 msgstr "Luo yksi käynnistättäessä"
 
-#: Gtk/ScheduleBox.vala:98
+#: Gtk/ScheduleBox.vala:100
 msgid "Create one per day"
 msgstr "Luo yksi päivässä"
 
-#: Gtk/ScheduleBox.vala:116
+#: Gtk/ScheduleBox.vala:118
 msgid "Create one per hour"
 msgstr "Luo yksi tunnissa"
 
-#: Gtk/ScheduleBox.vala:62
+#: Gtk/ScheduleBox.vala:64
 msgid "Create one per month"
 msgstr "Luo yksi kuukaudessa"
 
-#: Gtk/ScheduleBox.vala:80
+#: Gtk/ScheduleBox.vala:82
 msgid "Create one per week"
 msgstr "Luo yksi viikossa"
 
@@ -542,32 +527,33 @@ msgstr ""
 "järjestelmäsi suojaamiseen"
 
 #: Gtk/SnapshotBackendBox.vala:95
-msgid "Create snapshots using RSYNC"
+#, fuzzy
+msgid "Create snapshots using BTRFS"
 msgstr "Luo tilannekuvia käyttäen RSYNC"
 
 #: Gtk/SnapshotBackendBox.vala:78
 msgid "Create snapshots using RSYNC tool and hard-links"
-msgstr ""
+msgstr "Luo vedoksia käyttäen RSYNC–työkalua ja kiinteitä linkkejä"
 
-#: Gtk/RestoreBox.vala:123 Gtk/BackupBox.vala:85 Gtk/RsyncLogBox.vala:366
-#: Gtk/RsyncLogBox.vala:571 Gtk/RsyncLogBox.vala:592
+#: Gtk/RsyncLogBox.vala:366 Gtk/RsyncLogBox.vala:571 Gtk/RsyncLogBox.vala:592
+#: Gtk/RestoreBox.vala:123 Gtk/BackupBox.vala:85
 #, c-format
 msgid "Created"
 msgstr "Luotu"
 
-#: Core/Snapshot.vala:416
+#: Core/Snapshot.vala:430
 msgid "Created control file"
 msgstr "Luotu hallintatiedosto"
 
-#: Utility/TeeJee.FileSystem.vala:325
+#: Utility/TeeJee.FileSystem.vala:351
 msgid "Created directory"
 msgstr "Luotu hakemisto"
 
-#: Core/Main.vala:2963
+#: Core/Main.vala:2996
 msgid "Created pre-restore snapshot"
 msgstr "Luotu ennen-palautusta tilannekuva"
 
-#: Core/Main.vala:1445
+#: Core/Main.vala:1499
 msgid "Created subvolume snapshot"
 msgstr "Luotu alitaltioiden tilannekuva"
 
@@ -575,23 +561,23 @@ msgstr "Luotu alitaltioiden tilannekuva"
 msgid "Creating Snapshot..."
 msgstr "Luodaan tilannekuvaa..."
 
-#: Core/Main.vala:1399
+#: Core/Main.vala:1437
 msgid "Creating new backup..."
 msgstr "Luodaan uutta varmuuskopiota..."
 
-#: Core/Main.vala:1245
+#: Core/Main.vala:1283
 msgid "Creating new snapshot..."
 msgstr "Luodaan uutta tilannekuvaa..."
 
-#: Core/Main.vala:2891
+#: Core/Main.vala:2924
 msgid "Creating pre-restore snapshot from system subvolumes..."
 msgstr "Luodaan palautusta edeltävä tilannekuva järjestelmän alitaltioista..."
 
-#: Utility/Gtk/AboutWindow.vala:321 Utility/Gtk/AboutWindow.vala:382
+#: Utility/Gtk/AboutWindow.vala:321 Utility/Gtk/AboutWindow.vala:387
 msgid "Credits"
 msgstr "Kiitokset"
 
-#: Core/Main.vala:3472
+#: Core/Main.vala:3518
 msgid "Critical Error"
 msgstr "Kriittinen virhe"
 
@@ -607,25 +593,25 @@ msgstr "Cron–työ poistettu"
 msgid "Cron task exists"
 msgstr "Cron–työ on olemassa"
 
-#: Gtk/ScheduleBox.vala:98 Gtk/SnapshotListBox.vala:280
+#: Gtk/ScheduleBox.vala:100 Gtk/SnapshotListBox.vala:300
 msgid "Daily"
 msgstr "Päivittäinen"
 
-#: Core/Main.vala:1039
+#: Core/Main.vala:1077
 msgid "Daily snapshot failed!"
 msgstr "Päivittäinen tilannekuva epäonnistui!"
 
-#: Core/Main.vala:1020
+#: Core/Main.vala:1058
 msgid "Daily snapshots are enabled"
 msgstr "Päivittäiset tilannekuvat ovat käytössä"
 
-#: Core/Main.vala:2057
+#: Core/Main.vala:2111
 msgid "Data will be modified on following devices:"
 msgstr "Dataa muokataan seuraavilla laitteilla:"
 
-#: Console/AppConsole.vala:370 Gtk/MainWindow.vala:161
-#: Gtk/SnapshotListBox.vala:302 Gtk/DeleteWindow.vala:96
-#: Gtk/RsyncLogBox.vala:370 Gtk/RsyncLogBox.vala:575
+#: Console/AppConsole.vala:370 Gtk/RsyncLogBox.vala:370
+#: Gtk/RsyncLogBox.vala:575 Gtk/MainWindow.vala:161
+#: Gtk/SnapshotListBox.vala:322 Gtk/DeleteWindow.vala:98
 #, c-format
 msgid "Delete"
 msgstr "Poista"
@@ -646,29 +632,27 @@ msgstr "Poista valitut tilannekuvat"
 msgid "Delete snapshot"
 msgstr "Poista tilannekuva"
 
-#: Gtk/RestoreBox.vala:124 Gtk/BackupBox.vala:86 Gtk/RsyncLogBox.vala:370
-#: Gtk/RsyncLogBox.vala:575 Gtk/RsyncLogBox.vala:596
+#: Gtk/RsyncLogBox.vala:370 Gtk/RsyncLogBox.vala:575 Gtk/RsyncLogBox.vala:596
+#: Gtk/RestoreBox.vala:124 Gtk/BackupBox.vala:86
 #, c-format
 msgid "Deleted"
 msgstr "Poistettu"
 
-#: Utility/TeeJee.FileSystem.vala:355
+#: Utility/TeeJee.FileSystem.vala:381
 msgid "Deleted directory"
 msgstr "Poistettu hakemisto"
 
-#: Core/Subvolume.vala:129
+#: Core/Subvolume.vala:154 Core/Main.vala:2903 Core/Main.vala:2907
+#, c-format
 msgid "Deleted subvolume"
 msgstr "Poistettu alitaltio"
-
-#: Core/Main.vala:2871 Core/Main.vala:2874
-msgid "Deleted system subvolumes"
-msgstr "Poistetut järjestelmän alitaltiot"
 
 #: Gtk/DeleteBox.vala:58
 msgid "Deleting Snapshots..."
 msgstr "Poistetaan tilannekuvia..."
 
-#: Core/Subvolume.vala:116
+#: Core/Subvolume.vala:141
+#, c-format
 msgid "Deleting subvolume"
 msgstr "Poistetaan alitaltiota"
 
@@ -680,32 +664,34 @@ msgstr "Deluge, Transmission"
 msgid "Description"
 msgstr "Kuvaus"
 
-#: Core/Subvolume.vala:143
+#: Core/Subvolume.vala:168
+#, c-format
 msgid "Destroyed qgroup"
 msgstr "Tuhottu qgroup"
 
-#: Core/Subvolume.vala:133
+#: Core/Subvolume.vala:158
+#, c-format
 msgid "Destroying qgroup"
 msgstr "Tuhotaan qgroup"
 
-#: Core/SnapshotRepo.vala:72 Core/SnapshotRepo.vala:665
-#: Core/SnapshotRepo.vala:668 Core/Main.vala:2060 Core/Main.vala:2088
+#: Utility/Device.vala:1810 Utility/Device.vala:1820
 #: Console/AppConsole.vala:454 Console/AppConsole.vala:493
-#: Console/AppConsole.vala:541 Gtk/RestoreDeviceBox.vala:97
-#: Utility/Device.vala:1798 Utility/Device.vala:1808
+#: Console/AppConsole.vala:541 Core/SnapshotRepo.vala:76
+#: Core/SnapshotRepo.vala:683 Core/SnapshotRepo.vala:686 Core/Main.vala:2114
+#: Core/Main.vala:2146 Gtk/RestoreDeviceBox.vala:97
 #, c-format
 msgid "Device"
 msgstr "Laite"
 
-#: Utility/Device.vala:1257
+#: Utility/Device.vala:1269
 msgid "Device is unlocked"
 msgstr "Laite on lukitsematon"
 
-#: Utility/Device.vala:1152 Utility/Device.vala:1214
+#: Utility/Device.vala:1164 Utility/Device.vala:1226
 msgid "Device name is empty!"
 msgstr "Laitteen nimi on tyhjä!"
 
-#: Core/SnapshotRepo.vala:542 Core/Main.vala:3188 Console/AppConsole.vala:663
+#: Console/AppConsole.vala:663 Core/SnapshotRepo.vala:560 Core/Main.vala:3232
 msgid "Device not found"
 msgstr "Laitetta ei löytynyt"
 
@@ -762,15 +748,15 @@ msgstr ""
 "Tony George\n"
 "(teejeetech@gmail.com)"
 
-#: Utility/TeeJee.FileSystem.vala:492
+#: Utility/TeeJee.FileSystem.vala:518
 msgid "Dir not found"
 msgstr "Hakemistoa ei löydy"
 
-#: Core/SnapshotRepo.vala:964
+#: Core/SnapshotRepo.vala:982
 msgid "Directory not found"
 msgstr "Hakemistoa ei löydy"
 
-#: Core/Main.vala:2145 Gtk/RestoreSummaryBox.vala:64
+#: Core/Main.vala:2206 Gtk/RestoreSummaryBox.vala:64
 msgid "Disclaimer"
 msgstr "Huomautus"
 
@@ -778,16 +764,16 @@ msgstr "Huomautus"
 msgid "Disk"
 msgstr "Levy"
 
-#: Core/Main.vala:223
+#: Core/Main.vala:226
 msgid "Distribution"
 msgstr "Jakeluversio"
 
-#: Utility/Gtk/AboutWindow.vala:444
+#: Utility/Gtk/AboutWindow.vala:449
 #, fuzzy
 msgid "Documentation"
 msgstr "Lahjoitukset"
 
-#: Gtk/MainWindow.vala:388 Utility/Gtk/DonationWindow.vala:42
+#: Utility/Gtk/DonationWindow.vala:42 Gtk/MainWindow.vala:388
 msgid "Donate"
 msgstr "Lahjoita"
 
@@ -795,27 +781,27 @@ msgstr "Lahjoita"
 msgid "Donate with PayPal"
 msgstr "Lahjoita PayPal:lla"
 
-#: Utility/Gtk/AboutWindow.vala:460
+#: Utility/Gtk/AboutWindow.vala:465
 msgid "Donations"
 msgstr "Lahjoitukset"
 
-#: Gtk/ExcludeBox.vala:267
-msgid "Editing and Re-Ordering"
-msgstr "Muokkaus ja uudelleen järjestely"
+#: Gtk/UsersBox.vala:357
+msgid "Enable BTRFS qgroups (recommended)"
+msgstr ""
 
 #: Gtk/MainWindow.vala:1068
 msgid "Enable scheduled snapshots to protect your system"
 msgstr "Ota ajastetut tilannekuvat käyttöön suojataksesi järjestelmääsi"
 
-#: Core/Main.vala:3975 Core/Main.vala:4013
+#: Core/Main.vala:4030 Core/Main.vala:4070
 msgid "Enabled subvolume quota support"
 msgstr "Alitaltion kiintiötuki käytössä"
 
-#: Utility/Device.vala:1321
+#: Utility/Device.vala:1333
 msgid "Encrypted Device"
 msgstr "Salattu laite"
 
-#: Gtk/UsersBox.vala:229
+#: Gtk/UsersBox.vala:236
 msgid "Encrypted Home Directory"
 msgstr "Salattu kotihakemisto"
 
@@ -829,7 +815,7 @@ msgstr "Syötä laitteen nimi tai numero"
 msgid "Enter device name or number (a=Abort)"
 msgstr "Syötä laitteen nimi tai numero (a=Peru)"
 
-#: Utility/Device.vala:1322
+#: Utility/Device.vala:1334
 #, c-format
 msgid "Enter passphrase to unlock '%s'"
 msgstr "Syötä salauslause avataksesi '%s'"
@@ -843,19 +829,19 @@ msgstr "Syötä polku tai selaa hakemistoja"
 msgid "Enter snapshot number (a=Abort, p=Previous, n=Next)"
 msgstr "Syötä tilannekuvan numero (a=Peru, p=Edellinen, n=Seuraava)"
 
-#: Gtk/ExcludeBox.vala:232
+#: Gtk/ExcludeBox.vala:225
 msgid "Enter the pattern to exclude (Ex: *.mp3, *.bak)"
 msgstr "Syötä hävitettävä kaava (Esim: *.mp3, *.bak)"
 
-#: Gtk/RestoreDeviceBox.vala:534 Utility/GtkHelper.vala:18
+#: Utility/GtkHelper.vala:18 Gtk/RestoreDeviceBox.vala:534
 msgid "Error"
 msgstr "Virhe"
 
-#: Gtk/RestoreWindow.vala:464
+#: Gtk/RestoreWindow.vala:488
 msgid "Error running Rsync"
 msgstr ""
 
-#: Gtk/SetupWizardWindow.vala:95 Gtk/BackupWindow.vala:79
+#: Gtk/SetupWizardWindow.vala:99 Gtk/BackupWindow.vala:81
 msgid "Estimate"
 msgstr "Arvio"
 
@@ -863,7 +849,7 @@ msgstr "Arvio"
 msgid "Estimating System Size..."
 msgstr "Arvioidaan järjestelmän kokoa..."
 
-#: Core/Main.vala:1241
+#: Core/Main.vala:1279
 msgid "Estimating system size..."
 msgstr "Arvioidaan järjestelmän kokoa..."
 
@@ -871,16 +857,16 @@ msgstr "Arvioidaan järjestelmän kokoa..."
 msgid "Examples"
 msgstr "Esimerkit"
 
-#: Gtk/UsersBox.vala:129
+#: Gtk/UsersBox.vala:136
 #, fuzzy
 msgid "Exclude All"
 msgstr "Älä sisällytä sovelluksia"
 
-#: Gtk/RestoreExcludeBox.vala:55 Gtk/ExcludeAppsBox.vala:51
+#: Gtk/ExcludeAppsBox.vala:51 Gtk/RestoreExcludeBox.vala:55
 msgid "Exclude Application Settings"
 msgstr "Älä sisällytä sovellusten asetuksia"
 
-#: Gtk/RestoreWindow.vala:96
+#: Gtk/RestoreWindow.vala:99
 msgid "Exclude Apps"
 msgstr "Älä sisällytä sovelluksia"
 
@@ -892,7 +878,7 @@ msgstr "Poisto lista"
 msgid "Exclude List Summary"
 msgstr "Poista yhteenveto"
 
-#: Gtk/ExcludeBox.vala:231
+#: Gtk/ExcludeBox.vala:224
 msgid "Exclude Pattern"
 msgstr "Sulje kaava"
 
@@ -900,7 +886,7 @@ msgstr "Sulje kaava"
 msgid "Excluded Directories"
 msgstr "Poistetut hakemistot"
 
-#: Core/Main.vala:1513
+#: Core/Main.vala:1567
 msgid "Expected values: O, B, H, D, W, M"
 msgstr "Odotetut arvot: O, B, H, D, W, M"
 
@@ -912,27 +898,27 @@ msgstr "Cron–työn lisääminen epäonnistui"
 msgid "Failed to copy file"
 msgstr "Tiedoston kopiointi epäonnistui"
 
-#: Utility/TeeJee.FileSystem.vala:328 Utility/TeeJee.FileSystem.vala:336
+#: Utility/TeeJee.FileSystem.vala:354 Utility/TeeJee.FileSystem.vala:362
 msgid "Failed to create directory"
 msgstr "Hakemistoa ei voitu luoda"
 
-#: Core/Main.vala:1367
+#: Core/Main.vala:1405
 msgid "Failed to create new snapshot"
 msgstr "Uuden tilannekuvan luominen epäonnistui"
 
-#: Core/Main.vala:1217
+#: Core/Main.vala:1255
 msgid "Failed to create snapshot"
 msgstr "Tilannekuvan luominen epäonnistui"
 
-#: Core/Main.vala:1441
+#: Core/Main.vala:1495
 msgid "Failed to create subvolume snapshot"
 msgstr "Ei onnistuttu luomaan alitaltion tilannekuvaa"
 
-#: Core/SnapshotRepo.vala:1005
+#: Core/SnapshotRepo.vala:1023
 msgid "Failed to create symlinks"
 msgstr "Ei onnistuttu luomaan symbolisia linkkejä"
 
-#: Utility/TeeJee.FileSystem.vala:358
+#: Utility/TeeJee.FileSystem.vala:384
 msgid "Failed to delete directory"
 msgstr "Hakemiston poistaminen epäonnistui"
 
@@ -940,23 +926,23 @@ msgstr "Hakemiston poistaminen epäonnistui"
 msgid "Failed to delete file"
 msgstr "Tiedoston poistaminen epäonnistui"
 
-#: Core/Subvolume.vala:125
+#: Core/Subvolume.vala:150
 msgid "Failed to delete snapshot subvolume"
 msgstr "Ei onnistuttu poistamaan tilannekuvan alitaltiota"
 
-#: Core/SnapshotRepo.vala:1031
+#: Core/SnapshotRepo.vala:1049
 msgid "Failed to delete symlinks"
 msgstr "Ei onnistuttu poistamaan symbolisia linkkejä"
 
-#: Core/Subvolume.vala:139
+#: Core/Subvolume.vala:164
 msgid "Failed to destroy qgroup"
 msgstr "Ei onnistuttu tuhoamaan qroup:a"
 
-#: Core/Main.vala:3998
+#: Core/Main.vala:4055
 msgid "Failed to enable subvolume quota"
 msgstr "Ei onnistuttu ottamaan käyttöön alitaltioiden kiintiötä"
 
-#: Core/Main.vala:3687 Core/Main.vala:3693
+#: Core/Main.vala:3733 Core/Main.vala:3739
 msgid "Failed to estimate system size"
 msgstr "Järjestelmän koon arviointi epäonnistui"
 
@@ -974,7 +960,7 @@ msgstr "Ei onnistuttu saamaan syötettä käyttäjältä 3:lla yrityksellä"
 msgid "Failed to get partition list"
 msgstr "Osiolistaa ei saatu"
 
-#: Core/Main.vala:3271
+#: Core/Main.vala:3315
 msgid "Failed to get partition list."
 msgstr "Osiolistaa ei saatu."
 
@@ -990,16 +976,16 @@ msgstr "Laitteiden liittäminen epäonnistui"
 msgid "Failed to move file"
 msgstr "Tiedoston siirto epäonnistui"
 
-#: Core/Main.vala:2928
+#: Core/Main.vala:2961
 msgid "Failed to move system subvolume to snapshot directory"
 msgstr ""
 "Ei onnistuttu siirtämään järjestelmän alitaltiota tilannekuvahakemistoon"
 
-#: Core/Main.vala:3811
+#: Core/Main.vala:3863
 msgid "Failed to query subvolume list"
 msgstr "Ei onnistuttu tiedustelemaan alitaltioluetteloa"
 
-#: Core/Main.vala:3895
+#: Core/Main.vala:3947
 msgid "Failed to query subvolume quota"
 msgstr "Ei onnistuttu tiedustelemaan alitaltiokiintiötä"
 
@@ -1011,7 +997,7 @@ msgstr "Crontab:n lukeminen epäonnistui"
 msgid "Failed to read file"
 msgstr "Tiedoston lukeminen epäonnistui"
 
-#: Core/SnapshotRepo.vala:951
+#: Core/SnapshotRepo.vala:969
 msgid "Failed to remove"
 msgstr "Poisto epäonnistui"
 
@@ -1019,32 +1005,32 @@ msgstr "Poisto epäonnistui"
 msgid "Failed to remove cron job"
 msgstr "Cron–työn poisto epäonnistui"
 
-#: Core/Snapshot.vala:503 Core/Snapshot.vala:515 Core/Snapshot.vala:523
+#: Core/Snapshot.vala:530 Core/Snapshot.vala:542 Core/Snapshot.vala:550
 msgid "Failed to remove snapshot"
 msgstr "Tilannekuvan poisto epäonnistui"
 
-#: Core/Main.vala:4037
+#: Core/Main.vala:4094
 msgid "Failed to rescan subvolume quota"
 msgstr "Ei onnistuttu skannaamaan uudelleen alitaltiokiintiötä"
 
-#: Core/Main.vala:2808
+#: Core/Subvolume.vala:202
 msgid "Failed to restore system subvolume"
 msgstr "Ei onnistuttu palauttamaan järjestelmän alitaltiota"
 
-#: Core/Main.vala:1317
+#: Core/Main.vala:1355
 msgid "Failed to save exclude list"
 msgstr "Poisjätettyjen listan tallentaminen epäonnistui"
 
-#: Utility/Device.vala:1248 Utility/Device.vala:1302 Utility/Device.vala:1327
-#: Utility/Device.vala:1348 Utility/Device.vala:1368
+#: Utility/Device.vala:1260 Utility/Device.vala:1314 Utility/Device.vala:1339
+#: Utility/Device.vala:1360 Utility/Device.vala:1380
 msgid "Failed to unlock device"
 msgstr "Laitteen avaaminen epäonnistui"
 
-#: Utility/Device.vala:1599
+#: Utility/Device.vala:1611
 msgid "Failed to unmount"
 msgstr "Irrottaminen epäonnistui"
 
-#: Core/Main.vala:3473
+#: Core/Main.vala:3519
 msgid "Failed to unmount device!"
 msgstr "Laitteen irrottaminen epäonnistui!"
 
@@ -1070,12 +1056,12 @@ msgstr "Tiedostokaava"
 msgid "File and directory counts:"
 msgstr "Tiedosto– ja hakemistomäärät:"
 
-#: Utility/TeeJee.FileSystem.vala:645 Utility/TeeJee.FileSystem.vala:694
+#: Utility/TeeJee.FileSystem.vala:671 Utility/TeeJee.FileSystem.vala:720
 msgid "File is missing"
 msgstr "Tiedosto puuttuu"
 
+#: Utility/TeeJee.FileSystem.vala:205 Utility/TeeJee.FileSystem.vala:547
 #: Utility/CronTab.vala:225 Utility/RsyncTask.vala:296
-#: Utility/TeeJee.FileSystem.vala:205 Utility/TeeJee.FileSystem.vala:521
 msgid "File not found"
 msgstr "Tiedostoa ei löydy"
 
@@ -1084,8 +1070,11 @@ msgid ""
 "Files &amp; directories matching the patterns below will be excluded. "
 "Patterns starting with a + will include the item instead of excluding."
 msgstr ""
+"Tiedostoja &amp; hakemistoja jotka täsmäävät seuraaviin kaavoihin alla ei "
+"sisällytetä. Kaavat jotka alkavat + sisällyttävät kohteen pois jättämisen "
+"sijaan."
 
-#: Gtk/SnapshotBackendBox.vala:187
+#: Gtk/SnapshotBackendBox.vala:192
 msgid "Files and directories can be excluded to save disk space."
 msgstr "Tiedostoja ja hakemistoja voidaan jättää pois levytilan säästämiseksi."
 
@@ -1097,7 +1086,7 @@ msgstr "Tiedostojen ja hakemistojen määrät:"
 msgid "Files matching the following patterns will be excluded"
 msgstr "Seuraavaan kaavaan sopivat tiedostot jätetään pois"
 
-#: Utility/Device.vala:1816
+#: Utility/Device.vala:1828
 #, c-format
 msgid "Filesystem"
 msgstr "Tiedostojärjestelmä"
@@ -1106,16 +1095,16 @@ msgstr "Tiedostojärjestelmä"
 msgid "Filter by name or path"
 msgstr ""
 
-#: Gtk/SettingsWindow.vala:111
+#: Gtk/SettingsWindow.vala:100
 msgid "Filters"
 msgstr "Suodattimet"
 
-#: Gtk/SetupWizardWindow.vala:195 Gtk/BackupWindow.vala:94
-#: Gtk/DeleteWindow.vala:101
+#: Gtk/SetupWizardWindow.vala:205 Gtk/BackupWindow.vala:96
+#: Gtk/DeleteWindow.vala:103
 msgid "Finish"
 msgstr "Valmis"
 
-#: Gtk/SetupWizardWindow.vala:110 Gtk/RestoreWindow.vala:121
+#: Gtk/SetupWizardWindow.vala:120 Gtk/RestoreWindow.vala:130
 msgid "Finished"
 msgstr "Valmistui"
 
@@ -1123,19 +1112,19 @@ msgstr "Valmistui"
 msgid "Firefox, Chromium, Chrome, Opera, Epiphany, Midori"
 msgstr "Firefox, Chromium, Chrome, Opera, Epiphany, Midori"
 
-#: Core/SnapshotRepo.vala:649
+#: Core/SnapshotRepo.vala:667
 msgid "First snapshot requires:"
 msgstr "Ensimmäinen tilannekuva vaatii:"
 
-#: Core/Main.vala:2861
+#: Core/Main.vala:2894
 msgid "Found existing pre-restore snapshot"
-msgstr ""
+msgstr "Löydettiin olemassa oleva esipalautusvedos"
 
 #: Gtk/BackupDeviceBox.vala:215
 msgid "Free"
 msgstr "Vapaana"
 
-#: Core/SnapshotRepo.vala:73 Core/SnapshotRepo.vala:141
+#: Core/SnapshotRepo.vala:77 Core/SnapshotRepo.vala:147
 msgid "Free space"
 msgstr "Vapaata tilaa"
 
@@ -1151,7 +1140,7 @@ msgstr "GRUB–laitetta ei ole valittu"
 msgid "GRUB will NOT be reinstalled"
 msgstr "GRUB:a EI asenneta uudelleen"
 
-#: Core/Main.vala:2287
+#: Core/Main.vala:2348
 msgid "Generating initramfs..."
 msgstr "Luodaan intramfs..."
 
@@ -1159,7 +1148,7 @@ msgstr "Luodaan intramfs..."
 msgid "Global"
 msgstr "Globaali"
 
-#: Gtk/RestoreBox.vala:135 Gtk/BackupBox.vala:97 Gtk/RsyncLogBox.vala:400
+#: Gtk/RsyncLogBox.vala:400 Gtk/RestoreBox.vala:135 Gtk/BackupBox.vala:97
 #, c-format
 msgid "Group"
 msgstr "Ryhmä"
@@ -1172,7 +1161,7 @@ msgstr ""
 "Piilotetut tiedostot ja hakemistot sisältyvät oletusarvoisesti, koska ne "
 "sisältävät käyttäjäkohtaisia asetustiedostoja."
 
-#: Gtk/DeleteWindow.vala:176
+#: Gtk/DeleteWindow.vala:178
 msgid "Hide"
 msgstr "Piilota"
 
@@ -1180,11 +1169,11 @@ msgstr "Piilota"
 msgid "Hide rsync output"
 msgstr "Piilota rsync tuloste"
 
-#: Gtk/DeleteWindow.vala:177
+#: Gtk/DeleteWindow.vala:179
 msgid "Hide this window (files will be deleted in background)"
 msgstr "Piilota tämä ikkuna (tiedostot poistetaan taustalla)"
 
-#: Gtk/UsersBox.vala:113
+#: Gtk/UsersBox.vala:120
 msgid "Home"
 msgstr "Koti"
 
@@ -1192,19 +1181,19 @@ msgstr "Koti"
 msgid "Home Directory"
 msgstr "Kotihakemisto"
 
-#: Gtk/ScheduleBox.vala:116 Gtk/SnapshotListBox.vala:279
+#: Gtk/ScheduleBox.vala:118 Gtk/SnapshotListBox.vala:299
 msgid "Hourly"
 msgstr "Tunneittain"
 
-#: Core/Main.vala:1009
+#: Core/Main.vala:1047
 msgid "Hourly snapshot failed!"
 msgstr "Tunnittainen tilannekuva epäonnistui!"
 
-#: Core/Main.vala:990
+#: Core/Main.vala:1028
 msgid "Hourly snapshots are enabled"
 msgstr "Tunnittaiset tilannekuvat ovat käytössä"
 
-#: Utility/Gtk/AboutWindow.vala:452
+#: Utility/Gtk/AboutWindow.vala:457
 msgid "Icon Themes & Utilities"
 msgstr ""
 
@@ -1216,35 +1205,31 @@ msgstr ""
 "Jos palautetun järjestelmän käynnistys epäonnistuu, käynnistä Live CD/USB, "
 "asenna Timeshift ja yritä palauttamalla toinen tilannekuva."
 
-#: Core/Main.vala:2151
+#: Core/Main.vala:2212
 msgid ""
 "If these terms are not acceptable to you, please do not proceed beyond this "
 "point!"
 msgstr "Jos et hyväksy ehtoja, älä jatka pidemmälle!"
 
-#: Gtk/ExcludeBox.vala:53
+#: Gtk/ExcludeBox.vala:54
 msgid "Include / Exclude Patterns"
 msgstr "Sisällyksen / poisjätön kaavat"
 
-#: Gtk/UsersBox.vala:320
+#: Gtk/UsersBox.vala:340
 msgid "Include @home subvolume in backups"
-msgstr ""
+msgstr "Sisällytä @home alitaltio varmuuskopioihin"
 
-#: Gtk/UsersBox.vala:259
+#: Gtk/UsersBox.vala:266
 #, fuzzy
 msgid "Include All"
 msgstr "Älä sisällytä sovelluksia"
 
-#: Gtk/UsersBox.vala:187
+#: Gtk/UsersBox.vala:194
 #, fuzzy
 msgid "Include Hidden"
 msgstr "Sisällytä piilotetut kohteet"
 
-#: Gtk/ExcludeBox.vala:265
-msgid "Info"
-msgstr "Tietoja"
-
-#: Core/Main.vala:1972
+#: Core/Main.vala:2026
 msgid "Invalid Snapshot"
 msgstr "Virheellinen tilannekuva"
 
@@ -1260,12 +1245,14 @@ msgstr "Virheellinen tilannekuva"
 #: Utility/Gtk/DonationWindow.vala:97
 msgid "Issue Tracker ~ Report Issues, Request Features, Ask Questions"
 msgstr ""
+"Ongelmien jäljitin - Raportoi ongelmista, pyydä ominaisuuksia, kysy "
+"kysymyksiä"
 
-#: Gtk/ExcludeBox.vala:281
+#: Gtk/ExcludeBox.vala:272
 msgid "Items Not Selected"
 msgstr "Kohteita ei valittuna"
 
-#: Gtk/ScheduleBox.vala:269
+#: Gtk/ScheduleBox.vala:283
 msgid "Keep"
 msgstr "Pidä"
 
@@ -1295,80 +1282,80 @@ msgstr "Pidä juurilaitteella"
 msgid "Keep this mount path on the root filesystem"
 msgstr "Pidä tämä liitospolku juuritiedostojärjestelmällä"
 
-#: Gtk/SnapshotListBox.vala:486
+#: Gtk/SnapshotListBox.vala:519
 msgid "LIVE"
 msgstr "LIVE"
 
-#: Console/AppConsole.vala:458 Console/AppConsole.vala:497
-#: Gtk/BackupDeviceBox.vala:254 Utility/Device.vala:1817
+#: Utility/Device.vala:1829 Console/AppConsole.vala:458
+#: Console/AppConsole.vala:497 Gtk/BackupDeviceBox.vala:254
 #, c-format
 msgid "Label"
-msgstr ""
+msgstr "Tunniste"
 
-#: Core/Main.vala:972
+#: Core/Main.vala:1010
 #, c-format
 msgid "Last boot snapshot is %d hours old"
 msgstr "Viimeisin käynnistyksen tilannekuva on %d tuntia vanha"
 
-#: Core/Main.vala:967
+#: Core/Main.vala:1005
 msgid "Last boot snapshot is older than system start time"
 msgstr ""
 "Viimeisin käynnistyksen tilannekuva on vanhempi kuin järjestelmän "
 "käynnistysaika"
 
-#: Core/Main.vala:963
+#: Core/Main.vala:1001
 msgid "Last boot snapshot not found"
 msgstr "Viimeisintä käynnistyksen tilannekuvaa ei löydy"
 
-#: Core/Main.vala:1032
+#: Core/Main.vala:1070
 #, c-format
 msgid "Last daily snapshot is %d hours old"
 msgstr "Viimeisin päivittäinen tilannekuva on %d tuntia vanha"
 
-#: Core/Main.vala:1027
+#: Core/Main.vala:1065
 msgid "Last daily snapshot is more than 1 day old"
 msgstr "Viimeisin päivittäinen tilannekuva on yli 1 päivää vanhempi"
 
-#: Core/Main.vala:1023
+#: Core/Main.vala:1061
 msgid "Last daily snapshot not found"
 msgstr "Viimeisintä päivittäistä tilannekuvaa ei löydy"
 
-#: Core/Main.vala:1002
+#: Core/Main.vala:1040
 #, c-format
 msgid "Last hourly snapshot is %d minutes old"
 msgstr "Viimeisin tunneittainen tilannekuva on %d minuuttia vanha"
 
-#: Core/Main.vala:997
+#: Core/Main.vala:1035
 msgid "Last hourly snapshot is more than 1 hour old"
 msgstr "Viimeisin tunnittainen tilannekuva on yli 1 päivää vanhempi"
 
-#: Core/Main.vala:993
+#: Core/Main.vala:1031
 msgid "Last hourly snapshot not found"
 msgstr "Viimeistä tunnittaista tilannekuvaa ei löydy"
 
-#: Core/Main.vala:1092
+#: Core/Main.vala:1130
 #, c-format
 msgid "Last monthly snapshot is %d days old"
 msgstr "Edellinen kuukausittainen tilannekuva on %d päivää vanha"
 
-#: Core/Main.vala:1087
+#: Core/Main.vala:1125
 msgid "Last monthly snapshot is more than 1 month old"
 msgstr "Edellinen kuukausittainen tilannekuva on 1 kuukautta vanhempi"
 
-#: Core/Main.vala:1083
+#: Core/Main.vala:1121
 msgid "Last monthly snapshot not found"
 msgstr "Edellistä kuukausittaista tilannekuvaa ei löydy"
 
-#: Core/Main.vala:1062
+#: Core/Main.vala:1100
 #, c-format
 msgid "Last weekly snapshot is %d days old"
 msgstr "Edellinen viikoittainen tilannekuva on %d päivää vanha"
 
-#: Core/Main.vala:1057
+#: Core/Main.vala:1095
 msgid "Last weekly snapshot is more than 1 week old"
 msgstr "Edellisen viikottaisen tilannekuva on yli 1 viikkoa vanhempi"
 
-#: Core/Main.vala:1053
+#: Core/Main.vala:1091
 msgid "Last weekly snapshot not found"
 msgstr "Edellisen viikottoisen tilannekuvaa ei löydy"
 
@@ -1377,11 +1364,11 @@ msgstr "Edellisen viikottoisen tilannekuvaa ei löydy"
 msgid "Latest snapshot"
 msgstr "Viimeisin tilannekuva"
 
-#: Utility/Gtk/AboutWindow.vala:316 Utility/Gtk/AboutWindow.vala:351
+#: Utility/Gtk/AboutWindow.vala:316 Utility/Gtk/AboutWindow.vala:356
 msgid "License"
 msgstr ""
 
-#: Core/Main.vala:1306
+#: Core/Main.vala:1344
 #, c-format
 msgid "Linking from snapshot"
 msgstr "Linkitetään tilannekuvasta"
@@ -1402,8 +1389,8 @@ msgstr "Listaa tilannekuvat"
 msgid "Live USB Mode (Restore Only)"
 msgstr "Live USB tila (Ainoastaan palautus)"
 
-#: Gtk/SetupWizardWindow.vala:100 Gtk/BackupWindow.vala:84
-#: Gtk/SettingsWindow.vala:100
+#: Gtk/SetupWizardWindow.vala:104 Gtk/BackupWindow.vala:86
+#: Gtk/SettingsWindow.vala:89
 msgid "Location"
 msgstr "Sijainti"
 
@@ -1411,7 +1398,7 @@ msgstr "Sijainti"
 msgid "Main window closed by user"
 msgstr "Pääikkuna suljettiin käyttäjän toimesta"
 
-#: Gtk/SnapshotListBox.vala:309
+#: Gtk/SnapshotListBox.vala:329
 msgid "Mark for Deletion"
 msgstr "Merkitse poistettavaksi"
 
@@ -1419,45 +1406,49 @@ msgstr "Merkitse poistettavaksi"
 msgid "Marked for deletion"
 msgstr "Merkitty poistettavaksi"
 
-#: Core/SnapshotRepo.vala:693 Core/SnapshotRepo.vala:730
+#: Core/SnapshotRepo.vala:711 Core/SnapshotRepo.vala:748
 msgid "Maximum backups exceeded for backup level"
-msgstr ""
+msgstr "Maksimi varmuuskopiot ylittävät varmuuskopiointitason"
 
 #: Gtk/MainWindow.vala:208
 msgid "Menu"
 msgstr "Valikko"
 
-#: Core/Main.vala:232
+#: Gtk/UsersBox.vala:354
+msgid "Miscellaneous"
+msgstr ""
+
+#: Core/Main.vala:235
 msgid "Missing Dependencies"
 msgstr "Puuttuvia riippuvuuksia"
 
-#: Core/SnapshotRepo.vala:671
+#: Core/SnapshotRepo.vala:689
 #, c-format
 msgid "Mode"
 msgstr "Tila"
 
-#: Utility/Device.vala:1800
+#: Utility/Device.vala:1812
 #, c-format
 msgid "Model"
 msgstr "Malli"
 
-#: Gtk/ScheduleBox.vala:62 Gtk/SnapshotListBox.vala:282
+#: Gtk/ScheduleBox.vala:64 Gtk/SnapshotListBox.vala:302
 msgid "Monthly"
 msgstr "Kuukausittainen"
 
-#: Core/Main.vala:1080
+#: Core/Main.vala:1118
 msgid "Monthly snapshot are enabled"
 msgstr "Kuukausittaiset tilannekuvat käytössä"
 
-#: Core/Main.vala:1099
+#: Core/Main.vala:1137
 msgid "Monthly snapshot failed!"
 msgstr "Kuukausittainen tilannekuva epäonnistui"
 
-#: Core/Main.vala:2059 Core/Main.vala:2088
+#: Core/Main.vala:2113 Core/Main.vala:2146
 msgid "Mount"
 msgstr "Liitä"
 
-#: Core/Main.vala:2935
+#: Core/Main.vala:2968
 msgid "Moved system subvolume to snapshot directory"
 msgstr "Siirrettiin järjestelmän alitaltio tilannekuvahakemistoon"
 
@@ -1465,13 +1456,13 @@ msgstr "Siirrettiin järjestelmän alitaltio tilannekuvahakemistoon"
 msgid "Multiple snapshots selected"
 msgstr "Useita tilannekuvia valittuna"
 
-#: Console/AppConsole.vala:425 Gtk/BackupDeviceBox.vala:235
-#: Gtk/RsyncLogBox.vala:492
+#: Console/AppConsole.vala:425 Gtk/RsyncLogBox.vala:492
+#: Gtk/BackupDeviceBox.vala:235
 msgid "Name"
 msgstr "Nimi"
 
-#: Gtk/SetupWizardWindow.vala:187 Gtk/RestoreWindow.vala:187
-#: Gtk/BackupWindow.vala:158 Gtk/DeleteWindow.vala:160
+#: Gtk/SetupWizardWindow.vala:197 Gtk/BackupWindow.vala:160
+#: Gtk/DeleteWindow.vala:162 Gtk/RestoreWindow.vala:198
 msgid "Next"
 msgstr "Seuraava"
 
@@ -1483,7 +1474,7 @@ msgstr "Ei"
 msgid "No Change"
 msgstr "Ei muutosta"
 
-#: Gtk/MainWindow.vala:615 Gtk/DeleteWindow.vala:339
+#: Gtk/MainWindow.vala:615 Gtk/DeleteWindow.vala:341
 msgid "No Snapshots Selected"
 msgstr "Ei valittuja tilannekuvia"
 
@@ -1491,7 +1482,7 @@ msgstr "Ei valittuja tilannekuvia"
 msgid "No snapshots available"
 msgstr "Ei valittuja tilannekuvia saatavilla"
 
-#: Core/SnapshotRepo.vala:880 Console/AppConsole.vala:320
+#: Console/AppConsole.vala:320 Core/SnapshotRepo.vala:898
 #: Gtk/MainWindow.vala:1017
 msgid "No snapshots found"
 msgstr "Ei löydettyjä tilannekuvia"
@@ -1504,7 +1495,7 @@ msgstr "Ei löydettyjä tilannekuvia laitteella"
 msgid "No snapshots on device"
 msgstr "Ei tilannekuvia laitteella"
 
-#: Core/SnapshotRepo.vala:647
+#: Core/SnapshotRepo.vala:665
 msgid "No snapshots on this device"
 msgstr "Ei tilannekuvia tällä laitteella"
 
@@ -1516,15 +1507,20 @@ msgstr "Ei tilannekuvia valittuna"
 msgid "None"
 msgstr "Ei yhtään"
 
-#: Core/SnapshotRepo.vala:665
+#: Core/Subvolume.vala:184
+#, fuzzy, c-format
+msgid "Not Found"
+msgstr "Hakemistoa ei löydy"
+
+#: Core/SnapshotRepo.vala:683
 msgid "Not Selected"
 msgstr "Ei valittuna"
 
-#: Core/Main.vala:376
+#: Core/Main.vala:379
 msgid "Not Supported"
 msgstr "Ei tuettu"
 
-#: Core/SnapshotRepo.vala:611 Core/SnapshotRepo.vala:638
+#: Core/SnapshotRepo.vala:629 Core/SnapshotRepo.vala:656
 msgid "Not enough disk space"
 msgstr "Ei tarpeeksi levytilaa"
 
@@ -1532,7 +1528,7 @@ msgstr "Ei tarpeeksi levytilaa"
 msgid "Notes"
 msgstr "Merkinnät"
 
-#: Core/Main.vala:1109
+#: Core/Main.vala:1147
 msgid "Nothing to do!"
 msgstr "Ei tehtävää!"
 
@@ -1541,7 +1537,7 @@ msgstr "Ei tehtävää!"
 msgid "Num"
 msgstr "Num"
 
-#: Gtk/ScheduleBox.vala:268
+#: Gtk/ScheduleBox.vala:282
 msgid ""
 "Number of snapshots to keep.\n"
 "Older snapshots will be removed once this limit is exceeded."
@@ -1549,13 +1545,13 @@ msgstr ""
 "Säilytettävien tilannekuvien määrä.\n"
 "Vanhemmat tilannekuvat poistetaan, kun tämä raja ylittyy."
 
-#: Gtk/ExcludeListSummaryWindow.vala:84 Utility/GtkHelper.vala:121
-#: Utility/Gtk/CustomMessageDialog.vala:167
+#: Utility/GtkHelper.vala:121 Utility/Gtk/CustomMessageDialog.vala:167
 #: Utility/Gtk/CustomMessageDialog.vala:171
+#: Gtk/ExcludeListSummaryWindow.vala:84
 msgid "OK"
 msgstr "OK"
 
-#: Gtk/SnapshotBackendBox.vala:174
+#: Gtk/SnapshotBackendBox.vala:179
 msgid ""
 "OS must be installed on a BTRFS partition with Ubuntu-type subvolume layout "
 "(@ and @home subvolumes). Other layouts are not supported."
@@ -1563,7 +1559,7 @@ msgstr ""
 "Käyttöjärjestelmä tulee olla asennettuna BTRFS–osiolle Ubuntu–tyyppisellä "
 "alitaltioasettelulla (@ ja @home alitaltioilla). Muita asetteluja ei tueta."
 
-#: Core/Main.vala:4144
+#: Core/Main.vala:4201
 msgid "Older log files removed"
 msgstr "Vanhemmat lokitiedostot poistettu"
 
@@ -1571,24 +1567,28 @@ msgstr "Vanhemmat lokitiedostot poistettu"
 msgid "Oldest snapshot"
 msgstr "Vanhin tilannekuva"
 
-#: Gtk/SnapshotListBox.vala:277
+#: Gtk/SnapshotListBox.vala:297
 msgid "On demand (manual)"
 msgstr ""
 
-#: Core/Main.vala:374 Core/Main.vala:3386 Gtk/RestoreDeviceBox.vala:525
+#: Core/Main.vala:377 Core/Main.vala:3432 Gtk/RestoreDeviceBox.vala:525
 msgid ""
 "Only ubuntu-type layouts with @ and @home subvolumes are currently supported."
 msgstr ""
+"Vain ubuntu– tyyppisiä asetteluita @ ja @home alitaltioilla tuetaan tällä "
+"hetkellä."
 
 #: Gtk/MainWindow.vala:209
 msgid "Open Menu"
 msgstr "Avaa valikko"
 
-#: Core/Main.vala:3170
+#: Core/Main.vala:3214
 msgid ""
 "Option --snapshot-device should not be specified for creating snapshots in "
 "BTRFS mode"
 msgstr ""
+"Asetusta --snapshot-device ei tulisi määritellä vedosten luomisessa BTRFS–"
+"tilassa"
 
 #: Console/AppConsole.vala:350 Gtk/AppGtk.vala:114
 msgid "Options"
@@ -1598,17 +1598,17 @@ msgstr "Asetukset"
 msgid "Other applications (next page)"
 msgstr "Muut sovellukset (seuraava sivu)"
 
-#: Gtk/RestoreBox.vala:134 Gtk/BackupBox.vala:96 Gtk/RsyncLogBox.vala:398
+#: Gtk/RsyncLogBox.vala:398 Gtk/RestoreBox.vala:134 Gtk/BackupBox.vala:96
 #, c-format
 msgid "Owner"
 msgstr "Omistaja"
 
-#: Utility/Device.vala:1812
+#: Utility/Device.vala:1824
 #, c-format
 msgid "Parent Device"
-msgstr ""
+msgstr "Isäntälaite"
 
-#: Core/Main.vala:2408 Core/Main.vala:2499 Gtk/RsyncLogBox.vala:222
+#: Core/Main.vala:2469 Core/Main.vala:2560 Gtk/RsyncLogBox.vala:222
 msgid "Parsing log file..."
 msgstr "Kootaan lokitiedostoa..."
 
@@ -1616,29 +1616,29 @@ msgstr "Kootaan lokitiedostoa..."
 msgid "Partition has an unsupported subvolume layout."
 msgstr "Osiolla on tukematon alitaltio asettelu."
 
-#: Core/SnapshotRepo.vala:670 Gtk/RestoreDeviceBox.vala:93
+#: Core/SnapshotRepo.vala:688 Gtk/RestoreDeviceBox.vala:93
 #, c-format
 msgid "Path"
 msgstr "Polku"
 
-#: Gtk/ExcludeBox.vala:160
+#: Gtk/ExcludeBox.vala:162
 msgid "Pattern"
 msgstr "Kaava"
 
-#: Gtk/RestoreBox.vala:133 Gtk/BackupBox.vala:95 Gtk/RsyncLogBox.vala:396
+#: Gtk/RsyncLogBox.vala:396 Gtk/RestoreBox.vala:133 Gtk/BackupBox.vala:95
 #, c-format
 msgid "Permissions"
 msgstr "Luvat"
 
-#: Core/Main.vala:251
+#: Core/Main.vala:254
 msgid "Please check if you have multiple windows open."
 msgstr "Tarkasta onko sinulla useita ikkunoita avoimena."
 
-#: Core/Main.vala:2183
+#: Core/Main.vala:2244
 msgid "Please do not interrupt the restore process!"
 msgstr "Älä keskeytä palautusprosessia!"
 
-#: Core/Main.vala:345
+#: Core/Main.vala:348
 msgid "Please install required packages and try running TimeShift again"
 msgstr "Asenna tarvittavat paketit ja yritä suorittaa Timeshift uudelleen"
 
@@ -1653,7 +1653,7 @@ msgid "Please run the application as admin (using 'sudo' or 'su')"
 msgstr ""
 "Suorita sovellus pääkäyttäjänä (käyttäen komentoja kuten 'sudo' tai 'su')"
 
-#: Core/Main.vala:2133
+#: Core/Main.vala:2194
 msgid "Please save your work and close all applications."
 msgstr "Tallenna työsi ja sulje kaikki sovellukset."
 
@@ -1665,7 +1665,7 @@ msgstr "Valitse tilannekuva tarkastellaksesi lokia!"
 msgid "Please select the GRUB device"
 msgstr "Valitse GRUB–laite"
 
-#: Core/Main.vala:247
+#: Core/Main.vala:250
 msgid "Please wait a few minutes and try again."
 msgstr "Odota muutama minuutti ja yritä uudelleen."
 
@@ -1679,15 +1679,15 @@ msgstr ""
 
 #: Gtk/RsyncLogBox.vala:188
 msgid "Populating list..."
-msgstr ""
+msgstr "Kootaan listaa..."
 
-#: Core/Main.vala:1525 Gtk/RestoreBox.vala:88 Gtk/BackupBox.vala:114
-#: Gtk/DeleteBox.vala:68 Gtk/RsyncLogBox.vala:232
+#: Core/Main.vala:1579 Gtk/RsyncLogBox.vala:232 Gtk/DeleteBox.vala:68
+#: Gtk/RestoreBox.vala:88 Gtk/BackupBox.vala:114
 msgid "Preparing..."
 msgstr "Valmistellaan"
 
-#: Gtk/SetupWizardWindow.vala:179 Gtk/RestoreWindow.vala:179
-#: Gtk/BackupWindow.vala:150 Gtk/DeleteWindow.vala:152
+#: Gtk/SetupWizardWindow.vala:189 Gtk/BackupWindow.vala:152
+#: Gtk/DeleteWindow.vala:154 Gtk/RestoreWindow.vala:190
 msgid "Previous"
 msgstr "Edellinen"
 
@@ -1695,11 +1695,11 @@ msgstr "Edellinen"
 msgid "Print debug information"
 msgstr "Tulosta virheenkorjaustiedot"
 
-#: Core/Main.vala:3748
+#: Core/Main.vala:3794
 msgid "Query completed"
 msgstr "Tiedustelu valmistui"
 
-#: Core/Main.vala:3731
+#: Core/Main.vala:3777
 msgid "Querying subvolume info..."
 msgstr "Tiedustellaan alitaltion tietoja..."
 
@@ -1707,7 +1707,7 @@ msgstr "Tiedustellaan alitaltion tietoja..."
 msgid "RSYNC"
 msgstr "RSYNC"
 
-#: Gtk/SnapshotBackendBox.vala:179
+#: Gtk/SnapshotBackendBox.vala:184
 msgid "RSYNC Snapshots"
 msgstr "RSYNC–tilannekuvat"
 
@@ -1724,7 +1724,7 @@ msgstr ""
 msgid "Re-install GRUB2 bootloader?"
 msgstr "Asenna GRUB2–käynnistyslataaja uudelleen?"
 
-#: Core/Main.vala:2246
+#: Core/Main.vala:2307
 msgid "Re-installing GRUB2 bootloader..."
 msgstr "Asennetaan GRUB2–käynnistyslataaja uudelleen..."
 
@@ -1737,7 +1737,7 @@ msgstr "Asentaa GRUB2–käynnistyslataajan uudelleen"
 msgid "Read %'d of %'d lines..."
 msgstr "Luetaan '%d / %'d riviä..."
 
-#: Core/Main.vala:2339
+#: Core/Main.vala:2400
 msgid "Rebooting system..."
 msgstr "Käynnistetään järjestelmää uudelleen..."
 
@@ -1746,7 +1746,7 @@ msgstr "Käynnistetään järjestelmää uudelleen..."
 msgid "Recommended"
 msgstr "Suositetut"
 
-#: Gtk/RestoreDeviceBox.vala:70 Gtk/BackupDeviceBox.vala:65
+#: Gtk/BackupDeviceBox.vala:65 Gtk/RestoreDeviceBox.vala:70
 msgid "Refresh"
 msgstr "Päivitä"
 
@@ -1754,12 +1754,12 @@ msgstr "Päivitä"
 msgid "Remote and network locations are not supported."
 msgstr ""
 
-#: Gtk/ExcludeBox.vala:260
+#: Gtk/ExcludeBox.vala:253
 msgid "Remove"
 msgstr "Poista"
 
-#: Core/Snapshot.vala:482 Core/SnapshotRepo.vala:957 Core/Main.vala:1563
-#: Core/Main.vala:1574 Core/Main.vala:4140
+#: Core/SnapshotRepo.vala:975 Core/Main.vala:1617 Core/Main.vala:1628
+#: Core/Main.vala:4197 Core/Snapshot.vala:509
 #, c-format
 msgid "Removed"
 msgstr "Poistettu"
@@ -1768,48 +1768,59 @@ msgstr "Poistettu"
 msgid "Removed cron task"
 msgstr "Poistettu cron–tehtävä"
 
-#: Core/Main.vala:3536
+#: Core/Main.vala:3582
 #, c-format
 msgid "Removed mount directory: '%s'"
 msgstr "Poistettu liitoshakemisto: '%s'"
 
-#: Core/Snapshot.vala:528
+#: Core/Snapshot.vala:555
 msgid "Removed snapshot"
 msgstr "Poistettu tilannekuva"
 
-#: Core/Snapshot.vala:457
+#: Core/Snapshot.vala:484
 msgid "Removing"
 msgstr "Poistetaan"
 
-#: Core/Snapshot.vala:494
+#: Core/Snapshot.vala:521
 msgid "Removing snapshot"
 msgstr "Poistetaan tilannekuvaa"
 
-#: Core/SnapshotRepo.vala:813 Core/SnapshotRepo.vala:832
-#: Core/SnapshotRepo.vala:850 Core/SnapshotRepo.vala:864
+#: Core/SnapshotRepo.vala:831 Core/SnapshotRepo.vala:850
+#: Core/SnapshotRepo.vala:868 Core/SnapshotRepo.vala:882
 #, c-format
 msgid "Removing snapshots"
 msgstr "Poistetaan tilannekuvia"
 
-#: Console/AppConsole.vala:362 Gtk/MainWindow.vala:151
-#: Gtk/RestoreWindow.vala:116 Gtk/RestoreFinishBox.vala:71
-#: Gtk/RsyncLogBox.vala:377 Gtk/RsyncLogBox.vala:567
+#: Gtk/UsersBox.vala:360
+msgid ""
+"Required for displaying shared and unshared size for snapshots in the main "
+"window"
+msgstr ""
+
+#: Console/AppConsole.vala:362 Gtk/RestoreFinishBox.vala:71
+#: Gtk/RsyncLogBox.vala:377 Gtk/RsyncLogBox.vala:567 Gtk/MainWindow.vala:151
+#: Gtk/RestoreWindow.vala:125
 msgid "Restore"
 msgstr "Palauta"
 
-#: Gtk/RestoreWindow.vala:86
+#: Gtk/UsersBox.vala:329
+#, fuzzy
+msgid "Restore @home subvolume"
+msgstr "Palautettu järjestelmän alitaltio"
+
+#: Gtk/RestoreWindow.vala:89
 msgid "Restore Device"
 msgstr "Palauta laite"
 
-#: Gtk/RestoreWindow.vala:91
+#: Gtk/RestoreWindow.vala:94
 msgid "Restore Exclude"
 msgstr "Palauta poisjätetyt"
 
-#: Gtk/RestoreWindow.vala:68
+#: Gtk/RestoreWindow.vala:69
 msgid "Restore Snapshot"
 msgstr "Palauta tilannekuva"
 
-#: Core/Main.vala:2748 Core/Main.vala:2820
+#: Core/Main.vala:2809 Core/Main.vala:2851
 msgid "Restore completed"
 msgstr "Palautus valmis"
 
@@ -1826,7 +1837,7 @@ msgid "Restored subvolumes will become active after system is restarted."
 msgstr ""
 "Palautettu alitaltio aktivoituu järjestelmän uudelleenkäynnistyksen jälkeen."
 
-#: Core/Main.vala:2815
+#: Core/Subvolume.vala:206
 msgid "Restored system subvolume"
 msgstr "Palautettu järjestelmän alitaltio"
 
@@ -1844,7 +1855,7 @@ msgstr ""
 "alitaltiot säilytetään uutena tilannekuvana. Tarvittaessa tämä tilannekuva "
 "voidaan palauttaa myöhemmin 'peruuttaaksesi' palautuksen."
 
-#: Core/Main.vala:2717
+#: Core/Main.vala:2778
 msgid "Restoring snapshot..."
 msgstr "Palautetaan tilannekuvaa..."
 
@@ -1862,10 +1873,10 @@ msgstr ""
 "Sisällytetyt tiedostot varmuuskopioidaan tilannekuvaa luotaessa ja ne "
 "korvataan tilannekuvaa palautettaessa."
 
-#: Utility/Device.vala:1802
+#: Utility/Device.vala:1814
 #, c-format
 msgid "Revision"
-msgstr ""
+msgstr "Revisio"
 
 #: Gtk/RestoreDeviceBox.vala:452
 msgid "Root device not selected"
@@ -1884,9 +1895,9 @@ msgstr ""
 
 #: Console/AppConsole.vala:382
 msgid "Run in non-interactive mode"
-msgstr ""
+msgstr "Suorita ei–interaktiivisessa tilassa"
 
-#: Core/Main.vala:183
+#: Core/Main.vala:186
 msgid "Running"
 msgstr "Käynnissä"
 
@@ -1905,20 +1916,24 @@ msgid ""
 "even install another Linux distribution and later roll-back the previous "
 "distribution by restoring a snapshot."
 msgstr ""
+"Vedosten tallentaminen ei–järjestelmälevylle mahdollistaa sinun formatoida "
+"ja uudelleen asentaa OS:n järjestelmälevylle ilman sille tallennettujen "
+"vedosten menettämistä. Voit jopa asentaa toisen Linux jakeluversion ja "
+"myöhemmin palata aiempaan jakeluversioon palauttamalla vedoksen."
 
-#: Core/Main.vala:1247 Core/Main.vala:1401 Core/Main.vala:1403
+#: Core/Main.vala:1285 Core/Main.vala:1439 Core/Main.vala:1441
 msgid "Saving to device"
 msgstr "Tallennetaan laitteelle"
 
-#: Gtk/SetupWizardWindow.vala:105 Gtk/SettingsWindow.vala:103
+#: Gtk/SetupWizardWindow.vala:109 Gtk/SettingsWindow.vala:92
 msgid "Schedule"
 msgstr "Ajastus"
 
-#: Core/Main.vala:254
+#: Core/Main.vala:257
 msgid "Scheduled snapshot in progress..."
 msgstr "Ajastettu tilannekuvan ottaminen käynnissä..."
 
-#: Core/Main.vala:1109 Gtk/ScheduleBox.vala:299 Gtk/MainWindow.vala:1067
+#: Core/Main.vala:1147 Gtk/MainWindow.vala:1067 Gtk/ScheduleBox.vala:312
 msgid "Scheduled snapshots are disabled"
 msgstr "Ajastetut tilannekuvat eivät ole käytössä"
 
@@ -1927,7 +1942,7 @@ msgid "Scheduled snapshots are disabled. It's recommended to enable it."
 msgstr ""
 "Ajastetut tilannekuvat eivät ole käytössä. On suositeltua ottaa se käyttöön."
 
-#: Gtk/ScheduleBox.vala:292
+#: Gtk/ScheduleBox.vala:305
 msgid "Scheduled snapshots are enabled"
 msgstr "Ajastetut tilannekuvat ovat käytössä"
 
@@ -1942,9 +1957,9 @@ msgstr ""
 #: Console/AppConsole.vala:870
 #, c-format
 msgid "Select '%s' device (default = %s)"
-msgstr ""
+msgstr "Valitse '%s' laite (oletus = %s)"
 
-#: Core/SnapshotRepo.vala:575 Console/AppConsole.vala:689
+#: Console/AppConsole.vala:689 Core/SnapshotRepo.vala:593
 msgid "Select BTRFS system disk with root subvolume (@)"
 msgstr "Valitse BTRFS järjestelmälevy juurialitaltiolla (@)"
 
@@ -1960,7 +1975,7 @@ msgstr "Valitse polku"
 msgid "Select Snapshot"
 msgstr "Valitse tilannekuva"
 
-#: Gtk/ScheduleBox.vala:55
+#: Gtk/ScheduleBox.vala:57
 msgid "Select Snapshot Levels"
 msgstr "Valitse tilannekuvien tasot"
 
@@ -1972,7 +1987,7 @@ msgstr "Valitse tilannekuvan sijainti"
 msgid "Select Snapshot Type"
 msgstr "Valitse tilannekuvan tyyppi"
 
-#: Gtk/DeleteWindow.vala:83
+#: Gtk/DeleteWindow.vala:85
 msgid "Select Snapshots"
 msgstr "Valitse tilannekuvat"
 
@@ -1980,7 +1995,7 @@ msgstr "Valitse tilannekuvat"
 msgid "Select Target Device"
 msgstr "Valitse kohdelaite"
 
-#: Gtk/BackupDeviceBox.vala:377
+#: Gtk/BackupDeviceBox.vala:392
 #, c-format
 msgid "Select a partition on this disk"
 msgstr "Valitse osio tältä levyltä"
@@ -1993,7 +2008,7 @@ msgstr "Valitse yksittäinen tilannekuva palautettavaksi"
 msgid "Select another device for root file system (/)"
 msgstr "Valitse toinen laite juuritiedostojärjestelmälle (/)"
 
-#: Core/SnapshotRepo.vala:614 Core/SnapshotRepo.vala:641
+#: Core/SnapshotRepo.vala:632 Core/SnapshotRepo.vala:659
 msgid "Select another device or free up some space"
 msgstr "Valitse toinen laite tai vapauta hieman tilaa"
 
@@ -2013,11 +2028,11 @@ msgstr "Valitse palautuksesta poisjätettävät sovellukset"
 msgid "Select backup device"
 msgstr "Valitse laite varmuuskopiolle"
 
-#: Gtk/ExcludeBox.vala:434
+#: Gtk/ExcludeBox.vala:433
 msgid "Select directory"
 msgstr "Valitse hakemisto"
 
-#: Gtk/ExcludeBox.vala:413
+#: Gtk/ExcludeBox.vala:406
 msgid "Select file(s)"
 msgstr "Valitse tiedosto(t)"
 
@@ -2025,7 +2040,7 @@ msgstr "Valitse tiedosto(t)"
 msgid "Select snapshot"
 msgstr "Valitse tilannekuva"
 
-#: Gtk/DeleteWindow.vala:340
+#: Gtk/DeleteWindow.vala:342
 msgid "Select snapshots to delete"
 msgstr "Valitse poistettavat tilannekuvat"
 
@@ -2037,15 +2052,15 @@ msgstr "Valitse laite juuritiedostojärjestelmälle (/)"
 msgid "Select the devices where files will be restored."
 msgstr "Valitse laitteet minne tiedostot palautetaan."
 
-#: Gtk/ScheduleBox.vala:300
+#: Gtk/ScheduleBox.vala:313
 msgid "Select the intervals for creating snapshots"
 msgstr "Valitse tilannekuvien luomisen aikaväli"
 
-#: Gtk/ExcludeBox.vala:282
+#: Gtk/ExcludeBox.vala:273
 msgid "Select the items to be removed from the list"
 msgstr "Valitse listasta poistettavat kohteet"
 
-#: Core/SnapshotRepo.vala:535
+#: Core/SnapshotRepo.vala:553
 msgid "Select the snapshot device"
 msgstr "Valitse tilannekuvalaite"
 
@@ -2053,7 +2068,7 @@ msgstr "Valitse tilannekuvalaite"
 msgid "Select the snapshot to restore"
 msgstr "Valitse palautettava tilannekuva"
 
-#: Gtk/DeleteWindow.vala:85
+#: Gtk/DeleteWindow.vala:87
 msgid "Select the snapshots to be deleted"
 msgstr "Valitse poistettava tilannekuva"
 
@@ -2065,31 +2080,31 @@ msgstr "Valitse poistettavaksi merkittävät tilannekuvat"
 msgid "Select the target devices where system will be cloned."
 msgstr "Valitse kohdelaite mihin järjestelmä kloonataan."
 
-#: Core/Main.vala:3198
+#: Core/Main.vala:3242
 msgid "Selected default snapshot device"
 msgstr "Valittu oletusarvoinen laite tilannekuvalle"
 
-#: Core/Main.vala:3149 Core/Main.vala:3153
+#: Core/Main.vala:3193 Core/Main.vala:3197
 msgid "Selected default snapshot type"
 msgstr "Valittu oletusarvoinen tyyppi tilannekuvalle"
 
-#: Gtk/BackupDeviceBox.vala:358
+#: Gtk/BackupDeviceBox.vala:373
 msgid "Selected device does not have BTRFS partition"
 msgstr "Valitulla laitteella ei ole BTRFS–osiota"
 
-#: Gtk/BackupDeviceBox.vala:356
+#: Gtk/BackupDeviceBox.vala:371
 msgid "Selected device does not have Linux partition"
 msgstr "Valitulla laitteella ei ole Linux–osiota"
 
-#: Core/SnapshotRepo.vala:140
+#: Core/SnapshotRepo.vala:146
 msgid "Selected snapshot device"
 msgstr "Valittu laite tilannekuvalle"
 
-#: Core/SnapshotRepo.vala:574 Console/AppConsole.vala:688
+#: Console/AppConsole.vala:688 Core/SnapshotRepo.vala:592
 msgid "Selected snapshot device is not a system disk"
 msgstr "Valittu laite tilannekuvalle ei ole järjestelmälevy"
 
-#: Core/Main.vala:1973
+#: Core/Main.vala:2027
 msgid "Selected snapshot is marked for deletion"
 msgstr "Valittu tilannekuva on merkitty poistettavaksi"
 
@@ -2098,11 +2113,7 @@ msgid "Selected snapshot is marked for deletion and cannot be restored"
 msgstr ""
 "Valittu tilannekuva on merkitty poistettavaksi eikä sitä voida palauttaa"
 
-#: Core/SnapshotRepo.vala:66
-msgid "Selected snapshot path"
-msgstr "Valittu polku tilannekuvalle"
-
-#: Gtk/UsersBox.vala:231
+#: Gtk/UsersBox.vala:238
 msgid ""
 "Selected user has an encrypted home directory. It's not possible to include "
 "only hidden files."
@@ -2110,12 +2121,12 @@ msgstr ""
 "Valitulla käyttäjällä on salattu kotihakemisto. Ei ole mahdollista palauttaa "
 "vain piilotettuja tiedostoja."
 
-#: Utility/Device.vala:1801
+#: Utility/Device.vala:1813
 #, c-format
 msgid "Serial"
 msgstr "Sarjanumero"
 
-#: Core/Main.vala:211
+#: Core/Main.vala:214
 msgid "Session log file"
 msgstr "Istunnon lokitiedosto"
 
@@ -2135,7 +2146,7 @@ msgstr "Asetusvelho"
 msgid "Setup Complete"
 msgstr "Asennus valmis"
 
-#: Gtk/SetupWizardWindow.vala:63
+#: Gtk/SetupWizardWindow.vala:64
 msgid "Setup Wizard"
 msgstr "Asennusvelho"
 
@@ -2155,27 +2166,32 @@ msgstr "Näytä lisää poisjätettäviä sovelluksia seuraavalla sivulla"
 msgid "Show rsync output (default)"
 msgstr "Näytä rsync–tuloste (oletus)"
 
+#: Utility/Device.vala:1816 Utility/Device.vala:1831
 #: Console/AppConsole.vala:456 Console/AppConsole.vala:495
-#: Gtk/RestoreBox.vala:131 Gtk/BackupBox.vala:93 Gtk/SnapshotListBox.vala:174
-#: Gtk/BackupDeviceBox.vala:202 Gtk/RsyncLogBox.vala:392
-#: Utility/Device.vala:1804 Utility/Device.vala:1819
+#: Gtk/RsyncLogBox.vala:392 Gtk/RestoreBox.vala:131
+#: Gtk/BackupDeviceBox.vala:202 Gtk/BackupBox.vala:93
+#: Gtk/SnapshotListBox.vala:174
 #, c-format
 msgid "Size"
 msgstr "Koko"
 
-#: Gtk/SnapshotBackendBox.vala:172
+#: Gtk/SnapshotBackendBox.vala:177
 msgid ""
 "Size of BTRFS snapshots are initially zero. As system files gradually change "
 "with time, data gets written to new data blocks which take up disk space "
 "(copy-on-write). Files in the snapshot continue to point to original data "
 "blocks."
 msgstr ""
+"BTRFS–vedosten koko on lähtökohtaisesti nolla. Järjestelmän tiedostojen "
+"muuttuessa ajan kanssa, data kirjoitetaan uusiin datalohkoihin jotka vievät "
+"levytilaa (copy-on-write). Tiedostot vedoksissa jatkavat osoittamista "
+"alkuperäisiin datalohkoihin."
 
 #: Console/AppConsole.vala:368
 msgid "Skip GRUB2 reinstall"
 msgstr "Ohita GRUB2:n uudelleenasennus"
 
-#: Core/SnapshotRepo.vala:696 Core/SnapshotRepo.vala:734 Core/Main.vala:1978
+#: Core/SnapshotRepo.vala:714 Core/SnapshotRepo.vala:752 Core/Main.vala:2032
 #: Gtk/SnapshotListBox.vala:95
 #, c-format
 msgid "Snapshot"
@@ -2194,7 +2210,7 @@ msgstr ""
 msgid "Snapshot Created"
 msgstr "Tilannekuvat luotu"
 
-#: Gtk/SnapshotListBox.vala:276
+#: Gtk/SnapshotListBox.vala:296
 #, fuzzy, c-format
 msgid "Snapshot Levels"
 msgstr "Valitse tilannekuvien tasot"
@@ -2203,33 +2219,33 @@ msgstr "Valitse tilannekuvien tasot"
 msgid "Snapshot deletion in progress..."
 msgstr "Tilannekuvan poisto käynnissä..."
 
-#: Core/SnapshotRepo.vala:452
+#: Core/SnapshotRepo.vala:470
 #, c-format
 msgid "Snapshot device"
 msgstr "Tilannekuvalaite"
 
-#: Core/SnapshotRepo.vala:541 Console/AppConsole.vala:662
+#: Console/AppConsole.vala:662 Core/SnapshotRepo.vala:559
 msgid "Snapshot device not available"
 msgstr "Tilannekuvalaite ei saatavilla"
 
-#: Core/SnapshotRepo.vala:534 Console/AppConsole.vala:658
+#: Console/AppConsole.vala:658 Core/SnapshotRepo.vala:552
 msgid "Snapshot device not selected"
 msgstr "Tilannekuvalaitetta ei valittuna"
 
-#: Core/SnapshotRepo.vala:456
+#: Core/SnapshotRepo.vala:474
 #, c-format
 msgid "Snapshot location"
 msgstr "Tilannekuvan sijainti"
 
-#: Core/Main.vala:1214
+#: Core/Main.vala:1252
 msgid "Snapshot saved successfully"
 msgstr "Tilannekuva tallennettu onnistuneesti"
 
-#: Core/Main.vala:1968
+#: Core/Main.vala:2022
 msgid "Snapshot to restore not specified!"
 msgstr "Tilannekuvan palautusta ei määritelty!"
 
-#: Core/Main.vala:2824
+#: Core/Main.vala:2855
 msgid "Snapshot will become active after system is rebooted."
 msgstr "Tilannekuva aktivoituu järjestelmän uudelleenkäynnistyksen jälkeen."
 
@@ -2237,41 +2253,48 @@ msgstr "Tilannekuva aktivoituu järjestelmän uudelleenkäynnistyksen jälkeen."
 msgid "Snapshot(s) Deleted"
 msgstr "Tilannekuva(t) poistettu"
 
-#: Gtk/MainWindow.vala:310 Gtk/DeleteWindow.vala:87
+#: Gtk/MainWindow.vala:310 Gtk/DeleteWindow.vala:89
 msgid "Snapshots"
 msgstr "Tilannekuvat"
 
-#: Gtk/SnapshotBackendBox.vala:164
+#: Gtk/SnapshotBackendBox.vala:169
 msgid ""
 "Snapshots are created and restored instantly. Snapshot creation is an atomic "
 "transaction at the file system level."
 msgstr ""
+"Vedokset luodaan ja palautetaan välittömästi. Vedoksen luonti on atominen "
+"siirto järjestelmätasolla."
 
-#: Gtk/SnapshotBackendBox.vala:181
+#: Gtk/SnapshotBackendBox.vala:186
 msgid ""
 "Snapshots are created by creating copies of system files using rsync, and "
 "hard-linking unchanged files from previous snapshot."
 msgstr ""
+"Vedokset luodaan luomalla järjestelmätiedostojen kopiot käyttäen rsync–"
+"työkalua ja kiinteillä linkeillä muuttumattomista tiedostoista edellisestä "
+"vedoksesta."
 
-#: Gtk/SnapshotBackendBox.vala:162
+#: Gtk/SnapshotBackendBox.vala:167
 msgid ""
 "Snapshots are created using the built-in features of the BTRFS file system."
 msgstr ""
 "Tilannekuvat luodaan käyttäen sisäänrakennettuja BTRFS–tiedostojärjestelmän "
 "ominaisuuksia."
 
-#: Gtk/ScheduleBox.vala:151
+#: Gtk/ScheduleBox.vala:167
 #, fuzzy, c-format
 msgid "Snapshots are not scheduled at fixed times."
 msgstr "Tilannekuvalaitetta ei valittuna"
 
-#: Gtk/SnapshotBackendBox.vala:168
+#: Gtk/SnapshotBackendBox.vala:173
 msgid ""
 "Snapshots are perfect, byte-for-byte copies of the system. Nothing is "
 "excluded."
 msgstr ""
+"Vedokset ovat täydellisiä, bitti–bitistä kopioita järjestelmästä. Mitään ei "
+"jätetä pois."
 
-#: Gtk/SnapshotBackendBox.vala:166
+#: Gtk/SnapshotBackendBox.vala:171
 msgid ""
 "Snapshots are restored by replacing system subvolumes. Since files are never "
 "copied, deleted or overwritten, there is no risk of data loss. The existing "
@@ -2282,7 +2305,7 @@ msgstr ""
 "ole riskiä data häviöön. Olemassaoleva systeemi on säilytetty uutena "
 "tilannekuvana palautuksen jälkeen."
 
-#: Gtk/SnapshotBackendBox.vala:170
+#: Gtk/SnapshotBackendBox.vala:175
 msgid ""
 "Snapshots are saved on the same disk from which they are created (system "
 "disk). Storage on other disks is not supported. If system disk fails then "
@@ -2309,12 +2332,16 @@ msgstr ""
 msgid "Snapshots available for restore"
 msgstr "Palautukseen saatavilla olevat tilannekuvat"
 
-#: Gtk/SnapshotBackendBox.vala:185
+#: Gtk/SnapshotBackendBox.vala:190
 msgid ""
 "Snapshots can be saved to any disk formatted with a Linux file system. "
 "Saving snapshots to non-system or external disk allows the system to be "
 "restored even if system disk is damaged or re-formatted."
 msgstr ""
+"Vedokset voidaan tallentaa mille tahansa levylle, joka on formatoitu Linux "
+"tiedostojärjestelmällä. Vedosten tallentaminen ei–järjestelmä– tai "
+"ulkoiselle levylle mahdollistaa järjestelmän palauttamisen vaikka "
+"järjestelmälevy olisi vioittunut tai uudelleen formatoitu."
 
 #: Console/AppConsole.vala:283
 msgid "Snapshots cannot be created in Live CD mode"
@@ -2324,7 +2351,7 @@ msgstr "Tilannekuvia ei voi luoda Live CD tilassa"
 msgid "Snapshots will be created at selected intervals"
 msgstr "Tilannekuvat luodaan valituin aikavälein"
 
-#: Gtk/ScheduleBox.vala:293
+#: Gtk/ScheduleBox.vala:306
 msgid ""
 "Snapshots will be created at selected intervals if snapshot disk has enough "
 "space (> 1 GB)"
@@ -2352,12 +2379,12 @@ msgstr "Määritä palautettava tilannekuva"
 msgid "Specify target device"
 msgstr "Määritä kohdeasema"
 
-#: Core/SnapshotRepo.vala:462 Gtk/RsyncLogBox.vala:472
+#: Core/SnapshotRepo.vala:480 Gtk/RsyncLogBox.vala:472
 #, c-format
 msgid "Status"
 msgstr "Tila"
 
-#: Gtk/ScheduleBox.vala:168
+#: Gtk/ScheduleBox.vala:154
 msgid "Stop cron emails for scheduled tasks"
 msgstr "Pysäytä cron–sähköpostit ajastetuille tehtäville"
 
@@ -2365,8 +2392,18 @@ msgstr "Pysäytä cron–sähköpostit ajastetuille tehtäville"
 msgid "Stopped"
 msgstr "Pysäytetty"
 
-#: Gtk/RestoreWindow.vala:111 Gtk/ExcludeAppsBox.vala:135
-#: Gtk/ExcludeBox.vala:213
+#: Core/Subvolume.vala:189
+#, c-format
+msgid "Subvolume exists at destination"
+msgstr ""
+
+#: Gtk/SnapshotListBox.vala:275
+#, fuzzy, c-format
+msgid "Subvolumes"
+msgstr "Äänenvoimakkuus"
+
+#: Gtk/ExcludeAppsBox.vala:135 Gtk/ExcludeBox.vala:258
+#: Gtk/RestoreWindow.vala:120
 msgid "Summary"
 msgstr "Yhteenveto"
 
@@ -2378,15 +2415,15 @@ msgstr "Vaihda BTRFS–tilaan (oletus:config)"
 msgid "Switch to RSYNC mode (default: config)"
 msgstr "Vaihda RSYNC–tilaan (oletus: config)"
 
-#: Core/SnapshotRepo.vala:1011
+#: Core/SnapshotRepo.vala:1029
 msgid "Symlinks updated"
 msgstr "Symboliset linkit päivitetty"
 
-#: Core/Main.vala:2321
+#: Core/Main.vala:2382
 msgid "Synching file systems..."
 msgstr "Synkronoidaan tiedostojärjestelmiä..."
 
-#: Core/Main.vala:1323 Core/Main.vala:2483 Core/Main.vala:2724
+#: Core/Main.vala:1361 Core/Main.vala:2544 Core/Main.vala:2785
 msgid "Synching files with rsync..."
 msgstr "Synkronoidaan tiedostoja rsyncillä..."
 
@@ -2394,7 +2431,7 @@ msgstr "Synkronoidaan tiedostoja rsyncillä..."
 msgid "Syntax"
 msgstr "Syntaksi"
 
-#: Gtk/SnapshotListBox.vala:127 Utility/Device.vala:1825
+#: Utility/Device.vala:1837 Gtk/SnapshotListBox.vala:127
 #, c-format
 msgid "System"
 msgstr "Järjestelmä"
@@ -2407,15 +2444,15 @@ msgstr "Järjestelmänpalautustyökalu"
 msgid "System can be rolled-back to a previous date by restoring a snapshot."
 msgstr "Järjestelmä voidaan siirtää aiempaan tilaan palauttamalla tilannekuva."
 
-#: Core/Main.vala:2184
+#: Core/Main.vala:2245
 msgid "System will reboot after files are restored"
 msgstr "Järjestelmä käynnistetään uudelleen, kun tiedostot on palautettu"
 
-#: Core/Main.vala:2134
+#: Core/Main.vala:2195
 msgid "System will reboot after files are restored."
 msgstr "Järjestelmä käynnistetään uudelleen, kun tiedostot on palautettu"
 
-#: Core/Main.vala:1183 Core/Main.vala:1224
+#: Core/Main.vala:1221 Core/Main.vala:1262
 msgid "Tagged snapshot"
 msgstr "Merkitty tilannekuva"
 
@@ -2423,7 +2460,7 @@ msgstr "Merkitty tilannekuva"
 msgid "Tags"
 msgstr "Tägit"
 
-#: Core/Main.vala:2003
+#: Core/Main.vala:2057
 msgid "Target device is not mounted"
 msgstr "Kohdelaitetta ei ole liitetty"
 
@@ -2431,7 +2468,7 @@ msgstr "Kohdelaitetta ei ole liitetty"
 msgid "Target device is same as system device"
 msgstr "Kohdelaite on sama kuin järjestelmälaite"
 
-#: Core/Main.vala:1997
+#: Core/Main.vala:2051
 msgid "Target device not specified!"
 msgstr "Kohdelaitetta ei ole määritelty!"
 
@@ -2443,7 +2480,7 @@ msgstr ""
 "Komento 'btrfs' ei ole saatavilla järjestelmässäsi. Asenna 'btrfs-tools' "
 "paketti ja yritä uudelleen."
 
-#: Gtk/ScheduleBox.vala:170
+#: Gtk/ScheduleBox.vala:156
 msgid ""
 "The cron service sends the output of scheduled tasks as an email to the "
 "current user. Select this option to suppress the emails for cron tasks "
@@ -2453,24 +2490,24 @@ msgstr ""
 "nykyiselle käyttäjälle. Valitse tämä asetus lopettaaksesi sähköpostituksen "
 "Timeshift:n luomilta cron–tehtäviltä."
 
-#: Core/Main.vala:373
+#: Core/Main.vala:376
 msgid "The system partition has an unsupported subvolume layout."
 msgstr "Järjestelmäasemalla on tukematon alitaltioiden asettelu."
 
-#: Core/Main.vala:3385
+#: Core/Main.vala:3431
 msgid "The target partition has an unsupported subvolume layout."
 msgstr "Kohdeosiolla on tukematon alitaltio asettelu."
 
-#: Gtk/BackupDeviceBox.vala:479
+#: Gtk/BackupDeviceBox.vala:494
 #, c-format
 msgid "There are no snapshots on this device"
 msgstr "Tällä laitteella ei ole tilannekuvia"
 
-#: Utility/Device.vala:1247
+#: Utility/Device.vala:1259
 msgid "This device is not encrypted"
 msgstr "Tätä laitetta ei ole salattu"
 
-#: Core/Main.vala:2150
+#: Core/Main.vala:2211
 msgid ""
 "This software comes without absolutely NO warranty and the author takes no "
 "responsibility for any damage arising from the use of this program."
@@ -2488,7 +2525,7 @@ msgid ""
 "links for more information."
 msgstr ""
 
-#: Gtk/RestoreBox.vala:132 Gtk/BackupBox.vala:94 Gtk/RsyncLogBox.vala:394
+#: Gtk/RsyncLogBox.vala:394 Gtk/RestoreBox.vala:132 Gtk/BackupBox.vala:94
 #, c-format
 msgid "Timestamp"
 msgstr "Aikaleima"
@@ -2498,19 +2535,19 @@ msgstr "Aikaleima"
 msgid "To restore with default options, press the ENTER key for all prompts!"
 msgstr "Palauta oletusasetuksille, paina ENTER–näppäintä kaikkiin kyselyihin!"
 
-#: Utility/Gtk/AboutWindow.vala:436
+#: Utility/Gtk/AboutWindow.vala:441
 #, fuzzy
 msgid "Translations"
 msgstr "Kääntäjät"
 
-#: Console/AppConsole.vala:457 Console/AppConsole.vala:496
-#: Gtk/BackupDeviceBox.vala:190 Gtk/SettingsWindow.vala:97
-#: Utility/Device.vala:1815
+#: Utility/Device.vala:1827 Console/AppConsole.vala:457
+#: Console/AppConsole.vala:496 Gtk/BackupDeviceBox.vala:190
+#: Gtk/SettingsWindow.vala:86
 #, c-format
 msgid "Type"
 msgstr "Tyyppi"
 
-#: Utility/Device.vala:1814
+#: Utility/Device.vala:1826
 #, c-format
 msgid "UUID"
 msgstr "UUID"
@@ -2519,24 +2556,24 @@ msgstr "UUID"
 msgid "Unknown option"
 msgstr "Tuntematon valinta"
 
-#: Core/Main.vala:1165
+#: Core/Main.vala:1203
 msgid "Unknown snapshot type"
 msgstr "Tuntematon tilannekuvan tyyppi"
 
-#: Core/Main.vala:1512
+#: Core/Main.vala:1566
 msgid "Unknown value specified for option --tags"
-msgstr ""
+msgstr "Tuntematon arvo määritelty valinnalle --tags"
 
-#: Utility/Device.vala:1258 Utility/Device.vala:1374
+#: Utility/Device.vala:1270 Utility/Device.vala:1386
 #, c-format
 msgid "Unlocked device is mapped to '%s'"
 msgstr "Avattu laite on kartoitettu sijaintiin '%s'"
 
-#: Utility/Device.vala:1373
+#: Utility/Device.vala:1385
 msgid "Unlocked successfully"
 msgstr "Avattu onnistuneesti"
 
-#: Utility/Device.vala:1588
+#: Utility/Device.vala:1600
 msgid "Unmounting from"
 msgstr "Irrotetaan sijainnista"
 
@@ -2544,7 +2581,7 @@ msgstr "Irrotetaan sijainnista"
 msgid "Unshared"
 msgstr "Jakamaton"
 
-#: Core/Main.vala:3389 Gtk/RestoreDeviceBox.vala:522
+#: Core/Main.vala:3435 Gtk/RestoreDeviceBox.vala:522
 msgid "Unsupported Subvolume Layout"
 msgstr "Tukematon alitaltioiden asettelu"
 
@@ -2556,11 +2593,11 @@ msgstr "Päivitä GRUB–valikko"
 msgid "Update initramfs"
 msgstr "Päivitä initramfs"
 
-#: Core/Main.vala:2663
+#: Core/Main.vala:2724
 msgid "Updated /etc/crypttab on target device"
 msgstr "Päivitetty /etc/crypttab kohdelaitteella"
 
-#: Core/Main.vala:2583
+#: Core/Main.vala:2644
 msgid "Updated /etc/fstab on target device"
 msgstr "Päivitetty /etc/fstab kohdelaitteella"
 
@@ -2569,52 +2606,61 @@ msgid ""
 "Updates the GRUB menu entries (recommended). This is safe to run and should "
 "be left selected."
 msgstr ""
+"Päivittää GRUB–valikon merkinnät (suositeltua). Tämä on turvallinen "
+"suorittaa ja tulisi jättää valituksi."
 
-#: Core/Main.vala:2304
+#: Core/Main.vala:2365
 msgid "Updating GRUB menu..."
 msgstr "Päivitetään GRUB–valikkoa..."
 
-#: Core/Main.vala:2507
+#: Core/Main.vala:2568
 msgid "Updating bootloader configuration..."
 msgstr "Päivitetään käynnistyslataajan asetuksia..."
 
-#: Utility/Device.vala:1822
+#: Utility/Device.vala:1834
 #, c-format
 msgid "Used"
 msgstr "Käytetty"
 
-#: Gtk/UsersBox.vala:98
+#: Gtk/SetupWizardWindow.vala:114 Gtk/UsersBox.vala:105
 msgid "User"
 msgstr "Käyttäjä"
 
-#: Gtk/UsersBox.vala:58
+#: Gtk/UsersBox.vala:63
 msgid "User Home Directories"
 msgstr "Käyttäjän kotihakemistot"
 
-#: Utility/Device.vala:1328
+#: Utility/Device.vala:1340
 msgid "User cancelled the password prompt"
 msgstr "Käyttäjä peruutti salasanakyselyn"
 
-#: Gtk/UsersBox.vala:65
+#: Gtk/UsersBox.vala:67
 msgid ""
 "User home directories are excluded by default unless you enable them here"
 msgstr ""
+"Käyttäjien kotihakemistoja ei sisällytetä oletusarvoisesti ellet valitse "
+"niitä täältä"
 
-#: Gtk/SettingsWindow.vala:109
+#: Gtk/SettingsWindow.vala:98
 msgid "Users"
 msgstr "Käyttäjät"
 
-#: Utility/Device.vala:1799
+#: Gtk/RestoreWindow.vala:114
+#, fuzzy
+msgid "Users Home"
+msgstr "Käyttäjät"
+
+#: Utility/Device.vala:1811
 #, c-format
 msgid "Vendor"
 msgstr "Toimittajan myyjä"
 
-#: Gtk/SnapshotListBox.vala:323
+#: Gtk/SnapshotListBox.vala:343
 #, fuzzy
 msgid "View Rsync Log for Create"
 msgstr "Katso luonnin lokeja"
 
-#: Gtk/SnapshotListBox.vala:330
+#: Gtk/SnapshotListBox.vala:350
 #, fuzzy
 msgid "View Rsync Log for Restore"
 msgstr "Katso palautettavaa lokia"
@@ -2627,7 +2673,7 @@ msgstr "Katso TimeShiftin lokeja"
 msgid "Volume"
 msgstr "Äänenvoimakkuus"
 
-#: Core/Main.vala:2052 Gtk/RestoreSummaryBox.vala:53
+#: Core/Main.vala:2106 Gtk/RestoreSummaryBox.vala:53
 msgid "Warning"
 msgstr "Varoitus"
 
@@ -2640,15 +2686,15 @@ msgstr "Verkkoselaimet"
 msgid "Website"
 msgstr "Verkkosivu"
 
-#: Gtk/ScheduleBox.vala:80 Gtk/SnapshotListBox.vala:281
+#: Gtk/ScheduleBox.vala:82 Gtk/SnapshotListBox.vala:301
 msgid "Weekly"
 msgstr "Viikoittainen"
 
-#: Core/Main.vala:1069
+#: Core/Main.vala:1107
 msgid "Weekly snapshot failed!"
 msgstr "Viikoittainen tilannekuva epäonnistui!"
 
-#: Core/Main.vala:1050
+#: Core/Main.vala:1088
 msgid "Weekly snapshots are enabled"
 msgstr "Viikoittaiset tilannekuvat käytössä"
 
@@ -2656,7 +2702,7 @@ msgstr "Viikoittaiset tilannekuvat käytössä"
 msgid "Wiki ~ Documentation & Help"
 msgstr "Wiki ~ Dokumentaatio & Ohje"
 
-#: Gtk/DeleteFinishBox.vala:63 Gtk/BackupFinishBox.vala:63
+#: Gtk/BackupFinishBox.vala:63 Gtk/DeleteFinishBox.vala:63
 msgid "With Errors"
 msgstr "Virheiden kanssa"
 
@@ -2664,7 +2710,7 @@ msgstr "Virheiden kanssa"
 msgid "Wizard"
 msgstr "Velho"
 
-#: Utility/Device.vala:1301 Utility/Device.vala:1347
+#: Utility/Device.vala:1313 Utility/Device.vala:1359
 msgid "Wrong password"
 msgstr "Väärä salasana"
 
@@ -2704,16 +2750,16 @@ msgstr "[OLETUS = Default (%s), r = Juurijärjestelmä, a = Peruutus]"
 msgid "[Warning] Deleted invalid lock"
 msgstr "[Varoitu] Poistettu valittu lukko"
 
-#: Core/SnapshotRepo.vala:864
+#: Core/SnapshotRepo.vala:882
 msgid "all"
 msgstr "kaikki"
 
-#: Core/Main.vala:1440 Core/Main.vala:2807 Core/Main.vala:3810
-#: Core/Main.vala:3894 Core/Main.vala:3997 Core/Main.vala:4036
+#: Core/Subvolume.vala:201 Core/Main.vala:1494 Core/Main.vala:3862
+#: Core/Main.vala:3946 Core/Main.vala:4054 Core/Main.vala:4093
 msgid "btrfs returned an error"
 msgstr "btrfs palautti virheen"
 
-#: Core/Snapshot.vala:473 Core/Main.vala:1355
+#: Core/Main.vala:1393 Core/Snapshot.vala:500
 msgid "complete"
 msgstr "valmis"
 
@@ -2725,29 +2771,29 @@ msgstr "crontab–tiedosto viety"
 msgid "crontab file installed"
 msgstr "crontab–tiedosto asennettu"
 
-#: Core/SnapshotRepo.vala:850
+#: Core/SnapshotRepo.vala:868
 msgid "incomplete"
 msgstr "Keskeneräinen"
 
-#: Core/SnapshotRepo.vala:832
+#: Core/SnapshotRepo.vala:850
 msgid "marked for deletion"
 msgstr "merkitty poistettavaksi"
 
-#: Core/Main.vala:1247 Core/Main.vala:1401 Core/Main.vala:1403
+#: Core/Main.vala:1285 Core/Main.vala:1439 Core/Main.vala:1441
 msgid "mounted at path"
 msgstr "liitetty polkuun"
 
-#: Core/Snapshot.vala:474 Core/Main.vala:1355 Gtk/RestoreBox.vala:237
-#: Gtk/BackupBox.vala:234 Gtk/DeleteBox.vala:149
+#: Core/Main.vala:1393 Core/Snapshot.vala:501 Gtk/DeleteBox.vala:149
+#: Gtk/RestoreBox.vala:237 Gtk/BackupBox.vala:234
 msgid "remaining"
 msgstr "jäljellä"
 
-#: Core/Main.vala:1366
+#: Core/Main.vala:1404
 msgid "rsync returned an error"
 msgstr "rsync palautti virheen"
 
-#: Core/SnapshotRepo.vala:696 Core/SnapshotRepo.vala:734
-#: Core/SnapshotRepo.vala:813
+#: Core/SnapshotRepo.vala:714 Core/SnapshotRepo.vala:752
+#: Core/SnapshotRepo.vala:831
 msgid "un-tagged"
 msgstr "Merkitsemätön"
 
@@ -2770,17 +2816,48 @@ msgstr "Merkitsemätön"
 #~ "W\tViikoittain\n"
 #~ "M\tKuukausittain"
 
+#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
+#~ msgstr "<b>Tilannekuvan päiväys:</b> Päivämäärä jolloin tilannekuva luotiin"
+
+#~ msgid "<b>System:</b> Installed Linux distribution"
+#~ msgstr "<b>Järjestelmä:</b> Asennettu Linux–jakeluversio"
+
+#~ msgid ""
+#~ "Click an item to edit the pattern.\n"
+#~ "Drag and drop items with mouse to re-order."
+#~ msgstr ""
+#~ "Napsauta kohdetta muokataksesi kaavaa.\n"
+#~ "Vedä ja pudota kohteita hiirellä järjestääksesi uudelleen."
+
 #~ msgid "Cloning System..."
 #~ msgstr "Kloonataan järjestelmää..."
 
 #~ msgid "Close Window"
 #~ msgstr "Sulje ikkuna"
 
+#~ msgid "Contributions"
+#~ msgstr "Lahjoitukset"
+
+#~ msgid "Deleted system subvolumes"
+#~ msgstr "Poistetut järjestelmän alitaltiot"
+
 #~ msgid "Documenters"
 #~ msgstr "Dokumentoijat"
 
+#~ msgid "Editing and Re-Ordering"
+#~ msgstr "Muokkaus ja uudelleen järjestely"
+
 #~ msgid "Include everything"
 #~ msgstr "Sisällytä kaikki"
+
+#~ msgid "Include hidden items"
+#~ msgstr "Sisällytä piilotetut kohteet"
+
+#~ msgid "Info"
+#~ msgstr "Tietoja"
+
+#~ msgid "Log Viewer"
+#~ msgstr "Lokikatselin"
 
 #~ msgid "Refresh Snapshot List"
 #~ msgstr "Päivitä tilannekuvien lista"
@@ -2788,8 +2865,20 @@ msgstr "Merkitsemätön"
 #~ msgid "Scheduled task runs once every hour"
 #~ msgstr "Ajastettu tehtävä suoritetaan joka tunti"
 
+#~ msgid "Selected snapshot path"
+#~ msgstr "Valittu polku tilannekuvalle"
+
 #~ msgid "Third Party Tools"
 #~ msgstr "Kolmannen osapuolen työkalut"
+
+#~ msgid "Translators"
+#~ msgstr "Kääntäjät"
+
+#~ msgid "View Log for Create"
+#~ msgstr "Katso luonnin lokeja"
+
+#~ msgid "View Log for Restore"
+#~ msgstr "Katso palautettavaa lokia"
 
 #~ msgid "View:"
 #~ msgstr "Katsele"

--- a/po/timeshift-fr.po
+++ b/po/timeshift-fr.po
@@ -1,24 +1,17 @@
-# French translation for timeshift
-# Copyright (c) 2013 Rosetta Contributors and Canonical Ltd 2013
-# This file is distributed under the same license as the timeshift package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2013.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: timeshift\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
-"PO-Revision-Date: 2017-11-10 17:05+0000\n"
-"Last-Translator: Fr-coord <Unknown>\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
+"PO-Revision-Date: 2018-02-21 18:43+0000\n"
+"Last-Translator: Jean-Marc <Unknown>\n"
 "Language-Team: French <fr@li.org>\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:00+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -212,12 +205,6 @@ msgstr "Auteurs"
 msgid "Available"
 msgstr "Disponible"
 
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
-
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr "BTRFS"
@@ -233,6 +220,13 @@ msgstr "Outils BTRFS non trouvés"
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
 msgstr "Le périphérique BTRFS n'est pas monté"
+
+#: Gtk/BackupDeviceBox.vala:98
+#, fuzzy
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
+msgstr "Autres applications (page suivante)"
 
 #: Gtk/FinishBox.vala:92
 msgid ""
@@ -799,7 +793,7 @@ msgstr "Prise en charge des quotas de sous-volumes activée"
 
 #: Utility/Device.vala:1333
 msgid "Encrypted Device"
-msgstr "Périphérique crypté"
+msgstr "Périphérique chiffré"
 
 #: Gtk/UsersBox.vala:236
 msgid "Encrypted Home Directory"
@@ -2724,7 +2718,7 @@ msgstr "Assistant"
 
 #: Utility/Device.vala:1313 Utility/Device.vala:1359
 msgid "Wrong password"
-msgstr "Mauvais mot de passe"
+msgstr "Mot de passe incorrect"
 
 #: Utility/Gtk/CustomMessageDialog.vala:176
 msgid "Yes"
@@ -2810,36 +2804,6 @@ msgstr "rsync a retourné une erreur"
 msgid "un-tagged"
 msgstr "non marqué"
 
-#, fuzzy
-#~ msgid "Click to edit and drag-drop to re-order"
-#~ msgstr "Cliquez pour modifier. Glissez-déposez pour réordonner."
-
-#~ msgid ""
-#~ "Click an item to edit the pattern.\n"
-#~ "Drag and drop items with mouse to re-order."
-#~ msgstr ""
-#~ "Cliquez pour modifier le pattern.\n"
-#~ "Glissez-déposez pour réordonner."
-
-#~ msgid "Editing and Re-Ordering"
-#~ msgstr "Modification et tri"
-
-#~ msgid "Info"
-#~ msgstr "Info"
-
-#~ msgid "Deleted system subvolumes"
-#~ msgstr "Sous-volumes système supprimés"
-
-#~ msgid "<b>System:</b> Installed Linux distribution"
-#~ msgstr "<b>Système :</b> Distribution Linux installée"
-
-#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
-#~ msgstr ""
-#~ "<b>Date de l'instantané:</b> Date à laquelle l'instantané a été créé"
-
-#~ msgid "Selected snapshot path"
-#~ msgstr "Chemin sélectionné pour les instantanés"
-
 #~ msgid ""
 #~ "<b>Backup Levels</b>\n"
 #~ "\n"
@@ -2859,6 +2823,20 @@ msgstr "non marqué"
 #~ "W\tHebdomadaire\n"
 #~ "M\tMensuel"
 
+#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
+#~ msgstr ""
+#~ "<b>Date de l'instantané:</b> Date à laquelle l'instantané a été créé"
+
+#~ msgid "<b>System:</b> Installed Linux distribution"
+#~ msgstr "<b>Système :</b> Distribution Linux installée"
+
+#~ msgid ""
+#~ "Click an item to edit the pattern.\n"
+#~ "Drag and drop items with mouse to re-order."
+#~ msgstr ""
+#~ "Cliquez pour modifier le pattern.\n"
+#~ "Glissez-déposez pour réordonner."
+
 #~ msgid "Cloning System..."
 #~ msgstr "Clonage du système..."
 
@@ -2868,14 +2846,26 @@ msgstr "non marqué"
 #~ msgid "Contributions"
 #~ msgstr "Contributions"
 
+#~ msgid "Create snapshots using RSYNC"
+#~ msgstr "Créer un instantané en utilisant RSYNC"
+
+#~ msgid "Deleted system subvolumes"
+#~ msgstr "Sous-volumes système supprimés"
+
 #~ msgid "Documenters"
 #~ msgstr "Documentalistes"
+
+#~ msgid "Editing and Re-Ordering"
+#~ msgstr "Modification et tri"
 
 #~ msgid "Include everything"
 #~ msgstr "Inclure tout"
 
 #~ msgid "Include hidden items"
 #~ msgstr "Inclure les éléments cachés"
+
+#~ msgid "Info"
+#~ msgstr "Info"
 
 #~ msgid "Log Viewer"
 #~ msgstr "Visionneur de journaux"
@@ -2885,6 +2875,9 @@ msgstr "non marqué"
 
 #~ msgid "Scheduled task runs once every hour"
 #~ msgstr "La tâche programmée se lance une fois toutes les heures."
+
+#~ msgid "Selected snapshot path"
+#~ msgstr "Chemin sélectionné pour les instantanés"
 
 #~ msgid "Third Party Tools"
 #~ msgstr "Outils tiers"
@@ -2900,6 +2893,10 @@ msgstr "non marqué"
 
 #~ msgid "View:"
 #~ msgstr "Vue :"
+
+#, fuzzy
+#~ msgid "Click to edit and drag-drop to re-order"
+#~ msgstr "Cliquez pour modifier. Glissez-déposez pour réordonner."
 
 #~ msgid "Change"
 #~ msgstr "Modifié"

--- a/po/timeshift-he.po
+++ b/po/timeshift-he.po
@@ -1,13 +1,8 @@
-# Hebrew translation for linuxmint
-# Copyright (c) 2017 Rosetta Contributors and Canonical Ltd 2017
-# This file is distributed under the same license as the linuxmint package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
 "PO-Revision-Date: 2017-09-26 06:30+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Hebrew <he@li.org>\n"
@@ -15,10 +10,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:00+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -203,12 +196,6 @@ msgstr ""
 msgid "Available"
 msgstr ""
 
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
-
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr ""
@@ -223,6 +210,12 @@ msgstr ""
 
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
+msgstr ""
+
+#: Gtk/BackupDeviceBox.vala:98
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
 msgstr ""
 
 #: Gtk/FinishBox.vala:92

--- a/po/timeshift-hi.po
+++ b/po/timeshift-hi.po
@@ -1,13 +1,8 @@
-# Hindi translation for linuxmint
-# Copyright (c) 2017 Rosetta Contributors and Canonical Ltd 2017
-# This file is distributed under the same license as the linuxmint package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
 "PO-Revision-Date: 2017-09-19 14:37+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Hindi <hi@li.org>\n"
@@ -15,10 +10,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:01+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -203,12 +196,6 @@ msgstr ""
 msgid "Available"
 msgstr ""
 
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
-
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr ""
@@ -223,6 +210,12 @@ msgstr ""
 
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
+msgstr ""
+
+#: Gtk/BackupDeviceBox.vala:98
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
 msgstr ""
 
 #: Gtk/FinishBox.vala:92

--- a/po/timeshift-hr.po
+++ b/po/timeshift-hr.po
@@ -1,24 +1,17 @@
-# Croatian translation for linuxmint
-# Copyright (c) 2017 Rosetta Contributors and Canonical Ltd 2017
-# This file is distributed under the same license as the linuxmint package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
-"PO-Revision-Date: 2017-11-06 15:36+0000\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
+"PO-Revision-Date: 2018-06-12 08:10+0000\n"
 "Last-Translator: gogo <trebelnik2@gmail.com>\n"
 "Language-Team: Croatian <hr@li.org>\n"
 "Language: hr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:01+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -215,12 +208,6 @@ msgstr "Autor"
 msgid "Available"
 msgstr "Dostupno"
 
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
-
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr "BTRFS"
@@ -236,6 +223,13 @@ msgstr "BTRFS alati nisu pronađeni"
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
 msgstr "BTRFS uređaj nije pronađen"
+
+#: Gtk/BackupDeviceBox.vala:98
+#, fuzzy
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
+msgstr "Ostale aplikacije (sljedeća stranica)"
 
 #: Gtk/FinishBox.vala:92
 msgid ""
@@ -520,7 +514,7 @@ msgid ""
 "Create snapshots manually or enable scheduled snapshots to protect your "
 "system"
 msgstr ""
-"Stvori snimku sustava ručno ili omogući raspored snimaka sustava kako bi "
+"Stvorite snimku sustava ručno ili omogućite raspored snimaka sustava kako bi "
 "zaštitili svoj sustav"
 
 #: Gtk/SnapshotBackendBox.vala:95
@@ -732,10 +726,10 @@ msgid ""
 msgstr ""
 "Je li vam ovaj softver bio koristan?\n"
 "\n"
-"Možete mi kupiti kavu ili donirati putem PayPala kako bi me podržali. Ili mi "
-"jednostavno pošaljite e-poštu i recite mi Bok. Ova aplikacija je u "
-"potpunosti besplatna i takva će i ostati. Vaš doprinos će pomoći održati "
-"ovaj projekt živim i poboljšanim u budućnosti.\n"
+"Možete mi kupiti kavu ili donirati putem PayPala kako bi podržali moj rad. "
+"Ili mi jednostavno pošaljite e-poštu i recite mi Bok. Ova aplikacija je u "
+"potpunosti besplatna i takva će ubuduće ostati. Vaš doprinos će pomoći "
+"održati ovaj projekt živim i poboljšanim u budućnosti.\n"
 "\n"
 "Slobodno mi pošaljite e-poštu ako imate bilo kakav problem s ovom "
 "aplikacijom ili želite neku promjenu. Prijedlozi i povratne informacije su "
@@ -1401,9 +1395,7 @@ msgstr "Označeno za brisanje"
 
 #: Core/SnapshotRepo.vala:711 Core/SnapshotRepo.vala:748
 msgid "Maximum backups exceeded for backup level"
-msgstr ""
-"Premašen je broj sigurnosnih kopija za raspored sigurnosnog kopiranja\n"
-"Premašen je broj sigurnosnih kopija za razinu sigurnosnog kopiranja"
+msgstr "Premašen je broj sigurnosnih kopija za raspored sigurnosnog kopiranja"
 
 #: Gtk/MainWindow.vala:208
 msgid "Menu"
@@ -1895,8 +1887,6 @@ msgid ""
 "against drive failures."
 msgstr ""
 "Spremite snimke sustava na vanjski disk umjesto na disk sustava kako bi "
-"spriječili gubitak podataka uslijed kvara diska.\n"
-"Spremi snimke sustava na vanjski disk umjesto na disk sustava kako bi "
 "spriječili gubitak podataka uslijed kvara diska."
 
 #: Gtk/FinishBox.vala:97
@@ -1909,11 +1899,7 @@ msgstr ""
 "Spremanje snimaka sustava na nesustavski disk omogućuje vam formatiranje i "
 "ponovnu instalaciju OS-a bez gubitka snimaka sustava spremljenih na njemu. "
 "Možete čak instalirati drugu Linux distribuciju i zatim vratiti natrag "
-"prijašnju distribuciju obnovom iz snimke sustava.\n"
-"Spremanje snimaka sustava na nesustavski disk omogućuje vam formatiranje i "
-"reinstalaciju OS-a bez gubitka snimaka sustava spremljenih na njega. Možete "
-"čak instalirati drugu Linux distribuciju i zatim vratiti natrag prijašnju "
-"distribuciju obnovom iz snimke sustava."
+"prijašnju distribuciju obnovom iz snimke sustava."
 
 #: Core/Main.vala:1285 Core/Main.vala:1439 Core/Main.vala:1441
 msgid "Saving to device"
@@ -1929,26 +1915,24 @@ msgstr "Zakazivanje rasporeda snimanja sustava u tijeku..."
 
 #: Core/Main.vala:1147 Gtk/MainWindow.vala:1067 Gtk/ScheduleBox.vala:312
 msgid "Scheduled snapshots are disabled"
-msgstr "Raspored  snimanja sustava je onemogućen"
+msgstr "Raspored snimanja sustava je onemogućen"
 
 #: Gtk/FinishBox.vala:78
 msgid "Scheduled snapshots are disabled. It's recommended to enable it."
 msgstr ""
-"Raspored  snimanja sustava je onemogućen. Preporučljivo je da ga omogućite."
+"Raspored snimanja sustava je onemogućen. Preporučljivo je da ga omogućite."
 
 #: Gtk/ScheduleBox.vala:305
 msgid "Scheduled snapshots are enabled"
-msgstr "Raspored  snimanja sustava je omogućen"
+msgstr "Raspored snimanja sustava je omogućen"
 
 #: Gtk/FinishBox.vala:75
 msgid ""
 "Scheduled snapshots are enabled. Snapshots will be created automatically for "
 "selected levels."
 msgstr ""
-"Raspored  snimanja sustava je omogućen. Snimke sustava će biti automatski "
-"stvorene prema odabranom rasporedu.\n"
-"Raspored  snimanja sustava je omogućen. Snimke sustava će biti automatski "
-"stvorene za odabrane razine."
+"Raspored snimanja sustava je omogućen. Snimke sustava će biti automatski "
+"stvorene prema odabranom rasporedu."
 
 #: Console/AppConsole.vala:870
 #, c-format
@@ -1973,9 +1957,7 @@ msgstr "Odaberi snimku sustava"
 
 #: Gtk/ScheduleBox.vala:57
 msgid "Select Snapshot Levels"
-msgstr ""
-"Postavi raspored stvaranja snimke sustava\n"
-"Odaberi razinu snimke sustava"
+msgstr "Postavi raspored stvaranja snimke sustava"
 
 #: Gtk/BackupDeviceBox.vala:56
 msgid "Select Snapshot Location"
@@ -2052,7 +2034,7 @@ msgstr "Odaberi uređaj gdje će se datoteke obnoviti."
 
 #: Gtk/ScheduleBox.vala:313
 msgid "Select the intervals for creating snapshots"
-msgstr "Odaberi razdoblje stvaranja snimaka sustava"
+msgstr "Odaberite razdoblje stvaranja snimaka sustava"
 
 #: Gtk/ExcludeBox.vala:273
 msgid "Select the items to be removed from the list"
@@ -2260,9 +2242,7 @@ msgid ""
 "transaction at the file system level."
 msgstr ""
 "Stvaranje i obnova snimaka sustava je trenutačna. Stvaranje snimke sustava "
-"je poput atomske reakcije na razini datotečnog sustava.\n"
-"Stvaranje i obnova snimka sustava je trenutačna. Stvaranje snimke sustava je "
-"atomska transakcija na razini datotečnog sustava."
+"je poput atomske reakcije na razini datotečnog sustava."
 
 #: Gtk/SnapshotBackendBox.vala:186
 msgid ""
@@ -2346,7 +2326,7 @@ msgstr "Snimke sustava se ne mogu stvoriti u Live CD načinu rada"
 
 #: Gtk/MainWindow.vala:1059
 msgid "Snapshots will be created at selected intervals"
-msgstr "Snimke sustava će biti stvorene u odabranom  razdoblju"
+msgstr "Snimke sustava će biti stvorene u odabranom razdoblju"
 
 #: Gtk/ScheduleBox.vala:306
 msgid ""
@@ -2792,36 +2772,6 @@ msgstr "rsync je vratio grešku"
 msgid "un-tagged"
 msgstr "odznačeno"
 
-#, fuzzy
-#~ msgid "Click to edit and drag-drop to re-order"
-#~ msgstr ""
-#~ "Kliknite za uređivanje. Povucite i ispustite za promjenu redoslijeda."
-
-#~ msgid ""
-#~ "Click an item to edit the pattern.\n"
-#~ "Drag and drop items with mouse to re-order."
-#~ msgstr ""
-#~ "Kliknite na stavku kako bi uredili uzorak.\n"
-#~ "Povucite i ispustite stavke miše za promjenu redoslijeda."
-
-#~ msgid "Editing and Re-Ordering"
-#~ msgstr "Uređivanje i promjena redoslijeda"
-
-#~ msgid "Info"
-#~ msgstr "Informacije"
-
-#~ msgid "Deleted system subvolumes"
-#~ msgstr "Obrisani poduređaji sustava"
-
-#~ msgid "<b>System:</b> Installed Linux distribution"
-#~ msgstr "<b>Sustav:</b> Instalirana Linux distribucija"
-
-#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
-#~ msgstr "<b>Datum snimke sustava:</b> Datum kada je snimka sustava stvorena"
-
-#~ msgid "Selected snapshot path"
-#~ msgstr "Putanja odabrane snimke sustava"
-
 #~ msgid ""
 #~ "<b>Backup Levels</b>\n"
 #~ "\n"
@@ -2839,15 +2789,20 @@ msgstr "odznačeno"
 #~ "H\tSvaki sat\n"
 #~ "D\tSvaki dan\n"
 #~ "W\tTjedno\n"
-#~ "M\tMjesečno\n"
-#~ "<b>Razine sigurnosnog pokretanja</b>\n"
-#~ "\n"
-#~ "O\tNa zahtjev (ručno)\n"
-#~ "B\tPri pokretanju\n"
-#~ "H\tSvaki sat\n"
-#~ "D\tSvaki dan\n"
-#~ "W\tTjedno\n"
 #~ "M\tMjesečno"
+
+#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
+#~ msgstr "<b>Datum snimke sustava:</b> Datum kada je snimka sustava stvorena"
+
+#~ msgid "<b>System:</b> Installed Linux distribution"
+#~ msgstr "<b>Sustav:</b> Instalirana Linux distribucija"
+
+#~ msgid ""
+#~ "Click an item to edit the pattern.\n"
+#~ "Drag and drop items with mouse to re-order."
+#~ msgstr ""
+#~ "Kliknite na stavku kako bi uredili uzorak.\n"
+#~ "Povucite i ispustite stavke miše za promjenu redoslijeda."
 
 #~ msgid "Cloning System..."
 #~ msgstr "Kloniranje sustava..."
@@ -2858,14 +2813,26 @@ msgstr "odznačeno"
 #~ msgid "Contributions"
 #~ msgstr "Doprinijeli"
 
+#~ msgid "Create snapshots using RSYNC"
+#~ msgstr "Stvori snimku sustava koristeći RSYNC"
+
+#~ msgid "Deleted system subvolumes"
+#~ msgstr "Obrisani poduređaji sustava"
+
 #~ msgid "Documenters"
 #~ msgstr "Autori dokumentacije"
+
+#~ msgid "Editing and Re-Ordering"
+#~ msgstr "Uređivanje i promjena redoslijeda"
 
 #~ msgid "Include everything"
 #~ msgstr "Obuhvati sve"
 
 #~ msgid "Include hidden items"
 #~ msgstr "Obuhvati skrivene datoteke"
+
+#~ msgid "Info"
+#~ msgstr "Informacije"
 
 #~ msgid "Log Viewer"
 #~ msgstr "Preglednik zaspisa"
@@ -2875,6 +2842,9 @@ msgstr "odznačeno"
 
 #~ msgid "Scheduled task runs once every hour"
 #~ msgstr "Zadaci rasporeda se pokreću svaki sat"
+
+#~ msgid "Selected snapshot path"
+#~ msgstr "Putanja odabrane snimke sustava"
 
 #~ msgid "Third Party Tools"
 #~ msgstr "Alati treće strane"
@@ -2890,6 +2860,11 @@ msgstr "odznačeno"
 
 #~ msgid "View:"
 #~ msgstr "Pogled:"
+
+#, fuzzy
+#~ msgid "Click to edit and drag-drop to re-order"
+#~ msgstr ""
+#~ "Kliknite za uređivanje. Povucite i ispustite za promjenu redoslijeda."
 
 #~ msgid "Change"
 #~ msgstr "Promijenjeno"

--- a/po/timeshift-hu.po
+++ b/po/timeshift-hu.po
@@ -1,25 +1,17 @@
-# Hungarian translation for linuxmint
-# Copyright (c) 2017 Rosetta Contributors and Canonical Ltd 2017
-# This file is distributed under the same license as the linuxmint package.
-#
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# Kálmán szalai (KAMI) <kami911@gmail.com>, 2017.
 msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
-"PO-Revision-Date: 2017-11-20 14:15+0000\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
+"PO-Revision-Date: 2018-05-01 08:48+0000\n"
 "Last-Translator: KAMI <kami911@gmail.com>\n"
 "Language-Team: Hungarian <kde-l10n-hu@kde.org>\n"
 "Language: hu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:00+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -218,12 +210,6 @@ msgstr "Szerzők"
 msgid "Available"
 msgstr "Elérhető"
 
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
-
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr "BTRFS"
@@ -239,6 +225,13 @@ msgstr "BTRFS eszközök nem találhatóak"
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
 msgstr "A BTRFS eszköz nincs csatlakoztatva"
+
+#: Gtk/BackupDeviceBox.vala:98
+#, fuzzy
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
+msgstr "Más alkalmazások (következő oldal)"
 
 #: Gtk/FinishBox.vala:92
 msgid ""
@@ -781,11 +774,11 @@ msgstr "Adományok"
 
 #: Utility/Gtk/DonationWindow.vala:42 Gtk/MainWindow.vala:388
 msgid "Donate"
-msgstr "Támogatás"
+msgstr "Adományozás"
 
 #: Utility/Gtk/DonationWindow.vala:81
 msgid "Donate with PayPal"
-msgstr "Támogatás PayPal segítségével"
+msgstr "Adományozás PayPal segítségével"
 
 #: Utility/Gtk/AboutWindow.vala:465
 msgid "Donations"
@@ -1910,7 +1903,7 @@ msgstr "Futtatás nem interaktív üzemmódban"
 
 #: Core/Main.vala:186
 msgid "Running"
-msgstr "Fut"
+msgstr "Folyamatban"
 
 #: Gtk/FinishBox.vala:95
 msgid ""
@@ -2811,36 +2804,6 @@ msgstr "rsync program hibát jelzett"
 msgid "un-tagged"
 msgstr "nem kijelölt"
 
-#, fuzzy
-#~ msgid "Click to edit and drag-drop to re-order"
-#~ msgstr ""
-#~ "Kattintson a szerkesztéshez. Az elemek sorrendjét húzással átrendezheti."
-
-#~ msgid ""
-#~ "Click an item to edit the pattern.\n"
-#~ "Drag and drop items with mouse to re-order."
-#~ msgstr ""
-#~ "Kattintson egy elemre a minta megváltoztatásához.\n"
-#~ "Az elemek sorrendjét húzással átrendezheti az egérrel."
-
-#~ msgid "Editing and Re-Ordering"
-#~ msgstr "Szerkesztés és átrendezés"
-
-#~ msgid "Info"
-#~ msgstr "Információ"
-
-#~ msgid "Deleted system subvolumes"
-#~ msgstr "Rendszer alkötetek törlése"
-
-#~ msgid "<b>System:</b> Installed Linux distribution"
-#~ msgstr "<b>Rendszer:</b> Telepített Linux terjesztés"
-
-#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
-#~ msgstr "<b>Pillanatkép dátuma:</b> A pillanatkép létrehozásának dátuma"
-
-#~ msgid "Selected snapshot path"
-#~ msgstr "Kiválasztott pillanatkép elérési út"
-
 #~ msgid ""
 #~ "<b>Backup Levels</b>\n"
 #~ "\n"
@@ -2860,6 +2823,19 @@ msgstr "nem kijelölt"
 #~ "W\tHetente\n"
 #~ "M\tHavonta"
 
+#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
+#~ msgstr "<b>Pillanatkép dátuma:</b> A pillanatkép létrehozásának dátuma"
+
+#~ msgid "<b>System:</b> Installed Linux distribution"
+#~ msgstr "<b>Rendszer:</b> Telepített Linux terjesztés"
+
+#~ msgid ""
+#~ "Click an item to edit the pattern.\n"
+#~ "Drag and drop items with mouse to re-order."
+#~ msgstr ""
+#~ "Kattintson egy elemre a minta megváltoztatásához.\n"
+#~ "Az elemek sorrendjét húzással átrendezheti az egérrel."
+
 #~ msgid "Cloning System..."
 #~ msgstr "A rendszer klónozása…"
 
@@ -2869,14 +2845,26 @@ msgstr "nem kijelölt"
 #~ msgid "Contributions"
 #~ msgstr "Közreműködők"
 
+#~ msgid "Create snapshots using RSYNC"
+#~ msgstr "Pillanatkép készítése RSYNC program használatával"
+
+#~ msgid "Deleted system subvolumes"
+#~ msgstr "Rendszer alkötetek törlése"
+
 #~ msgid "Documenters"
 #~ msgstr "Dokumentáció írói"
+
+#~ msgid "Editing and Re-Ordering"
+#~ msgstr "Szerkesztés és átrendezés"
 
 #~ msgid "Include everything"
 #~ msgstr "Összes felvétele"
 
 #~ msgid "Include hidden items"
 #~ msgstr "Rejtett elemek felvétele"
+
+#~ msgid "Info"
+#~ msgstr "Információ"
 
 #~ msgid "Log Viewer"
 #~ msgstr "Naplómegjelenítő"
@@ -2886,6 +2874,9 @@ msgstr "nem kijelölt"
 
 #~ msgid "Scheduled task runs once every hour"
 #~ msgstr "Az ütemezett feladat óránként fut le"
+
+#~ msgid "Selected snapshot path"
+#~ msgstr "Kiválasztott pillanatkép elérési út"
 
 #~ msgid "Third Party Tools"
 #~ msgstr "Harmadik féltől származó szoftverek"
@@ -2901,6 +2892,11 @@ msgstr "nem kijelölt"
 
 #~ msgid "View:"
 #~ msgstr "Nézet:"
+
+#, fuzzy
+#~ msgid "Click to edit and drag-drop to re-order"
+#~ msgstr ""
+#~ "Kattintson a szerkesztéshez. Az elemek sorrendjét húzással átrendezheti."
 
 #~ msgid "Change"
 #~ msgstr "Megváltozott"

--- a/po/timeshift-ia.po
+++ b/po/timeshift-ia.po
@@ -1,24 +1,17 @@
-# Interlingua translation for linuxmint
-# Copyright (c) 2017 Rosetta Contributors and Canonical Ltd 2017
-# This file is distributed under the same license as the linuxmint package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
-"PO-Revision-Date: 2017-09-27 13:43+0000\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
+"PO-Revision-Date: 2017-12-12 12:36+0000\n"
 "Last-Translator: karm <melo@carmu.com>\n"
 "Language-Team: Interlingua <ia@li.org>\n"
 "Language: ia\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:01+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -216,12 +209,6 @@ msgstr "Autores"
 msgid "Available"
 msgstr "Disponibile"
 
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
-
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr "BTRFS"
@@ -237,6 +224,12 @@ msgstr "Instrumentos de BTRFS non trovate"
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
 msgstr "Le dispositivo BTRFS non es<montate"
+
+#: Gtk/BackupDeviceBox.vala:98
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
+msgstr ""
 
 #: Gtk/FinishBox.vala:92
 msgid ""
@@ -2798,36 +2791,6 @@ msgstr "rsync ha restituite un error"
 msgid "un-tagged"
 msgstr "no-taggate"
 
-#, fuzzy
-#~ msgid "Click to edit and drag-drop to re-order"
-#~ msgstr "Clicca pro rediger. Trahe e depone pro re-ordinar."
-
-#~ msgid ""
-#~ "Click an item to edit the pattern.\n"
-#~ "Drag and drop items with mouse to re-order."
-#~ msgstr ""
-#~ "Clicca un elemento pro rediger le modello.\n"
-#~ "Trahe e depone le elementos per le mus pro re-ordinar."
-
-#~ msgid "Editing and Re-Ordering"
-#~ msgstr "Rediger e Re-ordinar"
-
-#~ msgid "Info"
-#~ msgstr "Informationes"
-
-#~ msgid "Deleted system subvolumes"
-#~ msgstr "Sub-volumines de systema delite"
-
-#~ msgid "<b>System:</b> Installed Linux distribution"
-#~ msgstr "<b>Systema:</b> distribution de Linux installate"
-
-#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
-#~ msgstr ""
-#~ "<b>Data del instantaneo:</b> data in le qual le instantaneo esseva create"
-
-#~ msgid "Selected snapshot path"
-#~ msgstr "Percurso del instantaneo seligite"
-
 #~ msgid ""
 #~ "<b>Backup Levels</b>\n"
 #~ "\n"
@@ -2847,6 +2810,20 @@ msgstr "no-taggate"
 #~ "W\tSeptimanal\n"
 #~ "M\tMensual"
 
+#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
+#~ msgstr ""
+#~ "<b>Data del instantaneo:</b> data in le qual le instantaneo esseva create"
+
+#~ msgid "<b>System:</b> Installed Linux distribution"
+#~ msgstr "<b>Systema:</b> distribution de Linux installate"
+
+#~ msgid ""
+#~ "Click an item to edit the pattern.\n"
+#~ "Drag and drop items with mouse to re-order."
+#~ msgstr ""
+#~ "Clicca un elemento pro rediger le modello.\n"
+#~ "Trahe e depone le elementos per le mus pro re-ordinar."
+
 #~ msgid "Cloning System..."
 #~ msgstr "Clonation del systema..."
 
@@ -2856,14 +2833,26 @@ msgstr "no-taggate"
 #~ msgid "Contributions"
 #~ msgstr "Contributiones"
 
+#~ msgid "Create snapshots using RSYNC"
+#~ msgstr "Crear instantaneos per RSYNC"
+
+#~ msgid "Deleted system subvolumes"
+#~ msgstr "Sub-volumines de systema delite"
+
 #~ msgid "Documenters"
 #~ msgstr "Documentaristas"
+
+#~ msgid "Editing and Re-Ordering"
+#~ msgstr "Rediger e Re-ordinar"
 
 #~ msgid "Include everything"
 #~ msgstr "Includer toto"
 
 #~ msgid "Include hidden items"
 #~ msgstr "Includer le elementos celate"
+
+#~ msgid "Info"
+#~ msgstr "Informationes"
 
 #~ msgid "Log Viewer"
 #~ msgstr "Visor del log"
@@ -2873,6 +2862,9 @@ msgstr "no-taggate"
 
 #~ msgid "Scheduled task runs once every hour"
 #~ msgstr "Le labor programmate flue un vice cata hora"
+
+#~ msgid "Selected snapshot path"
+#~ msgstr "Percurso del instantaneo seligite"
 
 #~ msgid "Third Party Tools"
 #~ msgstr "Applicationes de tertie parte"
@@ -2888,6 +2880,10 @@ msgstr "no-taggate"
 
 #~ msgid "View:"
 #~ msgstr "Vista:"
+
+#, fuzzy
+#~ msgid "Click to edit and drag-drop to re-order"
+#~ msgstr "Clicca pro rediger. Trahe e depone pro re-ordinar."
 
 #~ msgid "Change"
 #~ msgstr "Cambiate"

--- a/po/timeshift-id.po
+++ b/po/timeshift-id.po
@@ -1,13 +1,8 @@
-# Indonesian translation for linuxmint
-# Copyright (c) 2017 Rosetta Contributors and Canonical Ltd 2017
-# This file is distributed under the same license as the linuxmint package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
 "PO-Revision-Date: 2017-10-01 01:19+0000\n"
 "Last-Translator: dodolzk <Unknown>\n"
 "Language-Team: Indonesian <id@li.org>\n"
@@ -15,10 +10,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:01+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -203,12 +196,6 @@ msgstr ""
 msgid "Available"
 msgstr ""
 
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
-
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr ""
@@ -223,6 +210,12 @@ msgstr ""
 
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
+msgstr ""
+
+#: Gtk/BackupDeviceBox.vala:98
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
 msgstr ""
 
 #: Gtk/FinishBox.vala:92

--- a/po/timeshift-is.po
+++ b/po/timeshift-is.po
@@ -1,25 +1,17 @@
-# Icelandic translation for linuxmint
-# Copyright (c) 2017 Rosetta Contributors and Canonical Ltd 2017
-# This file is distributed under the same license as the linuxmint package.
-#
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# Sveinn í Felli <sv1@fellsnet.is>, 2017.
 msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
-"PO-Revision-Date: 2017-11-22 11:42+0000\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
+"PO-Revision-Date: 2018-05-15 10:30+0000\n"
 "Last-Translator: Sveinn í Felli <sv1@fellsnet.is>\n"
 "Language-Team: Icelandic <is@li.org>\n"
 "Language: is\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:01+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -208,12 +200,6 @@ msgstr "Höfundar"
 msgid "Available"
 msgstr "Tiltækt"
 
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
-
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr "BTRFS"
@@ -229,6 +215,13 @@ msgstr "Fann ekki BTRFS-tólin"
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
 msgstr "BTRFS-tækið er ekki tengt í skráakerfi"
+
+#: Gtk/BackupDeviceBox.vala:98
+#, fuzzy
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
+msgstr "Önnur forrit (næsta síða)"
 
 #: Gtk/FinishBox.vala:92
 msgid ""
@@ -276,7 +269,7 @@ msgstr "Ekkert ræsitæki valið"
 
 #: Core/Main.vala:1017
 msgid "Boot snapshot failed!"
-msgstr ""
+msgstr "Boot-ræsiskyndiafrit mistókst!"
 
 #: Gtk/ScheduleBox.vala:169
 msgid ""
@@ -285,7 +278,7 @@ msgstr ""
 
 #: Core/Main.vala:998
 msgid "Boot snapshots are enabled"
-msgstr ""
+msgstr "Boot-ræsiskyndiafrit eru virk"
 
 #: Gtk/BootOptionsWindow.vala:49
 msgid "Bootloader Options"
@@ -332,7 +325,7 @@ msgstr ""
 
 #: Gtk/MainWindow.vala:563
 msgid "Cannot Delete Live Snapshot"
-msgstr ""
+msgstr "Tekst ekki að eyða Live-skyndiafriti"
 
 #: Gtk/RsyncLogBox.vala:380 Gtk/RsyncLogBox.vala:383 Gtk/RsyncLogBox.vala:567
 #: Gtk/RsyncLogBox.vala:588 Gtk/RestoreBox.vala:125 Gtk/BackupBox.vala:87
@@ -502,6 +495,8 @@ msgid ""
 "Create snapshots manually or enable scheduled snapshots to protect your "
 "system"
 msgstr ""
+"Útbúðu skyndiafrit handvirkt eða virkjaðu áætluð skyndiafrit til að vernda "
+"kerfið þitt"
 
 #: Gtk/SnapshotBackendBox.vala:95
 #, fuzzy
@@ -528,7 +523,7 @@ msgstr "Bjó til möppu"
 
 #: Core/Main.vala:2996
 msgid "Created pre-restore snapshot"
-msgstr ""
+msgstr "Útbjó for-endurheimtu skyndiafrit"
 
 #: Core/Main.vala:1499
 msgid "Created subvolume snapshot"
@@ -684,7 +679,7 @@ msgstr "Tæki með Linux-skráakerfum"
 
 #: Gtk/RestoreDeviceBox.vala:84
 msgid "Devices from which snapshot was created are pre-selected."
-msgstr ""
+msgstr "Tæki þar sem skyndiafrit var búið til eru forvalin."
 
 #: Console/AppConsole.vala:326
 msgid "Devices with Linux file systems"
@@ -710,6 +705,21 @@ msgid ""
 "Tony George\n"
 "(teejeetech@gmail.com)"
 msgstr ""
+"Finnst þér þessi hugbúnaður nytsamlegur?\n"
+"\n"
+"Þú getur keypt handa mér kaffibolla eða gefið smá pening með PayPal til að "
+"sýna mér stuðning í verki. Eða hripað til mín línu og sagt hvað þér finnst. "
+"Þetta forrit er algerlega frjálst og ókeypis og mun halda áfram að vera það. "
+"Framlag þitt hjálpar til við að halda verkefninu lifandi og verður kannski "
+"til þess að það verði ennþá betra.\n"
+"\n"
+"Ekki hika við að senda mér tölvupóst ef þú finnur einhver vandamál í "
+"hugbúnaðinum eða ef þú sérð fyrir þér eitthvað sem betur mætti fara. "
+"Tillögur og umsagnir eru alltaf vel þegnar.\n"
+"\n"
+"Takk fyrir,\n"
+"Tony George\n"
+"(teejeetech@gmail.com)"
 
 #: Utility/TeeJee.FileSystem.vala:518
 msgid "Dir not found"
@@ -753,7 +763,7 @@ msgstr ""
 
 #: Gtk/MainWindow.vala:1068
 msgid "Enable scheduled snapshots to protect your system"
-msgstr ""
+msgstr "Virkjaðu áætluð skyndiafrit til að vernda kerfið þitt"
 
 #: Core/Main.vala:4030 Core/Main.vala:4070
 msgid "Enabled subvolume quota support"
@@ -897,7 +907,7 @@ msgstr "Mistókst að eyða tákntengjum"
 
 #: Core/Subvolume.vala:164
 msgid "Failed to destroy qgroup"
-msgstr ""
+msgstr "Tókst ekki að eyða qgroup"
 
 #: Core/Main.vala:4055
 msgid "Failed to enable subvolume quota"
@@ -909,7 +919,7 @@ msgstr "Ekki tókst að áætla stærð kerfis"
 
 #: Utility/CronTab.vala:257
 msgid "Failed to export crontab file"
-msgstr ""
+msgstr "Mistókst að flytja út crontab-skrá"
 
 #: Console/AppConsole.vala:697 Console/AppConsole.vala:761
 #: Console/AppConsole.vala:893 Console/AppConsole.vala:988
@@ -927,7 +937,7 @@ msgstr "Tókst ekki að sækja lista yfir disksneiðar."
 
 #: Utility/CronTab.vala:240
 msgid "Failed to install crontab file"
-msgstr ""
+msgstr "Mistókst að setja upp crontab-skrá"
 
 #: Gtk/RestoreDeviceBox.vala:535
 msgid "Failed to mount devices"
@@ -951,7 +961,7 @@ msgstr ""
 
 #: Utility/CronTab.vala:50
 msgid "Failed to read cron tab"
-msgstr "Mistókst að lesa cron-flipann"
+msgstr "Mistókst að lesa crontab"
 
 #: Utility/TeeJee.FileSystem.vala:148
 msgid "Failed to read file"
@@ -1073,7 +1083,7 @@ msgstr "Fyrsta skyndiafrit krefst:"
 
 #: Core/Main.vala:2894
 msgid "Found existing pre-restore snapshot"
-msgstr ""
+msgstr "Fann fyrirliggjandi for-endurheimtu skyndiafrit"
 
 #: Gtk/BackupDeviceBox.vala:215
 msgid "Free"
@@ -1113,6 +1123,8 @@ msgid ""
 "Hidden files and folders are included by default since they contain user-"
 "specific configuration files."
 msgstr ""
+"Faldar skrár og möppur eru sjálfgefið hafðar með því þær innihalda sértækar "
+"stillingaskrár notandans."
 
 #: Gtk/DeleteWindow.vala:178
 msgid "Hide"
@@ -1155,6 +1167,9 @@ msgid ""
 "If the restored system fails to boot, then boot from the Live CD/USB, "
 "install Timeshift, and try restoring another snapshot."
 msgstr ""
+"Ef ekki tekst að ræsa endurheimta kerfið, ræstu þá upp af Live CD/USB "
+"keyrsludisk, settu inn Timeshift, og reyndu að endurheimta eitthvað annað "
+"skyndiafrit."
 
 #: Core/Main.vala:2212
 msgid ""
@@ -1244,15 +1259,15 @@ msgstr "Skýring"
 #: Core/Main.vala:1010
 #, c-format
 msgid "Last boot snapshot is %d hours old"
-msgstr "Síðasta boot-skyndiafrit er %d klst gamalt"
+msgstr "Síðasta boot-ræsiskyndiafrit er %d klst gamalt"
 
 #: Core/Main.vala:1005
 msgid "Last boot snapshot is older than system start time"
-msgstr "Síðasta boot-skyndiafrit er eldra en ræsitími kerfisins"
+msgstr "Síðasta boot-ræsiskyndiafrit er eldra en ræsitími kerfisins"
 
 #: Core/Main.vala:1001
 msgid "Last boot snapshot not found"
-msgstr "Síðasta boot-skyndiafrit fannst ekki"
+msgstr "Síðasta boot-ræsiskyndiafrit fannst ekki"
 
 #: Core/Main.vala:1070
 #, c-format
@@ -1318,7 +1333,7 @@ msgstr ""
 #: Core/Main.vala:1344
 #, c-format
 msgid "Linking from snapshot"
-msgstr ""
+msgstr "Tengi úr skyndiafriti"
 
 #: Console/AppConsole.vala:352
 msgid "List"
@@ -2229,7 +2244,7 @@ msgstr ""
 
 #: Console/AppConsole.vala:283
 msgid "Snapshots cannot be created in Live CD mode"
-msgstr ""
+msgstr "Ekki tókst að útbúa skyndiafrit í Live CD ham"
 
 #: Gtk/MainWindow.vala:1059
 msgid "Snapshots will be created at selected intervals"
@@ -2664,27 +2679,6 @@ msgstr "rsync skilaði villu"
 msgid "un-tagged"
 msgstr "ómerkt"
 
-#, fuzzy
-#~ msgid "Click to edit and drag-drop to re-order"
-#~ msgstr "Smelltu til að breyta. Dragðu og slepptu til að endurraða."
-
-#~ msgid "Editing and Re-Ordering"
-#~ msgstr "Breytingar og endurröðun"
-
-#~ msgid "Info"
-#~ msgstr "Upplýsingar"
-
-#~ msgid "<b>System:</b> Installed Linux distribution"
-#~ msgstr "<b>Kerfi:</b> Uppsett Linux-dreifing"
-
-#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
-#~ msgstr ""
-#~ "<b>Dagsetning skyndiafrits:</b> Dagsetningin þegar skyndiafrit var búið "
-#~ "til"
-
-#~ msgid "Selected snapshot path"
-#~ msgstr "Slóð á valið skyndiafrit"
-
 #~ msgid ""
 #~ "<b>Backup Levels</b>\n"
 #~ "\n"
@@ -2704,6 +2698,21 @@ msgstr "ómerkt"
 #~ "W\tVikulega\n"
 #~ "M\tMánaðarlega"
 
+#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
+#~ msgstr ""
+#~ "<b>Dagsetning skyndiafrits:</b> Dagsetningin þegar skyndiafrit var búið "
+#~ "til"
+
+#~ msgid "<b>System:</b> Installed Linux distribution"
+#~ msgstr "<b>Kerfi:</b> Uppsett Linux-dreifing"
+
+#~ msgid ""
+#~ "Click an item to edit the pattern.\n"
+#~ "Drag and drop items with mouse to re-order."
+#~ msgstr ""
+#~ "Smelltu á atriði til að breyta mynstrinu.\n"
+#~ "Dragðu og slepptu með músinni til að endurraða."
+
 #~ msgid "Cloning System..."
 #~ msgstr "Klóna kerfið ..."
 
@@ -2713,8 +2722,14 @@ msgstr "ómerkt"
 #~ msgid "Contributions"
 #~ msgstr "Framlög frá"
 
+#~ msgid "Create snapshots using RSYNC"
+#~ msgstr "Búa til skyndiafrit með RSYNC"
+
 #~ msgid "Documenters"
 #~ msgstr "Höfundar hjápargagna"
+
+#~ msgid "Editing and Re-Ordering"
+#~ msgstr "Breytingar og endurröðun"
 
 #~ msgid "Include everything"
 #~ msgstr "Hafa allt innifalið"
@@ -2722,11 +2737,17 @@ msgstr "ómerkt"
 #~ msgid "Include hidden items"
 #~ msgstr "Hafa með falin atriði"
 
+#~ msgid "Info"
+#~ msgstr "Upplýsingar"
+
 #~ msgid "Log Viewer"
 #~ msgstr "Atvikaskoðari"
 
 #~ msgid "Refresh Snapshot List"
 #~ msgstr "Endurlesa lista yfir skyndiafrit"
+
+#~ msgid "Selected snapshot path"
+#~ msgstr "Slóð á valið skyndiafrit"
 
 #~ msgid "Third Party Tools"
 #~ msgstr "Verkfæri frá þriðja aðila"
@@ -2742,6 +2763,10 @@ msgstr "ómerkt"
 
 #~ msgid "View:"
 #~ msgstr "Skoða:"
+
+#, fuzzy
+#~ msgid "Click to edit and drag-drop to re-order"
+#~ msgstr "Smelltu til að breyta. Dragðu og slepptu til að endurraða."
 
 #~ msgid "Change"
 #~ msgstr "Breytt"

--- a/po/timeshift-it.po
+++ b/po/timeshift-it.po
@@ -2,18 +2,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: timeshift 1.0\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
-"PO-Revision-Date: 2017-10-24 07:52+0000\n"
-"Last-Translator: Giorgio Ponza <Unknown>\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
+"PO-Revision-Date: 2018-06-15 14:25+0000\n"
+"Last-Translator: lang-it <Unknown>\n"
 "Language-Team: \n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:01+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -211,12 +209,6 @@ msgstr "Autori"
 msgid "Available"
 msgstr "Disponibile"
 
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
-
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr "BTRFS"
@@ -232,6 +224,13 @@ msgstr "Gli strumenti BTRFS non sono disponibili"
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
 msgstr "Il dispositivo BTRFS non è montato"
+
+#: Gtk/BackupDeviceBox.vala:98
+#, fuzzy
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
+msgstr "Altre applicazioni (pagina successiva)"
 
 #: Gtk/FinishBox.vala:92
 msgid ""
@@ -275,9 +274,7 @@ msgstr "Clients Bittorrent"
 
 #: Gtk/ScheduleBox.vala:136 Gtk/SnapshotListBox.vala:298
 msgid "Boot"
-msgstr ""
-"All'avvio\n"
-"Avvio"
+msgstr "All'avvio"
 
 #: Gtk/RestoreDeviceBox.vala:499
 msgid "Boot device not selected"
@@ -548,7 +545,7 @@ msgstr "Cartella creata"
 
 #: Core/Main.vala:2996
 msgid "Created pre-restore snapshot"
-msgstr "Creato snapshot di pre-ripristino"
+msgstr "Creata istantanea di pre-ripristino"
 
 #: Core/Main.vala:1499
 msgid "Created subvolume snapshot"
@@ -744,20 +741,6 @@ msgstr ""
 "\n"
 "Grazie,\n"
 "Tony George\n"
-"(teejeetech@gmail.com)\n"
-"Hai trovato utile questo software?\n"
-"\n"
-"Puoi comprarmi un caffe o fare una donazione tramite PayPal per dimostrare "
-"il tuo supporto. O mandami un'email e dimmi ciao. Questa applicazione è "
-"completamente gratuita e continuerà a rimanere tale. I tuoi contributi "
-"aiuteranno a mantenere questo progetto vivo e a migliorarlo ulteriormente.\n"
-"\n"
-"Sentiti libero di inviarmi un email se trovi qualche problema in questa "
-"applicazione o se hai bisogno di qualche cambiamento. I suggerimenti e i "
-"feedback sono sempre ben accetti.\n"
-"\n"
-"Grazie,\n"
-"Tony George\n"
 "(teejeetech@gmail.com)"
 
 #: Utility/TeeJee.FileSystem.vala:518
@@ -887,9 +870,7 @@ msgstr "Lista Esclusione"
 
 #: Gtk/ExcludeListSummaryWindow.vala:49
 msgid "Exclude List Summary"
-msgstr ""
-"Riepilogo Lista Esclusioni\n"
-"Sommario Lista Esclusioni"
+msgstr "Riepilogo Lista Esclusioni"
 
 #: Gtk/ExcludeBox.vala:224
 msgid "Exclude Pattern"
@@ -1045,9 +1026,7 @@ msgstr "Impossibile smontare"
 
 #: Core/Main.vala:3519
 msgid "Failed to unmount device!"
-msgstr ""
-"Impossibile smontare il dispositivo!\n"
-"Impossibile montare il dispositivo!"
+msgstr "Impossibile smontare il dispositivo!"
 
 #: Utility/TeeJee.FileSystem.vala:175
 msgid "Failed to write file"
@@ -1097,9 +1076,7 @@ msgstr "Conteggio file e cartelle:"
 
 #: Gtk/ExcludeMessageWindow.vala:76
 msgid "Files matching the following patterns will be excluded"
-msgstr ""
-"Saranno esclusi i file corrispondenti alle maschere seguenti\n"
-"Saranno esclusi i file corrispondenti ai seguenti modelli"
+msgstr "Saranno esclusi i file corrispondenti alle maschere seguenti"
 
 #: Utility/Device.vala:1828
 #, c-format
@@ -1141,9 +1118,7 @@ msgstr "Disponibile"
 
 #: Core/SnapshotRepo.vala:77 Core/SnapshotRepo.vala:147
 msgid "Free space"
-msgstr ""
-"Spazio disponibile\n"
-"Spazio libero"
+msgstr "Spazio disponibile"
 
 #: Console/AppConsole.vala:1042
 msgid "GRUB Device"
@@ -1261,7 +1236,8 @@ msgstr "Immagine non valida"
 
 #: Utility/Gtk/DonationWindow.vala:97
 msgid "Issue Tracker ~ Report Issues, Request Features, Ask Questions"
-msgstr "Issue Tracker ~ Segnala Problemi, Richiedi Funzionalità, Fai Domande"
+msgstr ""
+"Tracciamento Problemi ~ Segnala Problemi, Richiedi Funzionalità, Fai Domande"
 
 #: Gtk/ExcludeBox.vala:272
 msgid "Items Not Selected"
@@ -2823,35 +2799,6 @@ msgstr "rsync ha restituito un errore"
 msgid "un-tagged"
 msgstr "non-taggato"
 
-#, fuzzy
-#~ msgid "Click to edit and drag-drop to re-order"
-#~ msgstr "Clicca per modificare. Trascina e rilascia per riordinare."
-
-#~ msgid ""
-#~ "Click an item to edit the pattern.\n"
-#~ "Drag and drop items with mouse to re-order."
-#~ msgstr ""
-#~ "Clicca su un elemento per modificarne il pattern.\n"
-#~ "Trascina e rilascia gli elementi con il mouse per riordinarli."
-
-#~ msgid "Editing and Re-Ordering"
-#~ msgstr "Modifica e Riordinamento"
-
-#~ msgid "Info"
-#~ msgstr "Informazioni"
-
-#~ msgid "Deleted system subvolumes"
-#~ msgstr "Sottovolumi di sistema eliminati"
-
-#~ msgid "<b>System:</b> Installed Linux distribution"
-#~ msgstr "<b>Sistema:</b> Distribuzione Linux installata"
-
-#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
-#~ msgstr "<b>Data istantanea:</b> Data in cui è stata creata l'istantanea"
-
-#~ msgid "Selected snapshot path"
-#~ msgstr "Percorso istantanea selezionata"
-
 #~ msgid ""
 #~ "<b>Backup Levels</b>\n"
 #~ "\n"
@@ -2871,6 +2818,19 @@ msgstr "non-taggato"
 #~ "W\tOgni settimana\n"
 #~ "M\tOgni mese"
 
+#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
+#~ msgstr "<b>Data istantanea:</b> Data in cui è stata creata l'istantanea"
+
+#~ msgid "<b>System:</b> Installed Linux distribution"
+#~ msgstr "<b>Sistema:</b> Distribuzione Linux installata"
+
+#~ msgid ""
+#~ "Click an item to edit the pattern.\n"
+#~ "Drag and drop items with mouse to re-order."
+#~ msgstr ""
+#~ "Clicca su un elemento per modificarne il pattern.\n"
+#~ "Trascina e rilascia gli elementi con il mouse per riordinarli."
+
 #~ msgid "Cloning System..."
 #~ msgstr "Clonazione Sistema..."
 
@@ -2880,14 +2840,26 @@ msgstr "non-taggato"
 #~ msgid "Contributions"
 #~ msgstr "Contributi"
 
+#~ msgid "Create snapshots using RSYNC"
+#~ msgstr "Creare l'immagine usando RSYNC"
+
+#~ msgid "Deleted system subvolumes"
+#~ msgstr "Sottovolumi di sistema eliminati"
+
 #~ msgid "Documenters"
 #~ msgstr "Documentazione"
+
+#~ msgid "Editing and Re-Ordering"
+#~ msgstr "Modifica e Riordinamento"
 
 #~ msgid "Include everything"
 #~ msgstr "Includi tutto"
 
 #~ msgid "Include hidden items"
 #~ msgstr "Includi elementi nascosti"
+
+#~ msgid "Info"
+#~ msgstr "Informazioni"
 
 #~ msgid "Log Viewer"
 #~ msgstr "Visualizzatore Registro di Log"
@@ -2897,6 +2869,9 @@ msgstr "non-taggato"
 
 #~ msgid "Scheduled task runs once every hour"
 #~ msgstr "L'attività pianificata viene eseguita una volta ogni ora"
+
+#~ msgid "Selected snapshot path"
+#~ msgstr "Percorso istantanea selezionata"
 
 #~ msgid "Third Party Tools"
 #~ msgstr "Tool di terze parti"
@@ -2912,6 +2887,10 @@ msgstr "non-taggato"
 
 #~ msgid "View:"
 #~ msgstr "Visualizza:"
+
+#, fuzzy
+#~ msgid "Click to edit and drag-drop to re-order"
+#~ msgstr "Clicca per modificare. Trascina e rilascia per riordinare."
 
 #~ msgid "Change"
 #~ msgstr "Modificato"

--- a/po/timeshift-ko.po
+++ b/po/timeshift-ko.po
@@ -1,24 +1,17 @@
-# Korean translation for timeshift
-# Copyright (c) 2013 Rosetta Contributors and Canonical Ltd 2013
-# This file is distributed under the same license as the timeshift package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2013.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: timeshift\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
-"PO-Revision-Date: 2017-11-17 14:25+0000\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
+"PO-Revision-Date: 2017-12-08 16:26+0000\n"
 "Last-Translator: Jung-Kyu Park <bagjunggyu@gmail.com>\n"
 "Language-Team: Korean <ko@li.org>\n"
 "Language: ko\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:01+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -212,12 +205,6 @@ msgstr "저자"
 msgid "Available"
 msgstr "사용 가능"
 
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
-
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr "BTRFS"
@@ -233,6 +220,13 @@ msgstr "BTRFS 도구가 없습니다"
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
 msgstr "BTRFS 장치가 마운트 되지 않았습니다"
+
+#: Gtk/BackupDeviceBox.vala:98
+#, fuzzy
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
+msgstr "다른 애플리케이션 (다음 페이지)"
 
 #: Gtk/FinishBox.vala:92
 msgid ""
@@ -2314,8 +2308,6 @@ msgid ""
 "space (> 1 GB)"
 msgstr ""
 "디스크 공간이 충분하다면 설정한 스케줄대로 스냅샷이 만들어지게 됩니다 (> 1 "
-"GB)\n"
-"디스크 공간이 충분하다면 설정한 스케줄대로 스냅샷을 만들어지게 됩니다 (> 1 "
 "GB)"
 
 #: Gtk/MainWindow.vala:642
@@ -2751,35 +2743,6 @@ msgstr "알싱크가 오류를 실행했습니다"
 msgid "un-tagged"
 msgstr "태그 되지 않은"
 
-#, fuzzy
-#~ msgid "Click to edit and drag-drop to re-order"
-#~ msgstr "클릭해서 편집하기. 드래그 앤 드롭해서 다시 정렬하기."
-
-#~ msgid ""
-#~ "Click an item to edit the pattern.\n"
-#~ "Drag and drop items with mouse to re-order."
-#~ msgstr ""
-#~ "항목을 클릭해서 패턴을 편집하세요.\n"
-#~ "항목을 드래그 앤 드롭해서 다시 정렬하세요."
-
-#~ msgid "Editing and Re-Ordering"
-#~ msgstr "편집 및 다시 정렬하기"
-
-#~ msgid "Info"
-#~ msgstr "정보"
-
-#~ msgid "Deleted system subvolumes"
-#~ msgstr "지워진 시스템 서브 볼륨"
-
-#~ msgid "<b>System:</b> Installed Linux distribution"
-#~ msgstr "<b>시스템:</b> 설치된 리눅스 배포판입니다"
-
-#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
-#~ msgstr "<b>스냅샷 날짜:</b> 스냅샷이 만들어진 날짜입니다"
-
-#~ msgid "Selected snapshot path"
-#~ msgstr "선택한 스냅샷 경로"
-
 #~ msgid ""
 #~ "<b>Backup Levels</b>\n"
 #~ "\n"
@@ -2799,6 +2762,19 @@ msgstr "태그 되지 않은"
 #~ "W\t매주\n"
 #~ "M\t매월"
 
+#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
+#~ msgstr "<b>스냅샷 날짜:</b> 스냅샷이 만들어진 날짜입니다"
+
+#~ msgid "<b>System:</b> Installed Linux distribution"
+#~ msgstr "<b>시스템:</b> 설치된 리눅스 배포판입니다"
+
+#~ msgid ""
+#~ "Click an item to edit the pattern.\n"
+#~ "Drag and drop items with mouse to re-order."
+#~ msgstr ""
+#~ "항목을 클릭해서 패턴을 편집하세요.\n"
+#~ "항목을 드래그 앤 드롭해서 다시 정렬하세요."
+
 #~ msgid "Cloning System..."
 #~ msgstr "시스템을 복제하고 있습니다..."
 
@@ -2808,14 +2784,26 @@ msgstr "태그 되지 않은"
 #~ msgid "Contributions"
 #~ msgstr "기여"
 
+#~ msgid "Create snapshots using RSYNC"
+#~ msgstr "RSYNC를 써서 스냅샷 만들기"
+
+#~ msgid "Deleted system subvolumes"
+#~ msgstr "지워진 시스템 서브 볼륨"
+
 #~ msgid "Documenters"
 #~ msgstr "문서 작성자"
+
+#~ msgid "Editing and Re-Ordering"
+#~ msgstr "편집 및 다시 정렬하기"
 
 #~ msgid "Include everything"
 #~ msgstr "모두 포함하기"
 
 #~ msgid "Include hidden items"
 #~ msgstr "숨김 항목 포함하기"
+
+#~ msgid "Info"
+#~ msgstr "정보"
 
 #~ msgid "Log Viewer"
 #~ msgstr "로그 뷰어"
@@ -2825,6 +2813,9 @@ msgstr "태그 되지 않은"
 
 #~ msgid "Scheduled task runs once every hour"
 #~ msgstr "스케줄 관리는 매 시간마다 한 번씩 실행합니다"
+
+#~ msgid "Selected snapshot path"
+#~ msgstr "선택한 스냅샷 경로"
 
 #~ msgid "Third Party Tools"
 #~ msgstr "제삼자 도구"
@@ -2840,6 +2831,10 @@ msgstr "태그 되지 않은"
 
 #~ msgid "View:"
 #~ msgstr "보기:"
+
+#, fuzzy
+#~ msgid "Click to edit and drag-drop to re-order"
+#~ msgstr "클릭해서 편집하기. 드래그 앤 드롭해서 다시 정렬하기."
 
 #~ msgid "Change"
 #~ msgstr "변경됨"

--- a/po/timeshift-lt.po
+++ b/po/timeshift-lt.po
@@ -1,13 +1,8 @@
-# Lithuanian translation for linuxmint
-# Copyright (c) 2017 Rosetta Contributors and Canonical Ltd 2017
-# This file is distributed under the same license as the linuxmint package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
 "PO-Revision-Date: 2017-11-16 18:40+0000\n"
 "Last-Translator: Moo <hazap@hotmail.com>\n"
 "Language-Team: Lithuanian <lt@li.org>\n"
@@ -15,10 +10,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:00+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -216,12 +209,6 @@ msgstr "Autoriai"
 msgid "Available"
 msgstr "Prieinama"
 
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
-
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr "BTRFS"
@@ -237,6 +224,13 @@ msgstr "Nerasti BTRFS įrankiai"
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
 msgstr "BTRFS įrenginys nėra prijungtas"
+
+#: Gtk/BackupDeviceBox.vala:98
+#, fuzzy
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
+msgstr "Kitos programos (kitas puslapis)"
 
 #: Gtk/FinishBox.vala:92
 msgid ""
@@ -2795,36 +2789,6 @@ msgstr "rsync grąžino klaidą"
 msgid "un-tagged"
 msgstr "be žymių"
 
-#, fuzzy
-#~ msgid "Click to edit and drag-drop to re-order"
-#~ msgstr "Spustelėkite, norėdami taisyti. Vilkite, norėdami pertvarkyti."
-
-#~ msgid ""
-#~ "Click an item to edit the pattern.\n"
-#~ "Drag and drop items with mouse to re-order."
-#~ msgstr ""
-#~ "Spustelėkite ant elemento, norėdami taisyti šabloną.\n"
-#~ "Vilkite elementus pele, norėdami juos pertvarkyti."
-
-#~ msgid "Editing and Re-Ordering"
-#~ msgstr "Taisymas ir pertvarkymas"
-
-#~ msgid "Info"
-#~ msgstr "Informacija"
-
-#~ msgid "Deleted system subvolumes"
-#~ msgstr "Ištrinti sistemos patomiai"
-
-#~ msgid "<b>System:</b> Installed Linux distribution"
-#~ msgstr "<b>Sistema:</b> Įdiegta Linux distribucija"
-
-#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
-#~ msgstr ""
-#~ "<b>Momentinės kopijos data:</b> Data, kada buvo sukurta momentinė kopija"
-
-#~ msgid "Selected snapshot path"
-#~ msgstr "Pasirinktas momentinės kopijos kelias"
-
 #~ msgid ""
 #~ "<b>Backup Levels</b>\n"
 #~ "\n"
@@ -2844,6 +2808,20 @@ msgstr "be žymių"
 #~ "W\tKas savaitę\n"
 #~ "M\tKas mėnesį"
 
+#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
+#~ msgstr ""
+#~ "<b>Momentinės kopijos data:</b> Data, kada buvo sukurta momentinė kopija"
+
+#~ msgid "<b>System:</b> Installed Linux distribution"
+#~ msgstr "<b>Sistema:</b> Įdiegta Linux distribucija"
+
+#~ msgid ""
+#~ "Click an item to edit the pattern.\n"
+#~ "Drag and drop items with mouse to re-order."
+#~ msgstr ""
+#~ "Spustelėkite ant elemento, norėdami taisyti šabloną.\n"
+#~ "Vilkite elementus pele, norėdami juos pertvarkyti."
+
 #~ msgid "Cloning System..."
 #~ msgstr "Klonuojama sistema..."
 
@@ -2853,14 +2831,26 @@ msgstr "be žymių"
 #~ msgid "Contributions"
 #~ msgstr "Talkinimai"
 
+#~ msgid "Create snapshots using RSYNC"
+#~ msgstr "Sukurti momentines kopijas, naudojant RSYNC"
+
+#~ msgid "Deleted system subvolumes"
+#~ msgstr "Ištrinti sistemos patomiai"
+
 #~ msgid "Documenters"
 #~ msgstr "Dokumentuotojai"
+
+#~ msgid "Editing and Re-Ordering"
+#~ msgstr "Taisymas ir pertvarkymas"
 
 #~ msgid "Include everything"
 #~ msgstr "Įtraukti viską"
 
 #~ msgid "Include hidden items"
 #~ msgstr "Įtraukti paslėptus elementus"
+
+#~ msgid "Info"
+#~ msgstr "Informacija"
 
 #~ msgid "Log Viewer"
 #~ msgstr "Žurnalų žiūryklė"
@@ -2870,6 +2860,9 @@ msgstr "be žymių"
 
 #~ msgid "Scheduled task runs once every hour"
 #~ msgstr "Planinė užduotis yra vykdoma kartą per valandą"
+
+#~ msgid "Selected snapshot path"
+#~ msgstr "Pasirinktas momentinės kopijos kelias"
 
 #~ msgid "Third Party Tools"
 #~ msgstr "Trečiųjų šalių įrankiai"
@@ -2885,6 +2878,10 @@ msgstr "be žymių"
 
 #~ msgid "View:"
 #~ msgstr "Rodinys:"
+
+#, fuzzy
+#~ msgid "Click to edit and drag-drop to re-order"
+#~ msgstr "Spustelėkite, norėdami taisyti. Vilkite, norėdami pertvarkyti."
 
 #~ msgid "Change"
 #~ msgstr "Pakeista"

--- a/po/timeshift-nb.po
+++ b/po/timeshift-nb.po
@@ -1,24 +1,17 @@
-# Norwegian Bokmal translation for linuxmint
-# Copyright (c) 2017 Rosetta Contributors and Canonical Ltd 2017
-# This file is distributed under the same license as the linuxmint package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
-"PO-Revision-Date: 2017-09-26 15:28+0000\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
+"PO-Revision-Date: 2018-04-11 12:06+0000\n"
 "Last-Translator: Emil Våge <Unknown>\n"
 "Language-Team: Norwegian Bokmal <nb@li.org>\n"
 "Language: nb\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:00+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -32,7 +25,7 @@ msgstr ""
 #: Core/SnapshotRepo.vala:641
 #, c-format
 msgid "%d snapshots, %s free"
-msgstr ""
+msgstr "%d øyeblikksbilder, %s ledig"
 
 #: Console/AppConsole.vala:914
 #, c-format
@@ -106,7 +99,7 @@ msgstr "Legg til mapper"
 
 #: Gtk/ExcludeBox.vala:219
 msgid "Add custom pattern"
-msgstr "Legg til mønster"
+msgstr "Legg til egenopprettet mønster"
 
 #: Gtk/ExcludeBox.vala:239
 msgid "Add directories"
@@ -118,7 +111,7 @@ msgstr "Legg til filer"
 
 #: Console/AppConsole.vala:360
 msgid "Add tags to snapshot (default: O)"
-msgstr ""
+msgstr "Legg til merkelapper"
 
 #: Utility/CronTab.vala:312
 msgid "Added cron task"
@@ -126,12 +119,13 @@ msgstr "La til cronoppgave"
 
 #: Gtk/AppGtk.vala:131
 msgid "Admin Access Required"
-msgstr "Admintilgang påkrevd"
+msgstr "Krever administratortilgang"
 
 #: Gtk/AppGtk.vala:126
 msgid "Admin access is required to backup and restore system files."
 msgstr ""
-"Admintilgang er påkrevd for å ta backup eller gjennopprette systemfiler."
+"Administratortilgang er påkrevd for å ta backup eller gjennopprette "
+"systemfiler."
 
 #: Gtk/RsyncLogBox.vala:363
 msgid "All Files"
@@ -143,9 +137,9 @@ msgid ""
 "are incremental. Unchanged files will be hard-linked from the previous "
 "snapshot if available."
 msgstr ""
-"Alle filer er kopiert når første øyeblikksbildet er opprettet. Senere "
-"øyeblikksbilder er trinnvis. Uendrede filer vil bli hard-linket fra forrige "
-"øyeblikksbilde hvis tilgjengelig."
+"Alle filer er kopiert når første øyeblikksbildet blir opprettet. Senere "
+"øyeblikksbilder bygger trinnvis på det første bildet. Uendrede filer vil bli "
+"direktelenket fra forrige øyeblikksbilde hvis tilgjengelig."
 
 #: Gtk/ExcludeMessageWindow.vala:130
 msgid "All other files and folders are excluded."
@@ -160,12 +154,11 @@ msgid ""
 "Either select a non-encrypted device for boot directory or select a non-"
 "encrypted device for root filesystem."
 msgstr ""
-"En kryptert enhet er valgt for rootfilsystem (/). Bootmappa (/boot) må "
-"monteres på en ikke-kryptert enhet for at systemet skal starte uten "
-"problemer.\n"
+"En kryptert enhet er valgt som root-filsystem (/). Bootmappa (/boot) må "
+"monteres på en ukryptert enhet for at systemet skal starte uten problemer.\n"
 "\n"
-"Velg enten en ikke-kryptert enhet for bootmappa, eller velg ikke-kryptert "
-"enhet for for rootfilsystemet."
+"Velg enten en ukryptert enhet for bootmappa, eller velg ukryptert enhet for "
+"for root-filsystemet."
 
 #: Core/Main.vala:249
 msgid "Another instance of Timeshift is creating a snapshot."
@@ -213,28 +206,28 @@ msgstr "Forfattere"
 
 #: Gtk/MainWindow.vala:346
 msgid "Available"
-msgstr ""
-
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
+msgstr "Tilgjengelig"
 
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
-msgstr ""
+msgstr "BTRFS"
 
 #: Gtk/SnapshotBackendBox.vala:165
 msgid "BTRFS Snapshots"
-msgstr ""
+msgstr "BTRFS øyeblikksbilder"
 
 #: Gtk/SnapshotBackendBox.vala:119
 msgid "BTRFS Tools Not Found"
-msgstr ""
+msgstr "Fant ikke BTRFS verktøy"
 
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
+msgstr "BTRFS enheten er ikke mounted"
+
+#: Gtk/BackupDeviceBox.vala:98
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
 msgstr ""
 
 #: Gtk/FinishBox.vala:92
@@ -244,26 +237,30 @@ msgid ""
 "snapshots to an external non-system disk in RSYNC mode to guard against disk "
 "failures."
 msgstr ""
+"BTRFS øyeblikksbilder er lagret på samme disken som den er laget fra. Hvis "
+"systemet får diskfeil vil øyeblikksbildene gå tapt med systemet. Lagre "
+"øyeblikksbilder til en ekstern enhet som ikke er en del av systemdisken, i "
+"RSYNC modus, for å beskytte mot diskfeil."
 
 #: Utility/Gtk/AboutWindow.vala:349 Utility/Gtk/AboutWindow.vala:381
 msgid "Back"
-msgstr ""
+msgstr "Tilbake"
 
 #: Gtk/SetupWizardWindow.vala:94
 msgid "Backend"
-msgstr ""
+msgstr "Backend"
 
 #: Console/AppConsole.vala:356 Gtk/BackupWindow.vala:91
 msgid "Backup"
-msgstr ""
+msgstr "Sikkerhetskopi"
 
 #: Core/Main.vala:2017
 msgid "Backup Device"
-msgstr ""
+msgstr "Enhet for sikkerhetskopi"
 
 #: Core/Main.vala:2012
 msgid "Backup device not specified!"
-msgstr ""
+msgstr "Du har ikke valgt enhet til backup!"
 
 #: Utility/Gtk/DonationWindow.vala:89
 msgid "Become a Patron"
@@ -271,11 +268,11 @@ msgstr ""
 
 #: Gtk/RestoreExcludeBox.vala:91
 msgid "Bittorrent Clients"
-msgstr ""
+msgstr "Bittorrentklienter"
 
 #: Gtk/ScheduleBox.vala:136 Gtk/SnapshotListBox.vala:298
 msgid "Boot"
-msgstr ""
+msgstr "Oppstart"
 
 #: Gtk/RestoreDeviceBox.vala:499
 msgid "Boot device not selected"
@@ -2656,12 +2653,6 @@ msgstr ""
 msgid "un-tagged"
 msgstr ""
 
-#~ msgid "<b>System:</b> Installed Linux distribution"
-#~ msgstr "<b>System:</b> Innstallerte Linuxdistribusjon"
-
-#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
-#~ msgstr "<b>Øyeblikksbilde dato:</b> Dato når øyeblikksbildet ble tatt"
-
 #~ msgid ""
 #~ "<b>Backup Levels</b>\n"
 #~ "\n"
@@ -2680,3 +2671,9 @@ msgstr ""
 #~ "D\tDaglig\n"
 #~ "W\tUkentlig\n"
 #~ "M\tMånedlig"
+
+#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
+#~ msgstr "<b>Øyeblikksbilde dato:</b> Dato da øyeblikksbildet ble tatt"
+
+#~ msgid "<b>System:</b> Installed Linux distribution"
+#~ msgstr "<b>System:</b> Installert Linuxdistribusjon"

--- a/po/timeshift-ne.po
+++ b/po/timeshift-ne.po
@@ -1,13 +1,8 @@
-# Nepali translation for linuxmint
-# Copyright (c) 2017 Rosetta Contributors and Canonical Ltd 2017
-# This file is distributed under the same license as the linuxmint package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
 "PO-Revision-Date: 2017-09-25 15:45+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Nepali <ne@li.org>\n"
@@ -15,10 +10,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:01+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -203,12 +196,6 @@ msgstr ""
 msgid "Available"
 msgstr ""
 
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
-
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr ""
@@ -223,6 +210,12 @@ msgstr ""
 
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
+msgstr ""
+
+#: Gtk/BackupDeviceBox.vala:98
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
 msgstr ""
 
 #: Gtk/FinishBox.vala:92

--- a/po/timeshift-nl.po
+++ b/po/timeshift-nl.po
@@ -1,13 +1,8 @@
-# Dutch translation for timeshift
-# Copyright (c) 2014 Rosetta Contributors and Canonical Ltd 2014
-# This file is distributed under the same license as the timeshift package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: timeshift\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
 "PO-Revision-Date: 2017-11-03 14:49+0000\n"
 "Last-Translator: Pjotr12345 <Unknown>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -15,10 +10,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:01+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -50,7 +43,7 @@ msgstr "(Her)installeer GRUB2 op:"
 
 #: Core/Main.vala:362
 msgid "** Uninstalled Timeshift BTRFS **"
-msgstr "** Timeshift BTRFS verwijderd **"
+msgstr "** Tijdreis BTRFS verwijderd **"
 
 #: Core/Main.vala:3342
 msgid "/ is mapped to device"
@@ -172,7 +165,7 @@ msgstr ""
 #: Core/Main.vala:249
 msgid "Another instance of Timeshift is creating a snapshot."
 msgstr ""
-"Een andere instantie van Timeshift is reeds bezig met het maken van een "
+"Een andere instantie van Tijdreis is reeds bezig met het maken van een "
 "momentopname."
 
 #: Utility/AppLock.vala:49
@@ -181,7 +174,7 @@ msgstr "Er draait reeds een andere instantie van deze toepassing"
 
 #: Core/Main.vala:253
 msgid "Another instance of timeshift is currently running!"
-msgstr "Er draait nu al een andere instantie van Timeshift."
+msgstr "Er draait nu al een andere instantie van Tijdreis."
 
 #: Console/AppConsole.vala:376
 msgid "Answer YES to all confirmation prompts"
@@ -219,14 +212,6 @@ msgstr "Auteurs"
 msgid "Available"
 msgstr "Beschikbaar"
 
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
-"BTRFS momentopnames worden bewaard op de systeem partitie. Andere "
-"partitiesworden niet ondersteund."
-
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr "BTRFS"
@@ -242,6 +227,15 @@ msgstr "BTRFS-gereedschap niet aangetroffen"
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
 msgstr "BTRFS-apparaat is niet aangekoppeld"
+
+#: Gtk/BackupDeviceBox.vala:98
+#, fuzzy
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
+msgstr ""
+"BTRFS momentopnames worden bewaard op de systeem partitie. Andere "
+"partitiesworden niet ondersteund."
 
 #: Gtk/FinishBox.vala:92
 msgid ""
@@ -1647,7 +1641,7 @@ msgstr "Onderbreek a.u.b. het terugzetproces niet."
 #: Core/Main.vala:348
 msgid "Please install required packages and try running TimeShift again"
 msgstr ""
-"Installeer a.u.b. de vereiste pakketten en probeer dan om Timeshift opnieuw "
+"Installeer a.u.b. de vereiste pakketten en probeer dan om Tijdreis opnieuw "
 "te draaien"
 
 #: Gtk/AppGtk.vala:127
@@ -2512,7 +2506,7 @@ msgid ""
 msgstr ""
 "De crondienst verzendt de uitvoer van geagendeerde taken als een e-mail naar "
 "de huidige gebruiker. Kies deze optie om de e-mails te onderdrukken voor "
-"crontaken die door Timeshift zijn gemaakt."
+"crontaken die door Tijdreis zijn gemaakt."
 
 #: Core/Main.vala:376
 msgid "The system partition has an unsupported subvolume layout."
@@ -2542,7 +2536,7 @@ msgstr ""
 
 #: Gtk/MainWindow.vala:1047 Gtk/MainWindow.vala:1058
 msgid "Timeshift is active"
-msgstr "Timeshift is actief"
+msgstr "Tijdreis is actief"
 
 #: Gtk/MainWindow.vala:948
 msgid ""
@@ -2693,7 +2687,7 @@ msgstr "Bekijk logboek voor terugzetten"
 
 #: Gtk/MainWindow.vala:378
 msgid "View TimeShift Logs"
-msgstr "Bekijk de logboeken van Timeshift"
+msgstr "Bekijk de logboeken van Tijdreis"
 
 #: Gtk/RestoreDeviceBox.vala:101
 msgid "Volume"
@@ -2824,36 +2818,6 @@ msgstr "rsync meldde een fout"
 msgid "un-tagged"
 msgstr "ontmarkeerd"
 
-#, fuzzy
-#~ msgid "Click to edit and drag-drop to re-order"
-#~ msgstr "Klik om te bewerken. Versleep om te herschikken."
-
-#~ msgid ""
-#~ "Click an item to edit the pattern.\n"
-#~ "Drag and drop items with mouse to re-order."
-#~ msgstr ""
-#~ "Klik op een element om het patroon te bewerken.\n"
-#~ "Versleep elementen met de muis, om hen te herschikken."
-
-#~ msgid "Editing and Re-Ordering"
-#~ msgstr "Bewerken en herschikken"
-
-#~ msgid "Info"
-#~ msgstr "Informatie"
-
-#~ msgid "Deleted system subvolumes"
-#~ msgstr "Verwijderde systeemsubvolumes"
-
-#~ msgid "<b>System:</b> Installed Linux distribution"
-#~ msgstr "<b>Systeem:</b> Geïnstalleerde Linuxdistributie"
-
-#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
-#~ msgstr ""
-#~ "<b>Datum momentopname:</b> Datum waarop de momentopname werd gemaakt"
-
-#~ msgid "Selected snapshot path"
-#~ msgstr "Gekozen pad voor momentopnamen"
-
 #~ msgid ""
 #~ "<b>Backup Levels</b>\n"
 #~ "\n"
@@ -2873,6 +2837,20 @@ msgstr "ontmarkeerd"
 #~ "W\tWekelijks\n"
 #~ "M\tMaandelijks"
 
+#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
+#~ msgstr ""
+#~ "<b>Datum momentopname:</b> Datum waarop de momentopname werd gemaakt"
+
+#~ msgid "<b>System:</b> Installed Linux distribution"
+#~ msgstr "<b>Systeem:</b> Geïnstalleerde Linuxdistributie"
+
+#~ msgid ""
+#~ "Click an item to edit the pattern.\n"
+#~ "Drag and drop items with mouse to re-order."
+#~ msgstr ""
+#~ "Klik op een element om het patroon te bewerken.\n"
+#~ "Versleep elementen met de muis, om hen te herschikken."
+
 #~ msgid "Cloning System..."
 #~ msgstr "Systeem klonen..."
 
@@ -2882,14 +2860,26 @@ msgstr "ontmarkeerd"
 #~ msgid "Contributions"
 #~ msgstr "Bijdragen"
 
+#~ msgid "Create snapshots using RSYNC"
+#~ msgstr "Maak momentopnamen met RSYNC"
+
+#~ msgid "Deleted system subvolumes"
+#~ msgstr "Verwijderde systeemsubvolumes"
+
 #~ msgid "Documenters"
 #~ msgstr "Documentalisten"
+
+#~ msgid "Editing and Re-Ordering"
+#~ msgstr "Bewerken en herschikken"
 
 #~ msgid "Include everything"
 #~ msgstr "Alles opnemen"
 
 #~ msgid "Include hidden items"
 #~ msgstr "Verborgen elementen opnemen"
+
+#~ msgid "Info"
+#~ msgstr "Informatie"
 
 #~ msgid "Log Viewer"
 #~ msgstr "Logboekweergave"
@@ -2899,6 +2889,9 @@ msgstr "ontmarkeerd"
 
 #~ msgid "Scheduled task runs once every hour"
 #~ msgstr "Geagendeerde taak draait elk uur"
+
+#~ msgid "Selected snapshot path"
+#~ msgstr "Gekozen pad voor momentopnamen"
 
 #~ msgid "Third Party Tools"
 #~ msgstr "Hulpmiddelen van derden"
@@ -2914,6 +2907,10 @@ msgstr "ontmarkeerd"
 
 #~ msgid "View:"
 #~ msgstr "Weergeven:"
+
+#, fuzzy
+#~ msgid "Click to edit and drag-drop to re-order"
+#~ msgstr "Klik om te bewerken. Versleep om te herschikken."
 
 #~ msgid "Change"
 #~ msgstr "Gewijzigd"

--- a/po/timeshift-pl.po
+++ b/po/timeshift-pl.po
@@ -1,24 +1,17 @@
-# Polish translation for timeshift
-# Copyright (c) 2013 Rosetta Contributors and Canonical Ltd 2013
-# This file is distributed under the same license as the timeshift package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2013.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: timeshift\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
-"PO-Revision-Date: 2017-10-06 07:27+0000\n"
-"Last-Translator: Tomasz Nastula <tomasz.nastula@icloud.com>\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
+"PO-Revision-Date: 2018-06-15 10:04+0000\n"
+"Last-Translator: Paweł Pańczyk <pawelppanczyk@gmail.com>\n"
 "Language-Team: Polish <pl@li.org>\n"
 "Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:00+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -46,9 +39,7 @@ msgstr "'%s' będzie znajdował się na urządzeniu root"
 
 #: Gtk/BootOptionsBox.vala:118
 msgid "(Re)install GRUB2 on:"
-msgstr ""
-"Zainstaluj/Przeinstaluj GRUB2 na:\n"
-"Odinstaluj/Zainstaluj GRUB2 na:"
+msgstr "Zainstaluj/Przeinstaluj GRUB2 na:"
 
 #: Core/Main.vala:362
 msgid "** Uninstalled Timeshift BTRFS **"
@@ -218,12 +209,6 @@ msgstr "Autorzy"
 msgid "Available"
 msgstr "Dostępne"
 
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
-
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr "BTRFS"
@@ -239,6 +224,12 @@ msgstr "Nie odnaleziono narzędzi BTRFS"
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
 msgstr "Urządzenie BTRFS nie jest zamontowane"
+
+#: Gtk/BackupDeviceBox.vala:98
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
+msgstr ""
 
 #: Gtk/FinishBox.vala:92
 msgid ""
@@ -286,9 +277,7 @@ msgstr "Boot"
 
 #: Gtk/RestoreDeviceBox.vala:499
 msgid "Boot device not selected"
-msgstr ""
-"Nie wybrano urządzenia rozruchowego\n"
-"Nie wybrano urządzenia do uruchamiania"
+msgstr "Nie wybrano urządzenia rozruchowego"
 
 #: Core/Main.vala:1017
 msgid "Boot snapshot failed!"
@@ -301,9 +290,7 @@ msgstr ""
 
 #: Core/Main.vala:998
 msgid "Boot snapshots are enabled"
-msgstr ""
-"Migawki rozruchowe są włączone\n"
-"Włączono uruchamianie migawek"
+msgstr "Migawki rozruchowe są włączone"
 
 #: Gtk/BootOptionsWindow.vala:49
 msgid "Bootloader Options"
@@ -601,15 +588,11 @@ msgstr "Codziennie"
 
 #: Core/Main.vala:1077
 msgid "Daily snapshot failed!"
-msgstr ""
-"Codzienna migawka zakończyła się niepowodzeniem!\n"
-"Dzienna migawka nie została wykonana!"
+msgstr "Codzienna migawka zakończyła się niepowodzeniem!"
 
 #: Core/Main.vala:1058
 msgid "Daily snapshots are enabled"
-msgstr ""
-"Włączono codzienne migawki\n"
-"Włączono dziennie migawki"
+msgstr "Włączono codzienne migawki"
 
 #: Core/Main.vala:2111
 msgid "Data will be modified on following devices:"
@@ -871,7 +854,7 @@ msgstr "Pomiń ustawienia aplikacji"
 
 #: Gtk/RestoreWindow.vala:99
 msgid "Exclude Apps"
-msgstr ""
+msgstr "Wyklucz programy"
 
 #: Gtk/ExcludeMessageWindow.vala:70
 msgid "Exclude List"
@@ -879,7 +862,7 @@ msgstr "Lista do wykluczenia"
 
 #: Gtk/ExcludeListSummaryWindow.vala:49
 msgid "Exclude List Summary"
-msgstr ""
+msgstr "Podsumowanie listy wykluczeń"
 
 #: Gtk/ExcludeBox.vala:224
 msgid "Exclude Pattern"
@@ -1080,11 +1063,11 @@ msgstr ""
 
 #: Gtk/RestoreBox.vala:119
 msgid "Files and directory counts:"
-msgstr ""
+msgstr "Liczba plików i katalogów:"
 
 #: Gtk/ExcludeMessageWindow.vala:76
 msgid "Files matching the following patterns will be excluded"
-msgstr ""
+msgstr "Pliki pasujące do tych wzorców zostaną wykluczone"
 
 #: Utility/Device.vala:1828
 #, c-format
@@ -1114,7 +1097,7 @@ msgstr "Firefox, Chromium, Chrome, Opera, Epiphany, Midori"
 
 #: Core/SnapshotRepo.vala:667
 msgid "First snapshot requires:"
-msgstr ""
+msgstr "Pierwsza migawka wymaga:"
 
 #: Core/Main.vala:2894
 msgid "Found existing pre-restore snapshot"
@@ -1158,6 +1141,8 @@ msgid ""
 "Hidden files and folders are included by default since they contain user-"
 "specific configuration files."
 msgstr ""
+"Ukryte pliki i foldery są domyślnie uwzględniane, ponieważ zawierają pliki "
+"konfiguracyjne użytkownika."
 
 #: Gtk/DeleteWindow.vala:178
 msgid "Hide"
@@ -1185,11 +1170,11 @@ msgstr "Co godzinę"
 
 #: Core/Main.vala:1047
 msgid "Hourly snapshot failed!"
-msgstr ""
+msgstr "Utworzenie cogodzinnej migawki nie powiodło się!"
 
 #: Core/Main.vala:1028
 msgid "Hourly snapshots are enabled"
-msgstr ""
+msgstr "Migawki cogodzinne włączone"
 
 #: Utility/Gtk/AboutWindow.vala:457
 msgid "Icon Themes & Utilities"
@@ -1200,16 +1185,18 @@ msgid ""
 "If the restored system fails to boot, then boot from the Live CD/USB, "
 "install Timeshift, and try restoring another snapshot."
 msgstr ""
+"Jeżeli przywrócony system nie uruchamia się, uruchom komputer z Live CD/USB, "
+"zainstaluj Timeshift i spróbuj przywrócić inną migawkę."
 
 #: Core/Main.vala:2212
 msgid ""
 "If these terms are not acceptable to you, please do not proceed beyond this "
 "point!"
-msgstr ""
+msgstr "Jeżeli nie akceptujesz tych warunków, nie przechodź dalej!"
 
 #: Gtk/ExcludeBox.vala:54
 msgid "Include / Exclude Patterns"
-msgstr ""
+msgstr "Dołącz / wyklucz wzorce"
 
 #: Gtk/UsersBox.vala:340
 msgid "Include @home subvolume in backups"
@@ -1225,16 +1212,16 @@ msgstr ""
 
 #: Core/Main.vala:2026
 msgid "Invalid Snapshot"
-msgstr ""
+msgstr "Nieprawidłowa migawka"
 
 #: Console/AppConsole.vala:251
 #, c-format
 msgid "Invalid command line arguments"
-msgstr ""
+msgstr "Błędne argumenty wiersza poleceń"
 
 #: Gtk/MainWindow.vala:824
 msgid "Invalid snapshot"
-msgstr ""
+msgstr "Nieprawidłowa migawka"
 
 #: Utility/Gtk/DonationWindow.vala:97
 msgid "Issue Tracker ~ Report Issues, Request Features, Ask Questions"
@@ -1242,11 +1229,11 @@ msgstr ""
 
 #: Gtk/ExcludeBox.vala:272
 msgid "Items Not Selected"
-msgstr ""
+msgstr "Niewybrane elementy"
 
 #: Gtk/ScheduleBox.vala:283
 msgid "Keep"
-msgstr ""
+msgstr "Zachowaj"
 
 #: Gtk/RestoreExcludeBox.vala:112
 msgid ""
@@ -1254,100 +1241,106 @@ msgid ""
 "etc. If un-checked, previous configuration files will be restored from "
 "snapshot."
 msgstr ""
+"Zachowaj pliki konfiguracyjne klientów BitTorrent, takich jak Deluge, "
+"Transmission itp. Jeśli odznaczone, poprzednie pliki konfiguracyjne zostaną "
+"przywrócone z migawki."
 
 #: Gtk/RestoreExcludeBox.vala:85
 msgid ""
 "Keep configuration files for web browsers like Firefox and Chrome. If un-"
 "checked, previous configuration files will be restored from snapshot"
 msgstr ""
+"Zachowaj pliki konfiguracyjne przeglądarek, takich jak Firefox i Chrome. "
+"Jeśli odznaczone, poprzednie pliki konfiguracyjne zostaną przywrócone z "
+"migawki."
 
 #: Gtk/RestoreDeviceBox.vala:244
 msgid "Keep on Root Device"
-msgstr ""
+msgstr "Trzymaj na głównym urządzeniu"
 
 #: Gtk/RestoreDeviceBox.vala:229
 msgid "Keep this mount path on the root filesystem"
-msgstr ""
+msgstr "Trzymaj tę ścieżkę montowania w głównym systemie plików"
 
 #: Gtk/SnapshotListBox.vala:519
 msgid "LIVE"
-msgstr ""
+msgstr "Na żywo"
 
 #: Utility/Device.vala:1829 Console/AppConsole.vala:458
 #: Console/AppConsole.vala:497 Gtk/BackupDeviceBox.vala:254
 #, c-format
 msgid "Label"
-msgstr ""
+msgstr "Etykieta"
 
 #: Core/Main.vala:1010
 #, c-format
 msgid "Last boot snapshot is %d hours old"
-msgstr ""
+msgstr "Ostatnia migawka rozruchowa ma %d godzin."
 
 #: Core/Main.vala:1005
 msgid "Last boot snapshot is older than system start time"
-msgstr ""
+msgstr "Ostatnia migawka rozruchowa jest starsza niż czas startu systemu"
 
 #: Core/Main.vala:1001
 msgid "Last boot snapshot not found"
-msgstr ""
+msgstr "Nie odnaleziono migawki ostatniego  rozruchu"
 
 #: Core/Main.vala:1070
 #, c-format
 msgid "Last daily snapshot is %d hours old"
-msgstr ""
+msgstr "Ostatnia migawka dzienna ma %d godzin"
 
 #: Core/Main.vala:1065
 msgid "Last daily snapshot is more than 1 day old"
-msgstr ""
+msgstr "Ostatnia migawka dzienna jest starsza niż jeden dzień"
 
 #: Core/Main.vala:1061
 msgid "Last daily snapshot not found"
-msgstr ""
+msgstr "Nie odnaleziono migawki dziennej"
 
 #: Core/Main.vala:1040
 #, c-format
 msgid "Last hourly snapshot is %d minutes old"
-msgstr ""
+msgstr "Ostatnia migawka godzinna ma %d minut"
 
 #: Core/Main.vala:1035
 msgid "Last hourly snapshot is more than 1 hour old"
-msgstr ""
+msgstr "Ostatnia migawka godzinna jest starsza niż jedna godzina."
 
 #: Core/Main.vala:1031
 msgid "Last hourly snapshot not found"
-msgstr ""
+msgstr "Nie znaleziono migawki godzinnej"
 
 #: Core/Main.vala:1130
 #, c-format
 msgid "Last monthly snapshot is %d days old"
-msgstr ""
+msgstr "Ostatnia migawka miesięczna jest starsza niż %d dni."
 
 #: Core/Main.vala:1125
 msgid "Last monthly snapshot is more than 1 month old"
-msgstr ""
+msgstr "Ostatnia migawka miesięczna jest starsza niż miesiąc"
 
 #: Core/Main.vala:1121
 msgid "Last monthly snapshot not found"
-msgstr ""
+msgstr "Nie znaleziono migawki miesięcznej"
 
 #: Core/Main.vala:1100
 #, c-format
 msgid "Last weekly snapshot is %d days old"
-msgstr ""
+msgstr "Ostatnia migawka tygodniowa jest starsza niż %d dni"
 
 #: Core/Main.vala:1095
 msgid "Last weekly snapshot is more than 1 week old"
-msgstr ""
+msgstr "Ostatnia migawka tygodniowa jest starsza niż jeden tydzień"
 
 #: Core/Main.vala:1091
 msgid "Last weekly snapshot not found"
-msgstr ""
+msgstr "Nie znaleziono migawki tygodniowej"
 
 #: Gtk/MainWindow.vala:1049
 #, c-format
 msgid "Latest snapshot"
-msgstr ""
+msgstr "Ostatnia migawka"
 
 #: Utility/Gtk/AboutWindow.vala:316 Utility/Gtk/AboutWindow.vala:356
 msgid "License"
@@ -1356,48 +1349,48 @@ msgstr ""
 #: Core/Main.vala:1344
 #, c-format
 msgid "Linking from snapshot"
-msgstr ""
+msgstr "Powiązano z migawką"
 
 #: Console/AppConsole.vala:352
 msgid "List"
-msgstr ""
+msgstr "Lista"
 
 #: Console/AppConsole.vala:354
 msgid "List devices"
-msgstr ""
+msgstr "Lista urządzeń"
 
 #: Console/AppConsole.vala:353
 msgid "List snapshots"
-msgstr ""
+msgstr "Lista migawek"
 
 #: Gtk/MainWindow.vala:1000
 msgid "Live USB Mode (Restore Only)"
-msgstr ""
+msgstr "Uruchomienie z USB (Tylko przywracanie)"
 
 #: Gtk/SetupWizardWindow.vala:104 Gtk/BackupWindow.vala:86
 #: Gtk/SettingsWindow.vala:89
 msgid "Location"
-msgstr ""
+msgstr "Położenie"
 
 #: Gtk/MainWindow.vala:459
 msgid "Main window closed by user"
-msgstr ""
+msgstr "Główne okno zamknięte przez użytkownika"
 
 #: Gtk/SnapshotListBox.vala:329
 msgid "Mark for Deletion"
-msgstr ""
+msgstr "Zaznacz do usunięcia"
 
 #: Gtk/MainWindow.vala:641
 msgid "Marked for deletion"
-msgstr ""
+msgstr "Zaznaczone do usunięcia"
 
 #: Core/SnapshotRepo.vala:711 Core/SnapshotRepo.vala:748
 msgid "Maximum backups exceeded for backup level"
-msgstr ""
+msgstr "Maksymalna ilość kopii przekroczyła poziom kopii"
 
 #: Gtk/MainWindow.vala:208
 msgid "Menu"
-msgstr ""
+msgstr "Menu"
 
 #: Gtk/UsersBox.vala:354
 msgid "Miscellaneous"
@@ -1405,33 +1398,33 @@ msgstr ""
 
 #: Core/Main.vala:235
 msgid "Missing Dependencies"
-msgstr ""
+msgstr "Brakujące zależności"
 
 #: Core/SnapshotRepo.vala:689
 #, c-format
 msgid "Mode"
-msgstr ""
+msgstr "Tryb"
 
 #: Utility/Device.vala:1812
 #, c-format
 msgid "Model"
-msgstr ""
+msgstr "Model"
 
 #: Gtk/ScheduleBox.vala:64 Gtk/SnapshotListBox.vala:302
 msgid "Monthly"
-msgstr ""
+msgstr "Comiesięcznie"
 
 #: Core/Main.vala:1118
 msgid "Monthly snapshot are enabled"
-msgstr ""
+msgstr "Migawki miesięczne są włączone"
 
 #: Core/Main.vala:1137
 msgid "Monthly snapshot failed!"
-msgstr ""
+msgstr "Błąd migawki miesięcznej!"
 
 #: Core/Main.vala:2113 Core/Main.vala:2146
 msgid "Mount"
-msgstr ""
+msgstr "Zamontuj"
 
 #: Core/Main.vala:2968
 msgid "Moved system subvolume to snapshot directory"
@@ -1439,58 +1432,58 @@ msgstr ""
 
 #: Gtk/MainWindow.vala:800
 msgid "Multiple snapshots selected"
-msgstr ""
+msgstr "Zaznaczono wiele migawek"
 
 #: Console/AppConsole.vala:425 Gtk/RsyncLogBox.vala:492
 #: Gtk/BackupDeviceBox.vala:235
 msgid "Name"
-msgstr ""
+msgstr "Nazwa"
 
 #: Gtk/SetupWizardWindow.vala:197 Gtk/BackupWindow.vala:160
 #: Gtk/DeleteWindow.vala:162 Gtk/RestoreWindow.vala:198
 msgid "Next"
-msgstr ""
+msgstr "Dalej"
 
 #: Utility/Gtk/CustomMessageDialog.vala:177
 msgid "No"
-msgstr ""
+msgstr "Nie"
 
 #: Gtk/RestoreBox.vala:122 Gtk/BackupBox.vala:84
 msgid "No Change"
-msgstr ""
+msgstr "Bez zmian"
 
 #: Gtk/MainWindow.vala:615 Gtk/DeleteWindow.vala:341
 msgid "No Snapshots Selected"
-msgstr ""
+msgstr "Nie zaznaczono migawek"
 
 #: Gtk/MainWindow.vala:1073
 msgid "No snapshots available"
-msgstr ""
+msgstr "Brak dostępnych migawek"
 
 #: Console/AppConsole.vala:320 Core/SnapshotRepo.vala:898
 #: Gtk/MainWindow.vala:1017
 msgid "No snapshots found"
-msgstr ""
+msgstr "Nie odnaleziono migawek"
 
 #: Console/AppConsole.vala:740
 msgid "No snapshots found on device"
-msgstr ""
+msgstr "Nie odnaleziono migawek na urządzeniu"
 
 #: Gtk/MainWindow.vala:553
 msgid "No snapshots on device"
-msgstr ""
+msgstr "Brak migawek na urządzeniu"
 
 #: Core/SnapshotRepo.vala:665
 msgid "No snapshots on this device"
-msgstr ""
+msgstr "Brak migawek na tym urządzeniu"
 
 #: Gtk/MainWindow.vala:793
 msgid "No snapshots selected"
-msgstr ""
+msgstr "Nie zaznaczono migawek"
 
 #: Gtk/MainWindow.vala:1050 Gtk/MainWindow.vala:1052
 msgid "None"
-msgstr ""
+msgstr "Brak"
 
 #: Core/Subvolume.vala:184
 #, fuzzy, c-format
@@ -1499,15 +1492,15 @@ msgstr "Katalogu nie odnaleziono"
 
 #: Core/SnapshotRepo.vala:683
 msgid "Not Selected"
-msgstr ""
+msgstr "Nie zaznaczono"
 
 #: Core/Main.vala:379
 msgid "Not Supported"
-msgstr ""
+msgstr "Nieobsługiwane"
 
 #: Core/SnapshotRepo.vala:629 Core/SnapshotRepo.vala:656
 msgid "Not enough disk space"
-msgstr ""
+msgstr "Brak miejsca na dysku"
 
 #: Console/AppConsole.vala:397 Gtk/FinishBox.vala:55
 msgid "Notes"
@@ -1515,24 +1508,26 @@ msgstr ""
 
 #: Core/Main.vala:1147
 msgid "Nothing to do!"
-msgstr ""
+msgstr "Nie ma nic do zrobienia!"
 
 #: Console/AppConsole.vala:423 Console/AppConsole.vala:452
 #: Console/AppConsole.vala:491 Console/AppConsole.vala:539
 msgid "Num"
-msgstr ""
+msgstr "Lp"
 
 #: Gtk/ScheduleBox.vala:282
 msgid ""
 "Number of snapshots to keep.\n"
 "Older snapshots will be removed once this limit is exceeded."
 msgstr ""
+"Ilość przechowywanych migawek.\n"
+"Starsze migawki będą usunięte po przekroczeniu tego limitu."
 
 #: Utility/GtkHelper.vala:121 Utility/Gtk/CustomMessageDialog.vala:167
 #: Utility/Gtk/CustomMessageDialog.vala:171
 #: Gtk/ExcludeListSummaryWindow.vala:84
 msgid "OK"
-msgstr ""
+msgstr "OK"
 
 #: Gtk/SnapshotBackendBox.vala:179
 msgid ""
@@ -1546,7 +1541,7 @@ msgstr ""
 
 #: Gtk/MainWindow.vala:1051
 msgid "Oldest snapshot"
-msgstr ""
+msgstr "Najstarsza migawka"
 
 #: Gtk/SnapshotListBox.vala:297
 msgid "On demand (manual)"
@@ -1559,7 +1554,7 @@ msgstr ""
 
 #: Gtk/MainWindow.vala:209
 msgid "Open Menu"
-msgstr ""
+msgstr "Otwórz menu"
 
 #: Core/Main.vala:3214
 msgid ""
@@ -1573,17 +1568,17 @@ msgstr ""
 
 #: Gtk/RestoreExcludeBox.vala:118
 msgid "Other applications (next page)"
-msgstr ""
+msgstr "Inne aplikacje (następna strona)"
 
 #: Gtk/RsyncLogBox.vala:398 Gtk/RestoreBox.vala:134 Gtk/BackupBox.vala:96
 #, c-format
 msgid "Owner"
-msgstr ""
+msgstr "Właściciel"
 
 #: Utility/Device.vala:1824
 #, c-format
 msgid "Parent Device"
-msgstr ""
+msgstr "Urządzenie macierzyste"
 
 #: Core/Main.vala:2469 Core/Main.vala:2560 Gtk/RsyncLogBox.vala:222
 msgid "Parsing log file..."
@@ -1596,56 +1591,57 @@ msgstr ""
 #: Core/SnapshotRepo.vala:688 Gtk/RestoreDeviceBox.vala:93
 #, c-format
 msgid "Path"
-msgstr ""
+msgstr "Ścieżka"
 
 #: Gtk/ExcludeBox.vala:162
 msgid "Pattern"
-msgstr ""
+msgstr "Wzorzec"
 
 #: Gtk/RsyncLogBox.vala:396 Gtk/RestoreBox.vala:133 Gtk/BackupBox.vala:95
 #, c-format
 msgid "Permissions"
-msgstr ""
+msgstr "Prawa dostępu"
 
 #: Core/Main.vala:254
 msgid "Please check if you have multiple windows open."
-msgstr ""
+msgstr "Sprawdź, czy masz otwarte kilka okien."
 
 #: Core/Main.vala:2244
 msgid "Please do not interrupt the restore process!"
-msgstr ""
+msgstr "Nie przerywaj procesu przywracania!"
 
 #: Core/Main.vala:348
 msgid "Please install required packages and try running TimeShift again"
-msgstr ""
+msgstr "Zainstaluj wymagane pakiety i uruchom Timeshift ponownie."
 
 #: Gtk/AppGtk.vala:127
 msgid "Please re-run the application as admin (using 'sudo' or 'su')"
 msgstr ""
+"Uruchom program ponownie jako administrator (używając \"sudo\" lub \"su\")"
 
 #: Console/AppConsole.vala:103
 msgid "Please run the application as admin (using 'sudo' or 'su')"
-msgstr ""
+msgstr "Uruchom program jako administrator (używając \"sudo\" lub \"su\")"
 
 #: Core/Main.vala:2194
 msgid "Please save your work and close all applications."
-msgstr ""
+msgstr "Zapisz swoją pracę i zamknij wszystkie programy."
 
 #: Gtk/MainWindow.vala:695
 msgid "Please select a snapshot to view the log!"
-msgstr ""
+msgstr "Wybierz migawkę, aby zobaczyć pliki dziennika!"
 
 #: Gtk/RestoreDeviceBox.vala:512
 msgid "Please select the GRUB device"
-msgstr ""
+msgstr "Wybierz urządzenie GRUB"
 
 #: Core/Main.vala:250
 msgid "Please wait a few minutes and try again."
-msgstr ""
+msgstr "Poczekaj kilka minut i spróbuj ponownie."
 
 #: Gtk/MainWindow.vala:762
 msgid "Please wait for snapshots to be deleted."
-msgstr ""
+msgstr "Poczekaj, aż migawki zostaną usunięte."
 
 #: Gtk/EstimateBox.vala:66
 msgid "Please wait..."
@@ -1658,7 +1654,7 @@ msgstr ""
 #: Core/Main.vala:1579 Gtk/RsyncLogBox.vala:232 Gtk/DeleteBox.vala:68
 #: Gtk/RestoreBox.vala:88 Gtk/BackupBox.vala:114
 msgid "Preparing..."
-msgstr ""
+msgstr "Przygotowywanie..."
 
 #: Gtk/SetupWizardWindow.vala:189 Gtk/BackupWindow.vala:152
 #: Gtk/DeleteWindow.vala:154 Gtk/RestoreWindow.vala:190
@@ -1667,7 +1663,7 @@ msgstr ""
 
 #: Gtk/AppGtk.vala:116
 msgid "Print debug information"
-msgstr ""
+msgstr "Wyświetl informacje debugowania"
 
 #: Core/Main.vala:3794
 msgid "Query completed"
@@ -1683,7 +1679,7 @@ msgstr ""
 
 #: Gtk/SnapshotBackendBox.vala:184
 msgid "RSYNC Snapshots"
-msgstr ""
+msgstr "Migawki RSYNC"
 
 #: Gtk/BootOptionsBox.vala:137
 msgid ""
@@ -1694,15 +1690,16 @@ msgstr ""
 #: Console/AppConsole.vala:982
 #, c-format
 msgid "Re-install GRUB2 bootloader?"
-msgstr ""
+msgstr "Zainstalować ponownie program rozruchowy GRUB?"
 
 #: Core/Main.vala:2307
 msgid "Re-installing GRUB2 bootloader..."
-msgstr ""
+msgstr "Reinstalowanie programu rozruchowego GRUB..."
 
 #: Gtk/BootOptionsBox.vala:120
 msgid "Re-installs the GRUB2 bootloader on the selected device."
 msgstr ""
+"Instaluje ponownie ponownie program rozruchowy GRUB na wybranym urządzeniu."
 
 #: Gtk/RsyncLogBox.vala:181
 #, c-format
@@ -1711,16 +1708,16 @@ msgstr ""
 
 #: Core/Main.vala:2400
 msgid "Rebooting system..."
-msgstr ""
+msgstr "Ponowne uruchamianie..."
 
 #: Gtk/RestoreExcludeBox.vala:61 Gtk/RestoreExcludeBox.vala:91
 #, c-format
 msgid "Recommended"
-msgstr ""
+msgstr "Zalecane"
 
 #: Gtk/BackupDeviceBox.vala:65 Gtk/RestoreDeviceBox.vala:70
 msgid "Refresh"
-msgstr ""
+msgstr "Odśwież"
 
 #: Gtk/BackupDeviceBox.vala:106
 msgid "Remote and network locations are not supported."
@@ -1728,40 +1725,40 @@ msgstr ""
 
 #: Gtk/ExcludeBox.vala:253
 msgid "Remove"
-msgstr ""
+msgstr "Usuń"
 
 #: Core/SnapshotRepo.vala:975 Core/Main.vala:1617 Core/Main.vala:1628
 #: Core/Main.vala:4197 Core/Snapshot.vala:509
 #, c-format
 msgid "Removed"
-msgstr ""
+msgstr "Usunięto"
 
 #: Utility/CronTab.vala:341
 msgid "Removed cron task"
-msgstr ""
+msgstr "Usuń zadanie cron"
 
 #: Core/Main.vala:3582
 #, c-format
 msgid "Removed mount directory: '%s'"
-msgstr ""
+msgstr "Usunięto punkt montowania: '%s'"
 
 #: Core/Snapshot.vala:555
 msgid "Removed snapshot"
-msgstr ""
+msgstr "Usunięta migawka"
 
 #: Core/Snapshot.vala:484
 msgid "Removing"
-msgstr ""
+msgstr "Usuwanie"
 
 #: Core/Snapshot.vala:521
 msgid "Removing snapshot"
-msgstr ""
+msgstr "Usuwanie migawki"
 
 #: Core/SnapshotRepo.vala:831 Core/SnapshotRepo.vala:850
 #: Core/SnapshotRepo.vala:868 Core/SnapshotRepo.vala:882
 #, c-format
 msgid "Removing snapshots"
-msgstr ""
+msgstr "Usuwanie migawek"
 
 #: Gtk/UsersBox.vala:360
 msgid ""
@@ -1773,7 +1770,7 @@ msgstr ""
 #: Gtk/RsyncLogBox.vala:377 Gtk/RsyncLogBox.vala:567 Gtk/MainWindow.vala:151
 #: Gtk/RestoreWindow.vala:125
 msgid "Restore"
-msgstr ""
+msgstr "Przywracanie"
 
 #: Gtk/UsersBox.vala:329
 #, fuzzy
@@ -1782,7 +1779,7 @@ msgstr "Usunięto podwolumin"
 
 #: Gtk/RestoreWindow.vala:89
 msgid "Restore Device"
-msgstr ""
+msgstr "Przywróć urządzenie"
 
 #: Gtk/RestoreWindow.vala:94
 msgid "Restore Exclude"
@@ -1790,19 +1787,19 @@ msgstr ""
 
 #: Gtk/RestoreWindow.vala:69
 msgid "Restore Snapshot"
-msgstr ""
+msgstr "Przywróć migawkę"
 
 #: Core/Main.vala:2809 Core/Main.vala:2851
 msgid "Restore completed"
-msgstr ""
+msgstr "Przywracanie zakończone"
 
 #: Gtk/MainWindow.vala:152
 msgid "Restore selected snapshot"
-msgstr ""
+msgstr "Przywróć wybraną migawkę"
 
 #: Console/AppConsole.vala:363
 msgid "Restore snapshot"
-msgstr ""
+msgstr "Przywróć migawkę"
 
 #: Gtk/RestoreFinishBox.vala:96
 msgid "Restored subvolumes will become active after system is restarted."
@@ -1814,7 +1811,7 @@ msgstr ""
 
 #: Gtk/RestoreBox.vala:77 Gtk/RestoreBox.vala:190
 msgid "Restoring Snapshot..."
-msgstr ""
+msgstr "Przywracanie migawki..."
 
 #: Gtk/FinishBox.vala:85
 msgid ""
@@ -1825,7 +1822,7 @@ msgstr ""
 
 #: Core/Main.vala:2778
 msgid "Restoring snapshot..."
-msgstr ""
+msgstr "Przywracanie migawki..."
 
 #: Gtk/FinishBox.vala:88
 msgid ""
@@ -2657,7 +2654,7 @@ msgstr ""
 #: Core/Subvolume.vala:201 Core/Main.vala:1494 Core/Main.vala:3862
 #: Core/Main.vala:3946 Core/Main.vala:4054 Core/Main.vala:4093
 msgid "btrfs returned an error"
-msgstr ""
+msgstr "btrfs zwrócił błąd"
 
 #: Core/Main.vala:1393 Core/Snapshot.vala:500
 msgid "complete"
@@ -2665,11 +2662,11 @@ msgstr ""
 
 #: Utility/CronTab.vala:261
 msgid "crontab file exported"
-msgstr ""
+msgstr "wyeksportowano plik cronetab"
 
 #: Utility/CronTab.vala:244
 msgid "crontab file installed"
-msgstr ""
+msgstr "zainstalowano plik cronetab"
 
 #: Core/SnapshotRepo.vala:868
 msgid "incomplete"
@@ -2677,49 +2674,25 @@ msgstr ""
 
 #: Core/SnapshotRepo.vala:850
 msgid "marked for deletion"
-msgstr ""
+msgstr "zaznaczono do usunięcia"
 
 #: Core/Main.vala:1285 Core/Main.vala:1439 Core/Main.vala:1441
 msgid "mounted at path"
-msgstr ""
+msgstr "zamontowano w ścieżce"
 
 #: Core/Main.vala:1393 Core/Snapshot.vala:501 Gtk/DeleteBox.vala:149
 #: Gtk/RestoreBox.vala:237 Gtk/BackupBox.vala:234
 msgid "remaining"
-msgstr ""
+msgstr "pozostało"
 
 #: Core/Main.vala:1404
 msgid "rsync returned an error"
-msgstr ""
+msgstr "rsync zwrócił błąd"
 
 #: Core/SnapshotRepo.vala:714 Core/SnapshotRepo.vala:752
 #: Core/SnapshotRepo.vala:831
 msgid "un-tagged"
 msgstr ""
-
-#, fuzzy
-#~ msgid "Click to edit and drag-drop to re-order"
-#~ msgstr ""
-#~ "Kliknij, aby zmodyfikować. Przeciągnij i upuść, aby zmienić kolejność."
-
-#~ msgid ""
-#~ "Click an item to edit the pattern.\n"
-#~ "Drag and drop items with mouse to re-order."
-#~ msgstr ""
-#~ "Kliknij na element, aby zmodyfikować wzorzec.\n"
-#~ "Przeciągnij i upuść elementy za pomocą myszki, aby zmienić ich kolejność."
-
-#~ msgid "Editing and Re-Ordering"
-#~ msgstr "Edycja i zmiana kolejności"
-
-#~ msgid "Deleted system subvolumes"
-#~ msgstr "Usunięto podwolumin systemowy"
-
-#~ msgid "<b>System:</b> Installed Linux distribution"
-#~ msgstr "<b>System:</b> Zainstalowana dystrybucja Linuksa"
-
-#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
-#~ msgstr "<b>Data migawki:</b> Data utworzenia migawki"
 
 #~ msgid ""
 #~ "<b>Backup Levels</b>\n"
@@ -2740,6 +2713,19 @@ msgstr ""
 #~ "W\tCo tydzień\n"
 #~ "M\tCo miesiąc"
 
+#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
+#~ msgstr "<b>Data migawki:</b> Data utworzenia migawki"
+
+#~ msgid "<b>System:</b> Installed Linux distribution"
+#~ msgstr "<b>System:</b> Zainstalowana dystrybucja Linuksa"
+
+#~ msgid ""
+#~ "Click an item to edit the pattern.\n"
+#~ "Drag and drop items with mouse to re-order."
+#~ msgstr ""
+#~ "Kliknij na element, aby zmodyfikować wzorzec.\n"
+#~ "Przeciągnij i upuść elementy za pomocą myszki, aby zmienić ich kolejność."
+
 #~ msgid "Cloning System..."
 #~ msgstr "Klonowanie systemu..."
 
@@ -2749,8 +2735,34 @@ msgstr ""
 #~ msgid "Contributions"
 #~ msgstr "Wkład"
 
+#~ msgid "Create snapshots using RSYNC"
+#~ msgstr "Twórz migawki używając RSYNC"
+
+#~ msgid "Deleted system subvolumes"
+#~ msgstr "Usunięto podwolumin systemowy"
+
 #~ msgid "Documenters"
 #~ msgstr "Autorzy dokumentacji"
+
+#~ msgid "Editing and Re-Ordering"
+#~ msgstr "Edycja i zmiana kolejności"
+
+#~ msgid "Include everything"
+#~ msgstr "Uwzględnij wszystko"
+
+#~ msgid "Include hidden items"
+#~ msgstr "Uwzględnij ukryte pliki"
+
+#~ msgid "Log Viewer"
+#~ msgstr "Przegląd logów"
+
+#~ msgid "Refresh Snapshot List"
+#~ msgstr "Odśwież listę migawek"
+
+#, fuzzy
+#~ msgid "Click to edit and drag-drop to re-order"
+#~ msgstr ""
+#~ "Kliknij, aby zmodyfikować. Przeciągnij i upuść, aby zmienić kolejność."
 
 #~ msgid "deleted"
 #~ msgstr "Usuń"

--- a/po/timeshift-pt.po
+++ b/po/timeshift-pt.po
@@ -1,13 +1,8 @@
-# Portuguese translation for linuxmint
-# Copyright (c) 2017 Rosetta Contributors and Canonical Ltd 2017
-# This file is distributed under the same license as the linuxmint package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
 "PO-Revision-Date: 2017-11-16 16:18+0000\n"
 "Last-Translator: Tiago Santos <Unknown>\n"
 "Language-Team: Portuguese <pt@li.org>\n"
@@ -15,10 +10,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:01+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -217,12 +210,6 @@ msgstr "Autores"
 msgid "Available"
 msgstr "Disponível"
 
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
-
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr "BTRFS"
@@ -238,6 +225,13 @@ msgstr "Ferramentas BTRFS não encontradas"
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
 msgstr "Dispositivo BTRFS não está montado"
+
+#: Gtk/BackupDeviceBox.vala:98
+#, fuzzy
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
+msgstr "Outra aplicação (próxima página)"
 
 #: Gtk/FinishBox.vala:92
 msgid ""
@@ -2809,35 +2803,6 @@ msgstr "rsync deu um erro"
 msgid "un-tagged"
 msgstr "Desmarcado"
 
-#, fuzzy
-#~ msgid "Click to edit and drag-drop to re-order"
-#~ msgstr "Carregue para editar. Arraste para reorganizar."
-
-#~ msgid ""
-#~ "Click an item to edit the pattern.\n"
-#~ "Drag and drop items with mouse to re-order."
-#~ msgstr ""
-#~ "Carregue num item para editar o padrão.\n"
-#~ "Arreste e largue itens com o rato para reordenar."
-
-#~ msgid "Editing and Re-Ordering"
-#~ msgstr "A Editar e Reordenar"
-
-#~ msgid "Info"
-#~ msgstr "Informação"
-
-#~ msgid "Deleted system subvolumes"
-#~ msgstr "Apagar os subvolumes do sistemas"
-
-#~ msgid "<b>System:</b> Installed Linux distribution"
-#~ msgstr "<b>Sistema:</b> Distribuição Linux instalada"
-
-#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
-#~ msgstr "<b>Data da cópia de segurança:</b> Data em que o backup foi criado"
-
-#~ msgid "Selected snapshot path"
-#~ msgstr "Caminho da cópia de segurança selecionado"
-
 #~ msgid ""
 #~ "<b>Backup Levels</b>\n"
 #~ "\n"
@@ -2857,6 +2822,19 @@ msgstr "Desmarcado"
 #~ "W    Semanalmente\n"
 #~ "M    Mensalmente"
 
+#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
+#~ msgstr "<b>Data da cópia de segurança:</b> Data em que o backup foi criado"
+
+#~ msgid "<b>System:</b> Installed Linux distribution"
+#~ msgstr "<b>Sistema:</b> Distribuição Linux instalada"
+
+#~ msgid ""
+#~ "Click an item to edit the pattern.\n"
+#~ "Drag and drop items with mouse to re-order."
+#~ msgstr ""
+#~ "Carregue num item para editar o padrão.\n"
+#~ "Arreste e largue itens com o rato para reordenar."
+
 #~ msgid "Cloning System..."
 #~ msgstr "A Clonar o Sistema..."
 
@@ -2866,14 +2844,26 @@ msgstr "Desmarcado"
 #~ msgid "Contributions"
 #~ msgstr "Contribuições"
 
+#~ msgid "Create snapshots using RSYNC"
+#~ msgstr "Criar cópias de segurança utilizando RSYNC"
+
+#~ msgid "Deleted system subvolumes"
+#~ msgstr "Apagar os subvolumes do sistemas"
+
 #~ msgid "Documenters"
 #~ msgstr "Documentadores"
+
+#~ msgid "Editing and Re-Ordering"
+#~ msgstr "A Editar e Reordenar"
 
 #~ msgid "Include everything"
 #~ msgstr "Incluir tudo"
 
 #~ msgid "Include hidden items"
 #~ msgstr "Incluir itens ocultos"
+
+#~ msgid "Info"
+#~ msgstr "Informação"
 
 #~ msgid "Log Viewer"
 #~ msgstr "Visualizador de Registos"
@@ -2883,6 +2873,9 @@ msgstr "Desmarcado"
 
 #~ msgid "Scheduled task runs once every hour"
 #~ msgstr "A tarefa agendada é executada uma vez a cada hora"
+
+#~ msgid "Selected snapshot path"
+#~ msgstr "Caminho da cópia de segurança selecionado"
 
 #~ msgid "Third Party Tools"
 #~ msgstr "Ferramentas de Terceiros"
@@ -2898,6 +2891,10 @@ msgstr "Desmarcado"
 
 #~ msgid "View:"
 #~ msgstr "Ver:"
+
+#, fuzzy
+#~ msgid "Click to edit and drag-drop to re-order"
+#~ msgstr "Carregue para editar. Arraste para reorganizar."
 
 #~ msgid "Change"
 #~ msgstr "Alterado"

--- a/po/timeshift-pt_BR.po
+++ b/po/timeshift-pt_BR.po
@@ -1,24 +1,17 @@
-# Brazilian Portuguese translation for timeshift
-# Copyright (c) 2013 Rosetta Contributors and Canonical Ltd 2013
-# This file is distributed under the same license as the timeshift package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2013.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: timeshift\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
-"PO-Revision-Date: 2017-11-21 17:49+0000\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
+"PO-Revision-Date: 2018-01-05 15:33+0000\n"
 "Last-Translator: Sitonir de Oliveira <sitonir@outlook.com>\n"
 "Language-Team: Brazilian Portuguese <pt_BR@li.org>\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:00+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -30,25 +23,19 @@ msgstr ""
 "Aperte ENTER para continuar..."
 
 #: Core/SnapshotRepo.vala:641
-#, fuzzy, c-format
+#, c-format
 msgid "%d snapshots, %s free"
-msgstr ""
-"%d cópias de segurança, %s livre\n"
-"%d cópia, %s livre"
+msgstr "%d cópias de segurança, %s livre"
 
 #: Console/AppConsole.vala:914
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' will be on '%s'"
-msgstr ""
-"'%s' estará em '%s'\n"
-"'%s' será em '%s'"
+msgstr "'%s' estará em '%s'"
 
 #: Console/AppConsole.vala:911
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' will be on root device"
-msgstr ""
-"'%s' estará no dispositivo raiz\n"
-"'%s' será no dispositivo raiz"
+msgstr "'%s' estará no dispositivo raiz"
 
 #: Gtk/BootOptionsBox.vala:118
 msgid "(Re)install GRUB2 on:"
@@ -56,9 +43,7 @@ msgstr "(Re)instalar GRUB2 em:"
 
 #: Core/Main.vala:362
 msgid "** Uninstalled Timeshift BTRFS **"
-msgstr ""
-"** Timeshift BTRFS Desinstalado **\n"
-"**Desinstalou Timeshift BTRFS**"
+msgstr "** Timeshift BTRFS Desinstalado **"
 
 #: Core/Main.vala:3342
 msgid "/ is mapped to device"
@@ -110,9 +95,7 @@ msgstr "Adicionar Arquivos"
 
 #: Gtk/ExcludeBox.vala:239
 msgid "Add Folders"
-msgstr ""
-"Adicionar Diretórios\n"
-"Adicionar Pastas"
+msgstr "Adicionar Diretórios"
 
 #: Gtk/ExcludeBox.vala:219
 msgid "Add custom pattern"
@@ -156,10 +139,7 @@ msgid ""
 msgstr ""
 "Todos os arquivos são copiados quando o primeiro backup é criado. Os backups "
 "seguintes são incrementais. Os arquivos inalterados serão vinculados por um "
-"link físico a partir do backup anterior, se disponível.\n"
-"Todos os arquivos são copiados quando o primeiro backup é criado. Os backups "
-"subsequentes são incrementais. Os arquivos inalterados serão vinculados de "
-"forma rígida a partir do instantâneo anterior, se disponível."
+"link físico a partir do backup anterior, se disponível."
 
 #: Gtk/ExcludeMessageWindow.vala:130
 msgid "All other files and folders are excluded."
@@ -230,21 +210,13 @@ msgstr "Autores"
 msgid "Available"
 msgstr "Disponível"
 
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
-
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr "BTRFS"
 
 #: Gtk/SnapshotBackendBox.vala:165
 msgid "BTRFS Snapshots"
-msgstr ""
-"Backups BTRFS\n"
-"BTRFS Backups"
+msgstr "Backups BTRFS"
 
 #: Gtk/SnapshotBackendBox.vala:119
 msgid "BTRFS Tools Not Found"
@@ -253,6 +225,13 @@ msgstr "Ferramentas BTRFS não encontradas"
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
 msgstr "Dispositivo BTRFS não está montado"
+
+#: Gtk/BackupDeviceBox.vala:98
+#, fuzzy
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
+msgstr "Outro aplicativo (próxima página)"
 
 #: Gtk/FinishBox.vala:92
 msgid ""
@@ -264,11 +243,7 @@ msgstr ""
 "Os backups do BTRFS são salvos no mesmo disco do qual ele é criado. Se o "
 "disco do sistema falhar, os backups serão perdidos juntamente com o sistema. "
 "Salve os backups em um disco externo, que não seja de sistema, no modo RSYNC "
-"para proteger contra falhas de disco.\n"
-"Os backups do BTRFS são salvos no mesmo disco do qual ele é criado. Se o "
-"disco do sistema falhar, os backups serão perdidos juntamente com o sistema. "
-"Salvar backups para um disco não-sistema externo no modo RSYNC para proteger "
-"contra falhas de disco."
+"para proteger contra falhas de disco."
 
 #: Utility/Gtk/AboutWindow.vala:349 Utility/Gtk/AboutWindow.vala:381
 msgid "Back"
@@ -300,21 +275,15 @@ msgstr "Clientes Bittorrent"
 
 #: Gtk/ScheduleBox.vala:136 Gtk/SnapshotListBox.vala:298
 msgid "Boot"
-msgstr ""
-"Na Inicialização\n"
-"Boot"
+msgstr "Na Inicialização"
 
 #: Gtk/RestoreDeviceBox.vala:499
 msgid "Boot device not selected"
-msgstr ""
-"Dipositivo de inicialização não selecionado\n"
-"Dipositivo de boot não selecionado"
+msgstr "Dipositivo de inicialização não selecionado"
 
 #: Core/Main.vala:1017
 msgid "Boot snapshot failed!"
-msgstr ""
-"Backup durante a inicialização falhou!\n"
-"Boot pela cópia falhou!"
+msgstr "Backup durante a inicialização falhou!"
 
 #: Gtk/ScheduleBox.vala:169
 msgid ""
@@ -325,9 +294,7 @@ msgstr ""
 
 #: Core/Main.vala:998
 msgid "Boot snapshots are enabled"
-msgstr ""
-"Backups na inicialização estão ativados\n"
-"Cópias de boot estão ativadas"
+msgstr "Backups na inicialização estão ativados"
 
 #: Gtk/BootOptionsWindow.vala:49
 msgid "Bootloader Options"
@@ -442,9 +409,7 @@ msgstr "Fechar"
 #: Gtk/RestoreFinishBox.vala:106 Gtk/BackupFinishBox.vala:70
 #: Gtk/FinishBox.vala:101 Gtk/DeleteFinishBox.vala:71
 msgid "Close window to exit"
-msgstr ""
-"Feche a janela para sair\n"
-"Fechar janela para sair"
+msgstr "Feche a janela para sair"
 
 #: Utility/Gtk/AboutWindow.vala:425
 msgid "Code Contributions"
@@ -554,8 +519,6 @@ msgid ""
 "system"
 msgstr ""
 "Crie backups manualmente ou ative backups agendados para proteger o seu "
-"sistema\n"
-"Criar backups manualmente ou ativar backups agendados para proteger seu "
 "sistema"
 
 #: Gtk/SnapshotBackendBox.vala:95
@@ -631,15 +594,11 @@ msgstr "Diário"
 
 #: Core/Main.vala:1077
 msgid "Daily snapshot failed!"
-msgstr ""
-"Backup diário falhou!\n"
-"Cópia diária falhou!"
+msgstr "Backup diário falhou!"
 
 #: Core/Main.vala:1058
 msgid "Daily snapshots are enabled"
-msgstr ""
-"Backups diários estão habilitados\n"
-"Cópias diárias estão habilitadas"
+msgstr "Backups diários estão habilitados"
 
 #: Core/Main.vala:2111
 msgid "Data will be modified on following devices:"
@@ -654,27 +613,19 @@ msgstr "Excluir"
 
 #: Gtk/DeleteWindow.vala:62
 msgid "Delete Snapshots"
-msgstr ""
-"Excluir Backups\n"
-"Abapar Backups"
+msgstr "Excluir Backups"
 
 #: Console/AppConsole.vala:372
 msgid "Delete all snapshots"
-msgstr ""
-"Excluir todos os backups\n"
-"Apagar todos os backups"
+msgstr "Excluir todos os backups"
 
 #: Gtk/MainWindow.vala:162
 msgid "Delete selected snapshot"
-msgstr ""
-"Excluir backup selecionado\n"
-"Apagar backup selecionado"
+msgstr "Excluir backup selecionado"
 
 #: Console/AppConsole.vala:371
 msgid "Delete snapshot"
-msgstr ""
-"Excluir backup\n"
-"Apagar backup"
+msgstr "Excluir backup"
 
 #: Gtk/RsyncLogBox.vala:370 Gtk/RsyncLogBox.vala:575 Gtk/RsyncLogBox.vala:596
 #: Gtk/RestoreBox.vala:124 Gtk/BackupBox.vala:86
@@ -693,9 +644,7 @@ msgstr "Subvolume excluído"
 
 #: Gtk/DeleteBox.vala:58
 msgid "Deleting Snapshots..."
-msgstr ""
-"Excluindo Backup...\n"
-"Apagando Backup..."
+msgstr "Excluindo Backup..."
 
 #: Core/Subvolume.vala:141
 #, c-format
@@ -1112,9 +1061,7 @@ msgid ""
 "Patterns starting with a + will include the item instead of excluding."
 msgstr ""
 "Arquivos e Diretórios correspondentes aos padrões abaixo serão excluídos. "
-"Padrões começando com um + irá incluir o item em vez de excluir.\n"
-"Arquivos &amp; Diretórios correspondentes aos padrões abaixo serão "
-"excluídos. Padrões começando com um + irá incluir o item em vez de excluir."
+"Padrões começando com um + irá incluir o item em vez de excluir."
 
 #: Gtk/SnapshotBackendBox.vala:192
 msgid "Files and directories can be excluded to save disk space."
@@ -1246,9 +1193,7 @@ msgid ""
 "install Timeshift, and try restoring another snapshot."
 msgstr ""
 "Se o sistema restaurado falhar ao inicializar, inicie o sistema pelo CD/USB, "
-"instale o Timeshift e tente restaurar outro backup.\n"
-"Se o sistema restaurado falhar ao inicializar, inicialize CDs/USB, instale "
-"Timeshift e tente restaurar outro backup."
+"instale o Timeshift e tente restaurar outro backup."
 
 #: Core/Main.vala:2212
 msgid ""
@@ -1260,9 +1205,7 @@ msgstr ""
 
 #: Gtk/ExcludeBox.vala:54
 msgid "Include / Exclude Patterns"
-msgstr ""
-"Parâmetros de inclusão / exclusão\n"
-"Parâmetros de incluídos / excluidos"
+msgstr "Parâmetros de inclusão / exclusão"
 
 #: Gtk/UsersBox.vala:340
 msgid "Include @home subvolume in backups"
@@ -1310,9 +1253,6 @@ msgid ""
 msgstr ""
 "Mantenha arquivos de configuração para clientes de bittorrent como Deluge, "
 "Transmission, etc. Se desmarcado, os arquivos de configuração anteriores "
-"serão restaurados a partir do backup.\n"
-"Mantenha arquivos de configuração para clientes de bittorrent como Deluge, "
-"Transmissão, etc. Se desmarcado, os arquivos de configuração anteriores "
 "serão restaurados a partir do backup."
 
 #: Gtk/RestoreExcludeBox.vala:85
@@ -1343,84 +1283,63 @@ msgid "Label"
 msgstr "Rótulo"
 
 #: Core/Main.vala:1010
-#, fuzzy, c-format
+#, c-format
 msgid "Last boot snapshot is %d hours old"
-msgstr ""
-"Último backup da inicialização é de %d horas atrás\n"
-"Último backup de boot é %d horas velho"
+msgstr "Último backup da inicialização é de %d horas atrás"
 
 #: Core/Main.vala:1005
 msgid "Last boot snapshot is older than system start time"
 msgstr ""
 "Último backup da inicialização é mais antigo do que a hora de início do "
-"sistema\n"
-"Último backup de boot é mais velho do que a hora de início do sistema"
+"sistema"
 
 #: Core/Main.vala:1001
 msgid "Last boot snapshot not found"
-msgstr ""
-"Último backup de inicialização não foi encontrado\n"
-"Última backup de inicialização não encontrado"
+msgstr "Último backup de inicialização não foi encontrado"
 
 #: Core/Main.vala:1070
-#, fuzzy, c-format
+#, c-format
 msgid "Last daily snapshot is %d hours old"
-msgstr ""
-"Último backup diário é de %d horas atrás\n"
-"Último backup diária é de %d horas velho"
+msgstr "Último backup diário é de %d horas atrás"
 
 #: Core/Main.vala:1065
 msgid "Last daily snapshot is more than 1 day old"
-msgstr ""
-"Último backup diário foi feito há mais de 1 dia\n"
-"Último backup diária é mais de 1 dia"
+msgstr "Último backup diário foi feito há mais de 1 dia"
 
 #: Core/Main.vala:1061
 msgid "Last daily snapshot not found"
 msgstr "Último backup diário não encontrado"
 
 #: Core/Main.vala:1040
-#, fuzzy, c-format
+#, c-format
 msgid "Last hourly snapshot is %d minutes old"
-msgstr ""
-"Último backup foi a %d minutos atrás\n"
-"Último backup é de %d minutos mais velho"
+msgstr "Último backup foi a %d minutos atrás"
 
 #: Core/Main.vala:1035
 msgid "Last hourly snapshot is more than 1 hour old"
-msgstr ""
-"Último backup é de mais de 1 hora atrás\n"
-"Último backup é mais do que uma 1 hora mais velho"
+msgstr "Último backup é de mais de 1 hora atrás"
 
 #: Core/Main.vala:1031
 msgid "Last hourly snapshot not found"
-msgstr ""
-"Backup da última hora não encontrado\n"
-"Backup de última hora não encontrado"
+msgstr "Backup da última hora não encontrado"
 
 #: Core/Main.vala:1130
-#, fuzzy, c-format
+#, c-format
 msgid "Last monthly snapshot is %d days old"
-msgstr ""
-"Último backup mensal é de %d dias atrás\n"
-"Último backup mensal é de %d dias de idade"
+msgstr "Último backup mensal é de %d dias atrás"
 
 #: Core/Main.vala:1125
 msgid "Last monthly snapshot is more than 1 month old"
-msgstr ""
-"Último backup mensal foi efetuado há mais de 1 mês\n"
-"Último backup mensal é de mais de 1 mês de idade"
+msgstr "Último backup mensal foi efetuado há mais de 1 mês"
 
 #: Core/Main.vala:1121
 msgid "Last monthly snapshot not found"
 msgstr "Último backup mensal não encontrado"
 
 #: Core/Main.vala:1100
-#, fuzzy, c-format
+#, c-format
 msgid "Last weekly snapshot is %d days old"
-msgstr ""
-"Último backup semanal é de %d dias atrás\n"
-"Último backup semanal é de %d dias de idade"
+msgstr "Último backup semanal é de %d dias atrás"
 
 #: Core/Main.vala:1095
 msgid "Last weekly snapshot is more than 1 week old"
@@ -1433,9 +1352,7 @@ msgstr "Último backup semanal não encontrado"
 #: Gtk/MainWindow.vala:1049
 #, c-format
 msgid "Latest snapshot"
-msgstr ""
-"Backup mais recente\n"
-"Backup recente"
+msgstr "Backup mais recente"
 
 #: Utility/Gtk/AboutWindow.vala:316 Utility/Gtk/AboutWindow.vala:356
 msgid "License"
@@ -1515,9 +1432,7 @@ msgstr "Backups Mensal estão habilitados"
 
 #: Core/Main.vala:1137
 msgid "Monthly snapshot failed!"
-msgstr ""
-"Backup mensal falhou!\n"
-"Backups mensal falhou!"
+msgstr "Backup mensal falhou!"
 
 #: Core/Main.vala:2113 Core/Main.vala:2146
 msgid "Mount"
@@ -1555,9 +1470,7 @@ msgstr "Nenhum Backup Selecionado"
 
 #: Gtk/MainWindow.vala:1073
 msgid "No snapshots available"
-msgstr ""
-"Nenhum backup disponível\n"
-"Nenhum backups disponíveis"
+msgstr "Nenhum backup disponível"
 
 #: Console/AppConsole.vala:320 Core/SnapshotRepo.vala:898
 #: Gtk/MainWindow.vala:1017
@@ -1566,9 +1479,7 @@ msgstr "Nenhum backup encontrado"
 
 #: Console/AppConsole.vala:740
 msgid "No snapshots found on device"
-msgstr ""
-"Nenhum backup encontrado no dispositivo\n"
-"Nenhum snapshot encontrado no dispositivo"
+msgstr "Nenhum backup encontrado no dispositivo"
 
 #: Gtk/MainWindow.vala:553
 msgid "No snapshots on device"
@@ -1645,9 +1556,7 @@ msgstr "Arquivos de log mais antigos removidos"
 
 #: Gtk/MainWindow.vala:1051
 msgid "Oldest snapshot"
-msgstr ""
-"Backup mais antigo\n"
-"Backup antigos"
+msgstr "Backup mais antigo"
 
 #: Gtk/SnapshotListBox.vala:297
 msgid "On demand (manual)"
@@ -1742,9 +1651,7 @@ msgstr "Por favor, salve seu trabalho e feche todas as aplicações."
 
 #: Gtk/MainWindow.vala:695
 msgid "Please select a snapshot to view the log!"
-msgstr ""
-"Por favor selecione um backup para visualizar o log!\n"
-"Por favor selecione um backup para vizualiar o log!"
+msgstr "Por favor selecione um backup para visualizar o log!"
 
 #: Gtk/RestoreDeviceBox.vala:512
 msgid "Please select the GRUB device"
@@ -1756,9 +1663,7 @@ msgstr "Por favor aguarde alguns minutos e tente novamente."
 
 #: Gtk/MainWindow.vala:762
 msgid "Please wait for snapshots to be deleted."
-msgstr ""
-"Por favor aguarde que os backups serem apagados.\n"
-"Por favor aguarde os backups serem apagados."
+msgstr "Por favor aguarde que os backups serem apagados."
 
 #: Gtk/EstimateBox.vala:66
 msgid "Please wait..."
@@ -1805,10 +1710,7 @@ msgid ""
 msgstr ""
 "Gerar novamente o initramfs para todos os kernels instalados. Geralmente "
 "isso não é necessário. Selecione esta opção somente se o sistema restaurado "
-"falhar ao inicializar.\n"
-"Re-gerar initramfs para todos os kernels instalados. Geralmente isso não é "
-"necessário. Selecione esta opção somente se o sistema restaurado falhar ao "
-"inicializar."
+"falhar ao inicializar."
 
 #: Console/AppConsole.vala:982
 #, c-format
@@ -1817,9 +1719,7 @@ msgstr "Reinstalar bootloader GRUB2?"
 
 #: Core/Main.vala:2307
 msgid "Re-installing GRUB2 bootloader..."
-msgstr ""
-"Reinstalando bootloader GRUB2...\n"
-"Reinstalando bootloader BRUB2..."
+msgstr "Reinstalando bootloader GRUB2..."
 
 #: Gtk/BootOptionsBox.vala:120
 msgid "Re-installs the GRUB2 bootloader on the selected device."
@@ -1923,9 +1823,7 @@ msgstr "Restaurar backup selecionado"
 
 #: Console/AppConsole.vala:363
 msgid "Restore snapshot"
-msgstr ""
-"Restaurar backup\n"
-"Restaurar snapshot"
+msgstr "Restaurar backup"
 
 #: Gtk/RestoreFinishBox.vala:96
 msgid "Restored subvolumes will become active after system is restarted."
@@ -1938,9 +1836,7 @@ msgstr "Subvolume do sistema restaurado"
 
 #: Gtk/RestoreBox.vala:77 Gtk/RestoreBox.vala:190
 msgid "Restoring Snapshot..."
-msgstr ""
-"Restaurando Backup\n"
-"Restaudando Backup"
+msgstr "Restaurando Backup"
 
 #: Gtk/FinishBox.vala:85
 msgid ""
@@ -1951,17 +1847,11 @@ msgstr ""
 "A restauração de um backup substituirá os subvolumes do sistema, e os "
 "subvolumes do sistema atualmente em uso serão preservados como um novo "
 "backup. Se necessário, este backup pode ser restaurado mais tarde para "
-"\"desfazer\" a restauração.\n"
-"A restauração de um backup substituirá os subvolumes do sistema e os "
-"subvolumes do sistema atualmente em uso serão preservados como um novo "
-"backup. Se necessário, este backup pode ser restaurado mais tarde para "
 "\"desfazer\" a restauração."
 
 #: Core/Main.vala:2778
 msgid "Restoring snapshot..."
-msgstr ""
-"Restaurando backup...\n"
-"Restaurando snapshot..."
+msgstr "Restaurando backup..."
 
 #: Gtk/FinishBox.vala:88
 msgid ""
@@ -1975,12 +1865,7 @@ msgstr ""
 "sistema. Arquivos não-ocultos e diretórios na pasta pessoal do usuário não "
 "serão alterados. Esse comportamento pode ser alterado adicionando um filtro "
 "para incluir esses arquivos. Os arquivos incluídos serão copiados quando o "
-"backup for criado e substituído quando o backup for restaurado.\n"
-"A restauração de backups apenas substitui arquivos e configurações do "
-"sistema. Arquivos não-ocultos e diretórios nos diretórios pessoais do "
-"usuário não serão tocados. Esse comportamento pode ser alterado adicionando "
-"um filtro para incluir esses arquivos. Os arquivos incluídos serão copiados "
-"quando o backup for criado e substituído quando o backup for restaurado."
+"backup for criado e substituído quando o backup for restaurado."
 
 #: Utility/Device.vala:1814
 #, c-format
@@ -2015,9 +1900,7 @@ msgid ""
 "against drive failures."
 msgstr ""
 "Salve backups em um disco externo em vez do disco do sistema, para protegê-"
-"los de falhas na unidade.\n"
-"Salvar instantâneos para um disco externo em vez do disco do sistema para "
-"proteger contra falhas de unidade."
+"los de falhas na unidade."
 
 #: Gtk/FinishBox.vala:97
 msgid ""
@@ -2041,27 +1924,19 @@ msgstr "Agendamento"
 
 #: Core/Main.vala:257
 msgid "Scheduled snapshot in progress..."
-msgstr ""
-"Backup agendado em curso...\n"
-"Backup agendado em curso ..."
+msgstr "Backup agendado em curso..."
 
 #: Core/Main.vala:1147 Gtk/MainWindow.vala:1067 Gtk/ScheduleBox.vala:312
 msgid "Scheduled snapshots are disabled"
-msgstr ""
-"Backups agendados estão desativados\n"
-"Snapshots agendados estão desativados"
+msgstr "Backups agendados estão desativados"
 
 #: Gtk/FinishBox.vala:78
 msgid "Scheduled snapshots are disabled. It's recommended to enable it."
-msgstr ""
-"Os backups agendados estão desativados. Recomenda-se ativá-los.\n"
-"Os backups agendados estão desativados. Recomenda-se ativá-lo."
+msgstr "Os backups agendados estão desativados. Recomenda-se ativá-los."
 
 #: Gtk/ScheduleBox.vala:305
 msgid "Scheduled snapshots are enabled"
-msgstr ""
-"Backups agendados estão ativados\n"
-"Backup agendado estão ativados"
+msgstr "Backups agendados estão ativados"
 
 #: Gtk/FinishBox.vala:75
 msgid ""
@@ -2171,9 +2046,7 @@ msgstr "Selecione os dispositivos onde os arquivos serão restaurados."
 
 #: Gtk/ScheduleBox.vala:313
 msgid "Select the intervals for creating snapshots"
-msgstr ""
-"Selecione os intervalos de criação de backups\n"
-"Selecione os intervalos para criar backups"
+msgstr "Selecione os intervalos de criação de backups"
 
 #: Gtk/ExcludeBox.vala:273
 msgid "Select the items to be removed from the list"
@@ -2189,9 +2062,7 @@ msgstr "Selecionar o backup para restaurar"
 
 #: Gtk/DeleteWindow.vala:87
 msgid "Select the snapshots to be deleted"
-msgstr ""
-"Selecionar o backup a ser apagado\n"
-"selecionar o backup para apagar"
+msgstr "Selecionar o backup a ser apagado"
 
 #: Gtk/MainWindow.vala:616
 msgid "Select the snapshots to mark for deletion"
@@ -2319,15 +2190,13 @@ msgid "Snapshot"
 msgstr "Backup"
 
 #: Gtk/MainWindow.vala:564
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "Snapshot '%s' is being used by the system and cannot be deleted. Restart the "
 "system to activate the restored snapshot."
 msgstr ""
 "O backup '%s' está sendo usado pelo sistema e não pode ser excluído. "
-"Reinicie o sistema para ativar o backup restaurado.\n"
-"O backup '%s' está sendo usado pelo sistema e não pode ser excluído. "
-"Reinicie o sistema para ativar o backup de restaurado."
+"Reinicie o sistema para ativar o backup restaurado."
 
 #: Gtk/BackupFinishBox.vala:60
 msgid "Snapshot Created"
@@ -2340,9 +2209,7 @@ msgstr "Selecionar Níveis de Backups"
 
 #: Gtk/MainWindow.vala:761
 msgid "Snapshot deletion in progress..."
-msgstr ""
-"Exclusão do backup em progresso...\n"
-"Excluindo backup em progresso..."
+msgstr "Exclusão do backup em progresso..."
 
 #: Core/SnapshotRepo.vala:470
 #, c-format
@@ -2364,15 +2231,11 @@ msgstr "Localização do backup"
 
 #: Core/Main.vala:1252
 msgid "Snapshot saved successfully"
-msgstr ""
-"Backup efetuado com sucesso\n"
-"Snapshot salva com sucesso"
+msgstr "Backup efetuado com sucesso"
 
 #: Core/Main.vala:2022
 msgid "Snapshot to restore not specified!"
-msgstr ""
-"O backup a ser restaurado não foi especificado!\n"
-"Snapshot para restaurar não especificado!"
+msgstr "O backup a ser restaurado não foi especificado!"
 
 #: Core/Main.vala:2855
 msgid "Snapshot will become active after system is rebooted."
@@ -2384,9 +2247,7 @@ msgstr "Backup(s) Excluído"
 
 #: Gtk/MainWindow.vala:310 Gtk/DeleteWindow.vala:89
 msgid "Snapshots"
-msgstr ""
-"Backup(s)\n"
-"Backups"
+msgstr "Backup(s)"
 
 #: Gtk/SnapshotBackendBox.vala:169
 msgid ""
@@ -2402,9 +2263,7 @@ msgid ""
 "hard-linking unchanged files from previous snapshot."
 msgstr ""
 "Os backups são criados através de cópias de arquivos do sistema usando o "
-"rsync, e vinculando os arquivos inalterados ao backup anterior.\n"
-"Os backups são criados criando cópias de arquivos de sistema usando o rsync "
-"e vinculando arquivos inalterados do backup anterior."
+"rsync, e vinculando os arquivos inalterados ao backup anterior."
 
 #: Gtk/SnapshotBackendBox.vala:167
 msgid ""
@@ -2461,9 +2320,7 @@ msgstr ""
 
 #: Gtk/MainWindow.vala:1012
 msgid "Snapshots available for restore"
-msgstr ""
-"Backups disponíveis para ser restaurados\n"
-"Backups disponíveis para rastaurar"
+msgstr "Backups disponíveis para ser restaurados"
 
 #: Gtk/SnapshotBackendBox.vala:190
 msgid ""
@@ -2482,9 +2339,7 @@ msgstr "Os backups não podem ser criados no modo Live CD"
 
 #: Gtk/MainWindow.vala:1059
 msgid "Snapshots will be created at selected intervals"
-msgstr ""
-"Os backups serão criados nos intervalos selecionados\n"
-"Os backups serão criados em intervalos selecionados"
+msgstr "Os backups serão criados nos intervalos selecionados"
 
 #: Gtk/ScheduleBox.vala:306
 msgid ""
@@ -2508,9 +2363,7 @@ msgstr "Especificar dispositivo para a instalação do bootloader GRUB2"
 
 #: Console/AppConsole.vala:365
 msgid "Specify snapshot to restore"
-msgstr ""
-"Especificar backup a ser restaurado\n"
-"Especificar snapshot para restaurar"
+msgstr "Especificar backup a ser restaurado"
 
 #: Console/AppConsole.vala:366
 msgid "Specify target device"
@@ -2523,9 +2376,7 @@ msgstr "Estado"
 
 #: Gtk/ScheduleBox.vala:154
 msgid "Stop cron emails for scheduled tasks"
-msgstr ""
-"Parar emails do cron para tarefas agendadas\n"
-"Parar emails no cron para tarefas agendadas"
+msgstr "Parar emails do cron para tarefas agendadas"
 
 #: Utility/TeeJee.Process.vala:511
 msgid "Stopped"
@@ -2560,9 +2411,7 @@ msgstr "Links simbólicos atualizados"
 
 #: Core/Main.vala:2382
 msgid "Synching file systems..."
-msgstr ""
-"Sincronizando sistemas de arquivos...\n"
-"Sincronizar sistemas de arquivos ..."
+msgstr "Sincronizando sistemas de arquivos..."
 
 #: Core/Main.vala:1361 Core/Main.vala:2544 Core/Main.vala:2785
 msgid "Synching files with rsync..."
@@ -2630,10 +2479,7 @@ msgid ""
 msgstr ""
 "O serviço cron envia a saída de tarefas agendadas através de um e-mail para "
 "o usuário atual. Selecione esta opção para evitar esses envios, criados no "
-"cron pelo Timeshift.\n"
-"O serviço cron envia a saída de tarefas agendadas como um e-mail para o "
-"usuário atual. Selecione esta opção para suprimir os emails das tarefas "
-"criadas no cron pelo Timeshift."
+"cron pelo Timeshift."
 
 #: Core/Main.vala:376
 msgid "The system partition has an unsupported subvolume layout."
@@ -2705,9 +2551,7 @@ msgstr "Opção desconhecida"
 
 #: Core/Main.vala:1203
 msgid "Unknown snapshot type"
-msgstr ""
-"Tipo de backup desconhecido\n"
-"Tipo de snapshot Desconhecido"
+msgstr "Tipo de backup desconhecido"
 
 #: Core/Main.vala:1566
 msgid "Unknown value specified for option --tags"
@@ -2777,9 +2621,7 @@ msgstr "Usuário"
 
 #: Gtk/UsersBox.vala:63
 msgid "User Home Directories"
-msgstr ""
-"Diretórios Home do Usuário (Pasta Pessoal)\n"
-"Diretórios Home do Usuário"
+msgstr "Diretórios Home do Usuário (Pasta Pessoal)"
 
 #: Utility/Device.vala:1340
 msgid "User cancelled the password prompt"
@@ -2790,8 +2632,6 @@ msgid ""
 "User home directories are excluded by default unless you enable them here"
 msgstr ""
 "Os Diretórios Home do usuário não são inclusos por padrão, a menos seja que "
-"habilitados aqui\n"
-"Diretórios Home do usuário não são inclusos por padrão a menos que "
 "habilitados aqui"
 
 #: Gtk/SettingsWindow.vala:98
@@ -2843,15 +2683,11 @@ msgstr "Semanalmente."
 
 #: Core/Main.vala:1107
 msgid "Weekly snapshot failed!"
-msgstr ""
-"Backup semanal falhou!\n"
-"Snapshot semanal falhou!"
+msgstr "Backup semanal falhou!"
 
 #: Core/Main.vala:1088
 msgid "Weekly snapshots are enabled"
-msgstr ""
-"Backups semanais estão habilitados\n"
-"Snapshots semanais estão habilitados"
+msgstr "Backups semanais estão habilitados"
 
 #: Utility/Gtk/DonationWindow.vala:105
 msgid "Wiki ~ Documentation & Help"
@@ -2920,15 +2756,11 @@ msgstr "concluído"
 
 #: Utility/CronTab.vala:261
 msgid "crontab file exported"
-msgstr ""
-"Arquivo crontab exportado\n"
-"Exportado ao arquivo crontab"
+msgstr "Arquivo crontab exportado"
 
 #: Utility/CronTab.vala:244
 msgid "crontab file installed"
-msgstr ""
-"Arquivo crontab instalado\n"
-"Instalado ao arquivo crontab"
+msgstr "Arquivo crontab instalado"
 
 #: Core/SnapshotRepo.vala:868
 msgid "incomplete"
@@ -2956,35 +2788,6 @@ msgstr "rsync retornou um erro"
 msgid "un-tagged"
 msgstr "Desmarcado"
 
-#, fuzzy
-#~ msgid "Click to edit and drag-drop to re-order"
-#~ msgstr "Clique para editar. Arraste e solte para reordenar."
-
-#~ msgid ""
-#~ "Click an item to edit the pattern.\n"
-#~ "Drag and drop items with mouse to re-order."
-#~ msgstr ""
-#~ "Clique em um item para editar o padrão.\n"
-#~ "Arraste e solte itens com o mouse para reordenar"
-
-#~ msgid "Editing and Re-Ordering"
-#~ msgstr "Editando e Reordenando"
-
-#~ msgid "Info"
-#~ msgstr "Informação"
-
-#~ msgid "Deleted system subvolumes"
-#~ msgstr "Apagar os subvolumes do sistemas"
-
-#~ msgid "<b>System:</b> Installed Linux distribution"
-#~ msgstr "<b>Sistema:</b> Distribuição Linux instalada"
-
-#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
-#~ msgstr "<b>Data do backup:</b> Data em que o backup foi criado"
-
-#~ msgid "Selected snapshot path"
-#~ msgstr "Caminho do backup selecionado"
-
 #~ msgid ""
 #~ "<b>Backup Levels</b>\n"
 #~ "\n"
@@ -3002,15 +2805,20 @@ msgstr "Desmarcado"
 #~ "H\tDe hora em hora\n"
 #~ "D\tDiário\n"
 #~ "W\tSemanal\n"
-#~ "M\tMensal\n"
-#~ "<b>Níveis de Backup</b>\n"
-#~ "\n"
-#~ "O    Por demanda (manual)\n"
-#~ "B    A cada Boot\n"
-#~ "H    De hora em hora\n"
-#~ "D    Diariamente\n"
-#~ "W    Semanal\n"
-#~ "M    Mensal"
+#~ "M\tMensal"
+
+#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
+#~ msgstr "<b>Data do backup:</b> Data em que o backup foi criado"
+
+#~ msgid "<b>System:</b> Installed Linux distribution"
+#~ msgstr "<b>Sistema:</b> Distribuição Linux instalada"
+
+#~ msgid ""
+#~ "Click an item to edit the pattern.\n"
+#~ "Drag and drop items with mouse to re-order."
+#~ msgstr ""
+#~ "Clique em um item para editar o padrão.\n"
+#~ "Arraste e solte itens com o mouse para reordenar"
 
 #~ msgid "Cloning System..."
 #~ msgstr "Clonando Sistema..."
@@ -3021,14 +2829,26 @@ msgstr "Desmarcado"
 #~ msgid "Contributions"
 #~ msgstr "Contribuidores"
 
+#~ msgid "Create snapshots using RSYNC"
+#~ msgstr "Criar backups usando RSYNC"
+
+#~ msgid "Deleted system subvolumes"
+#~ msgstr "Apagar os subvolumes do sistemas"
+
 #~ msgid "Documenters"
 #~ msgstr "Documentadores"
+
+#~ msgid "Editing and Re-Ordering"
+#~ msgstr "Editando e Reordenando"
 
 #~ msgid "Include everything"
 #~ msgstr "Incluir tudo"
 
 #~ msgid "Include hidden items"
 #~ msgstr "Incluir itens ocultos"
+
+#~ msgid "Info"
+#~ msgstr "Informação"
 
 #~ msgid "Log Viewer"
 #~ msgstr "Visualizador de log"
@@ -3038,6 +2858,9 @@ msgstr "Desmarcado"
 
 #~ msgid "Scheduled task runs once every hour"
 #~ msgstr "A tarefa agendada é executada uma vez a cada hora"
+
+#~ msgid "Selected snapshot path"
+#~ msgstr "Caminho do backup selecionado"
 
 #~ msgid "Third Party Tools"
 #~ msgstr "Ferramentas de Terceiros"
@@ -3053,6 +2876,10 @@ msgstr "Desmarcado"
 
 #~ msgid "View:"
 #~ msgstr "Visualizar:"
+
+#, fuzzy
+#~ msgid "Click to edit and drag-drop to re-order"
+#~ msgstr "Clique para editar. Arraste e solte para reordenar."
 
 #~ msgid "Change"
 #~ msgstr "Alterado"

--- a/po/timeshift-ro.po
+++ b/po/timeshift-ro.po
@@ -1,24 +1,17 @@
-# Romanian translation for linuxmint
-# Copyright (c) 2017 Rosetta Contributors and Canonical Ltd 2017
-# This file is distributed under the same license as the linuxmint package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
-"PO-Revision-Date: 2017-11-03 11:25+0000\n"
-"Last-Translator: Dorian Baciu <>\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
+"PO-Revision-Date: 2017-12-27 16:27+0000\n"
+"Last-Translator: Dorian Baciu <Unknown>\n"
 "Language-Team: Romanian <ro@li.org>\n"
 "Language: ro\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:01+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -215,12 +208,6 @@ msgstr "Autori"
 msgid "Available"
 msgstr "Disponibil"
 
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
-
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr "BTRFS"
@@ -236,6 +223,12 @@ msgstr "Uneltele BTRFS nu s-au găsit"
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
 msgstr "Dispozitivul BTRFS nu este montat"
+
+#: Gtk/BackupDeviceBox.vala:98
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
+msgstr ""
 
 #: Gtk/FinishBox.vala:92
 msgid ""
@@ -2714,32 +2707,6 @@ msgstr ""
 msgid "un-tagged"
 msgstr ""
 
-#, fuzzy
-#~ msgid "Click to edit and drag-drop to re-order"
-#~ msgstr "Clic pentru editare. Trage și lasă să cadă pentru a reordona."
-
-#~ msgid ""
-#~ "Click an item to edit the pattern.\n"
-#~ "Drag and drop items with mouse to re-order."
-#~ msgstr ""
-#~ "Clic pe un articol pentru a edita modelul.\n"
-#~ "Trage și lasă să cadă articole cu mouse-ul pentru a le reordona."
-
-#~ msgid "Editing and Re-Ordering"
-#~ msgstr "Editarea și recondiționarea"
-
-#~ msgid "Info"
-#~ msgstr "Informații"
-
-#~ msgid "Deleted system subvolumes"
-#~ msgstr "Subvolume sistem șterse"
-
-#~ msgid "<b>System:</b> Installed Linux distribution"
-#~ msgstr "<b>Sistem:</b> Distribuție Linux instalată"
-
-#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
-#~ msgstr "<b>Data Instantaneului:</b> Data la care a fost creat instantaneul"
-
 #~ msgid ""
 #~ "<b>Backup Levels</b>\n"
 #~ "\n"
@@ -2759,6 +2726,19 @@ msgstr ""
 #~ "W\tSăptămânal\n"
 #~ "M\tLunar"
 
+#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
+#~ msgstr "<b>Data Instantaneului:</b> Data la care a fost creat instantaneul"
+
+#~ msgid "<b>System:</b> Installed Linux distribution"
+#~ msgstr "<b>Sistem:</b> Distribuție Linux instalată"
+
+#~ msgid ""
+#~ "Click an item to edit the pattern.\n"
+#~ "Drag and drop items with mouse to re-order."
+#~ msgstr ""
+#~ "Clic pe un articol pentru a edita modelul.\n"
+#~ "Trage și lasă să cadă articole cu mouse-ul pentru a le reordona."
+
 #~ msgid "Cloning System..."
 #~ msgstr "Se clonează sistemul..."
 
@@ -2768,14 +2748,26 @@ msgstr ""
 #~ msgid "Contributions"
 #~ msgstr "Contribuții"
 
+#~ msgid "Create snapshots using RSYNC"
+#~ msgstr "Creează instantanee utilizând RSYNC"
+
+#~ msgid "Deleted system subvolumes"
+#~ msgstr "Subvolume sistem șterse"
+
 #~ msgid "Documenters"
 #~ msgstr "Documentatori"
+
+#~ msgid "Editing and Re-Ordering"
+#~ msgstr "Editarea și recondiționarea"
 
 #~ msgid "Include everything"
 #~ msgstr "Include totul"
 
 #~ msgid "Include hidden items"
 #~ msgstr "Include obiecte ascunse"
+
+#~ msgid "Info"
+#~ msgstr "Informații"
 
 #~ msgid "Log Viewer"
 #~ msgstr "Vizualizator de jurnal"
@@ -2785,6 +2777,10 @@ msgstr ""
 
 #~ msgid "View:"
 #~ msgstr "Vedere:"
+
+#, fuzzy
+#~ msgid "Click to edit and drag-drop to re-order"
+#~ msgstr "Clic pentru editare. Trage și lasă să cadă pentru a reordona."
 
 #~ msgid "Change"
 #~ msgstr "Modificat"

--- a/po/timeshift-ru.po
+++ b/po/timeshift-ru.po
@@ -1,13 +1,8 @@
-# Russian translation for timeshift
-# Copyright (c) 2014 Rosetta Contributors and Canonical Ltd 2014
-# This file is distributed under the same license as the timeshift package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: timeshift\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
 "PO-Revision-Date: 2017-11-03 18:57+0000\n"
 "Last-Translator: Dmitriy Kulikov <Unknown>\n"
 "Language-Team: Russian <ru@li.org>\n"
@@ -15,10 +10,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:01+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -218,12 +211,6 @@ msgstr "Авторы"
 msgid "Available"
 msgstr "Доступно"
 
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
-
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr "BTRFS"
@@ -239,6 +226,15 @@ msgstr "Инструменты BTRFS не найдены"
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
 msgstr "Устройство BTRFS не смонтировано"
+
+#: Gtk/BackupDeviceBox.vala:98
+#, fuzzy
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
+msgstr ""
+"Снимки сохраняются в папку /timeshift на выбранном разделе. Другие пути не "
+"поддерживаются."
 
 #: Gtk/FinishBox.vala:92
 msgid ""
@@ -1067,7 +1063,7 @@ msgid ""
 "Patterns starting with a + will include the item instead of excluding."
 msgstr ""
 "Файлы и каталоги, соответствующие шаблонам ниже, будут исключены. Шаблоны, "
-"начинающиеся с \"+\", будут включать объекты независимо от исключений."
+"начинающиеся с + будут включать объекты, независимо от исключений."
 
 #: Gtk/SnapshotBackendBox.vala:192
 msgid "Files and directories can be excluded to save disk space."
@@ -1977,15 +1973,15 @@ msgstr "Выберите снимок"
 
 #: Gtk/ScheduleBox.vala:57
 msgid "Select Snapshot Levels"
-msgstr "Выберите уровни создания снимков"
+msgstr "Выберите уровни снимка"
 
 #: Gtk/BackupDeviceBox.vala:56
 msgid "Select Snapshot Location"
-msgstr "Выберите место снимков"
+msgstr "Выберите место для снимка"
 
 #: Gtk/SnapshotBackendBox.vala:62
 msgid "Select Snapshot Type"
-msgstr "Выберите тип снимков"
+msgstr "Выберите тип снимка"
 
 #: Gtk/DeleteWindow.vala:85
 msgid "Select Snapshots"
@@ -1998,7 +1994,7 @@ msgstr "Выберите целевое устройство"
 #: Gtk/BackupDeviceBox.vala:392
 #, c-format
 msgid "Select a partition on this disk"
-msgstr "Выберите раздел на этом диске"
+msgstr "Выбероите раздел на этом диске"
 
 #: Gtk/MainWindow.vala:801
 msgid "Select a single snapshot to restore"
@@ -2269,7 +2265,7 @@ msgid ""
 "Snapshots are created by creating copies of system files using rsync, and "
 "hard-linking unchanged files from previous snapshot."
 msgstr ""
-"Снимки создаются с использованием копирования системных файлов при помощи "
+"Снимки создаются путем создания копий системных файлов с использованием "
 "rsync и создания жёстких ссылок на неизменённые файлы из предыдущего снимка."
 
 #: Gtk/SnapshotBackendBox.vala:167
@@ -2288,8 +2284,8 @@ msgid ""
 "Snapshots are perfect, byte-for-byte copies of the system. Nothing is "
 "excluded."
 msgstr ""
-"Снимки - идеальное средство, копирование системы байт в байт. Ничто не будет "
-"пропущено."
+"Снимки - идеальное средство, копирование системы байт в байт. Ничего не "
+"будет пропущено."
 
 #: Gtk/SnapshotBackendBox.vala:171
 msgid ""
@@ -2438,7 +2434,7 @@ msgstr "Система"
 
 #: Gtk/MainWindow.vala:957
 msgid "System Restore Utility"
-msgstr "Программа восстановления системы"
+msgstr "Утилита восстановления системы"
 
 #: Gtk/FinishBox.vala:82
 msgid "System can be rolled-back to a previous date by restoring a snapshot."
@@ -2456,7 +2452,7 @@ msgstr "Система будет перезагружена после восс
 
 #: Core/Main.vala:1221 Core/Main.vala:1262
 msgid "Tagged snapshot"
-msgstr "Отмеченный снимок"
+msgstr "Помеченный снимок"
 
 #: Console/AppConsole.vala:426 Gtk/SnapshotListBox.vala:151
 msgid "Tags"
@@ -2799,4 +2795,93 @@ msgstr "rsync вернуло ошибку"
 #: Core/SnapshotRepo.vala:714 Core/SnapshotRepo.vala:752
 #: Core/SnapshotRepo.vala:831
 msgid "un-tagged"
-msgstr "не отмечено"
+msgstr "не помечено"
+
+#~ msgid ""
+#~ "<b>Backup Levels</b>\n"
+#~ "\n"
+#~ "O\tOn demand (manual)\n"
+#~ "B\tBoot\n"
+#~ "H\tHourly\n"
+#~ "D\tDaily\n"
+#~ "W\tWeekly\n"
+#~ "M\tMonthly"
+#~ msgstr ""
+#~ "<b>Периодичность резервного копирования</b>\n"
+#~ "\n"
+#~ "O\tПо запросу (ручной режим)\n"
+#~ "B\tПри загрузке\n"
+#~ "H\tЕжечасно\n"
+#~ "D\tЕжедневно\n"
+#~ "W\tЕженедельно\n"
+#~ "M\tЕжемесячно"
+
+#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
+#~ msgstr "<b>Дата снимка:</b> Дата создания снимка"
+
+#~ msgid "<b>System:</b> Installed Linux distribution"
+#~ msgstr "<b>Система:</b> Установленный дистрибутив Linux"
+
+#~ msgid ""
+#~ "Click an item to edit the pattern.\n"
+#~ "Drag and drop items with mouse to re-order."
+#~ msgstr ""
+#~ "Щёлкните на элементе для изменения шаблона.\n"
+#~ "Перетаскивайте элементы мышью для изменения порядка."
+
+#~ msgid "Cloning System..."
+#~ msgstr "Клонирование системы..."
+
+#~ msgid "Close Window"
+#~ msgstr "Закрыть окно"
+
+#~ msgid "Contributions"
+#~ msgstr "Благодарности"
+
+#~ msgid "Create snapshots using RSYNC"
+#~ msgstr "Создавать снимки с помощью RSYNC"
+
+#~ msgid "Deleted system subvolumes"
+#~ msgstr "Системные подразделы удалены"
+
+#~ msgid "Documenters"
+#~ msgstr "Составители документации"
+
+#~ msgid "Editing and Re-Ordering"
+#~ msgstr "Редактирование и изменение порядка"
+
+#~ msgid "Include everything"
+#~ msgstr "Включить всё"
+
+#~ msgid "Include hidden items"
+#~ msgstr "Включить скрытые объекты"
+
+#~ msgid "Info"
+#~ msgstr "Информация"
+
+#~ msgid "Log Viewer"
+#~ msgstr "Просмотр журналов"
+
+#~ msgid "Refresh Snapshot List"
+#~ msgstr "Обновить список снимков"
+
+#~ msgid "Scheduled task runs once every hour"
+#~ msgstr "Запланированная задача выполняется каждый час"
+
+#~ msgid "Selected snapshot path"
+#~ msgstr "Путь для снимка выбран"
+
+#~ msgid "Third Party Tools"
+#~ msgstr "Сторонние инструменты"
+
+#~ msgid "Translators"
+#~ msgstr "Переводчики"
+
+#~ msgid "View Log for Create"
+#~ msgstr "Просмотреть журнал создания"
+
+#~ msgid "View Log for Restore"
+#~ msgstr "Просмотреть журнал восстановления"
+
+#~ msgid "View:"
+#~ msgstr "Вид:"

--- a/po/timeshift-sk.po
+++ b/po/timeshift-sk.po
@@ -1,13 +1,8 @@
-# Slovak translation for linuxmint
-# Copyright (c) 2017 Rosetta Contributors and Canonical Ltd 2017
-# This file is distributed under the same license as the linuxmint package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
 "PO-Revision-Date: 2017-10-12 20:18+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Slovak <sk@li.org>\n"
@@ -15,10 +10,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:01+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -203,12 +196,6 @@ msgstr ""
 msgid "Available"
 msgstr ""
 
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
-
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr ""
@@ -223,6 +210,12 @@ msgstr ""
 
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
+msgstr ""
+
+#: Gtk/BackupDeviceBox.vala:98
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
 msgstr ""
 
 #: Gtk/FinishBox.vala:92

--- a/po/timeshift-sr.po
+++ b/po/timeshift-sr.po
@@ -1,24 +1,17 @@
-# Serbian translation for linuxmint
-# Copyright (c) 2017 Rosetta Contributors and Canonical Ltd 2017
-# This file is distributed under the same license as the linuxmint package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
-"PO-Revision-Date: 2017-10-01 16:29+0000\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
+"PO-Revision-Date: 2018-06-11 17:07+0000\n"
+"Last-Translator: Knez <Unknown>\n"
 "Language-Team: Serbian <sr@li.org>\n"
 "Language: sr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:00+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -32,45 +25,45 @@ msgstr ""
 #: Core/SnapshotRepo.vala:641
 #, c-format
 msgid "%d snapshots, %s free"
-msgstr ""
+msgstr "%d резервне копије,%s бесплатно"
 
 #: Console/AppConsole.vala:914
 #, c-format
 msgid "'%s' will be on '%s'"
-msgstr ""
+msgstr "%s' биће на '%s'"
 
 #: Console/AppConsole.vala:911
 #, c-format
 msgid "'%s' will be on root device"
-msgstr ""
+msgstr "'%s' ће бити на root уређају"
 
 #: Gtk/BootOptionsBox.vala:118
 msgid "(Re)install GRUB2 on:"
-msgstr ""
+msgstr "(Поново) инсталирај GRUB2 на:"
 
 #: Core/Main.vala:362
 msgid "** Uninstalled Timeshift BTRFS **"
-msgstr ""
+msgstr "** Деинсталиран Временски-помак BTRFS **"
 
 #: Core/Main.vala:3342
 msgid "/ is mapped to device"
-msgstr ""
+msgstr "/ мапиран је на уређај"
 
 #: Core/Main.vala:3364
 msgid "/boot is mapped to device"
-msgstr ""
+msgstr "/ boot мапиран је на уређај"
 
 #: Core/Main.vala:3375
 msgid "/boot/efi is mapped to device"
-msgstr ""
+msgstr "/ boot / efi мапиран је на уређај"
 
 #: Core/Main.vala:3353
 msgid "/home is mapped to device"
-msgstr ""
+msgstr "/ home мапиран је на уређај"
 
 #: Gtk/SnapshotListBox.vala:290
 msgid "<b>Comments</b> (double-click to edit)"
-msgstr ""
+msgstr "<b> Коментари </ b> (двапут кликните да бисте изменили)"
 
 #: Gtk/ScheduleBox.vala:168
 msgid ""
@@ -82,11 +75,11 @@ msgstr ""
 #: Console/AppConsole.vala:1034 Console/AppConsole.vala:1075
 #: Console/AppConsole.vala:1093
 msgid "Aborted."
-msgstr ""
+msgstr "Прекинут."
 
 #: Gtk/MainWindow.vala:393
 msgid "About"
-msgstr ""
+msgstr "Око"
 
 #: Gtk/RsyncLogBox.vala:472
 msgid "Action"
@@ -94,43 +87,45 @@ msgstr ""
 
 #: Gtk/ExcludeBox.vala:219
 msgid "Add"
-msgstr ""
+msgstr "Додавање"
 
 #: Gtk/ExcludeBox.vala:233
 msgid "Add Files"
-msgstr ""
+msgstr "Додавање датотеке"
 
 #: Gtk/ExcludeBox.vala:239
 msgid "Add Folders"
-msgstr ""
+msgstr "Додавање фасцикли"
 
 #: Gtk/ExcludeBox.vala:219
 msgid "Add custom pattern"
-msgstr ""
+msgstr "Додај прилагођени узорак"
 
 #: Gtk/ExcludeBox.vala:239
 msgid "Add directories"
-msgstr ""
+msgstr "Додавање директоријуме"
 
 #: Gtk/ExcludeBox.vala:233
 msgid "Add files"
-msgstr ""
+msgstr "Додајте датотеке"
 
 #: Console/AppConsole.vala:360
 msgid "Add tags to snapshot (default: O)"
-msgstr ""
+msgstr "Додајте ознаке у снимак (подразумевано: О)"
 
 #: Utility/CronTab.vala:312
 msgid "Added cron task"
-msgstr ""
+msgstr "Додан cron задатак"
 
 #: Gtk/AppGtk.vala:131
 msgid "Admin Access Required"
-msgstr ""
+msgstr "Потребан је администраторски приступ"
 
 #: Gtk/AppGtk.vala:126
 msgid "Admin access is required to backup and restore system files."
 msgstr ""
+"Потребан је администраторски приступ за сигурносну копију и враћање "
+"системских датотека."
 
 #: Gtk/RsyncLogBox.vala:363
 msgid "All Files"
@@ -142,10 +137,13 @@ msgid ""
 "are incremental. Unchanged files will be hard-linked from the previous "
 "snapshot if available."
 msgstr ""
+"Све датотеке се копирају када се креира први снимак. Накнадни снимци су "
+"инкрементални. Непромењене датотеке ће бити тешко повезане са претходним "
+"снимком ако су доступне."
 
 #: Gtk/ExcludeMessageWindow.vala:130
 msgid "All other files and folders are excluded."
-msgstr ""
+msgstr "Све остале датотеке и фасцикле су искључене."
 
 #: Gtk/RestoreDeviceBox.vala:500
 msgid ""
@@ -156,75 +154,81 @@ msgid ""
 "Either select a non-encrypted device for boot directory or select a non-"
 "encrypted device for root filesystem."
 msgstr ""
+"За коријенски систем датотека (/) изабран је шифровани уређај. Директоријум "
+"за покретање (/boot) мора бити монтиран на не-шифрованом уређају за успешно "
+"покретање система.\n"
+"\n"
+"Или изаберите не-шифрирани уређај за покретачки директориј или изаберите не-"
+"шифровани уређај за роот систем датотека."
 
 #: Core/Main.vala:249
 msgid "Another instance of Timeshift is creating a snapshot."
-msgstr ""
+msgstr "Још један пример Timeshift је креирао снимак."
 
 #: Utility/AppLock.vala:49
 msgid "Another instance of this application is running"
-msgstr ""
+msgstr "Још један пример ове апликације је покренут"
 
 #: Core/Main.vala:253
 msgid "Another instance of timeshift is currently running!"
-msgstr ""
+msgstr "Још један пример timeshift тренутно ради!"
 
 #: Console/AppConsole.vala:376
 msgid "Answer YES to all confirmation prompts"
-msgstr ""
+msgstr "Одговорите са ДА на сва потврдна упутства"
 
 #: Core/Main.vala:3179
 msgid "App config loaded"
-msgstr ""
+msgstr "Стављен је конфигурација апликације"
 
 #: Core/Main.vala:3076
 msgid "App config saved"
-msgstr ""
+msgstr "Конфигурација апликације је спремљена"
 
 #: Console/AppConsole.vala:102
 msgid "Application needs admin access."
-msgstr ""
+msgstr "Апликација захтева администраторски приступ."
 
 #: Core/Main.vala:3519
 msgid "Application will exit"
-msgstr ""
+msgstr "Апликација ће изаћи"
 
 #: Core/Main.vala:378
 msgid "Application will exit."
-msgstr ""
+msgstr "Апликација ће изаћи"
 
 #: Utility/Gtk/AboutWindow.vala:433
 msgid "Artists"
-msgstr ""
+msgstr "Уметници"
 
 #: Utility/Gtk/AboutWindow.vala:417
 msgid "Authors"
-msgstr ""
+msgstr "Аутори"
 
 #: Gtk/MainWindow.vala:346
 msgid "Available"
-msgstr ""
-
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
+msgstr "Доступан"
 
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
-msgstr ""
+msgstr "BTRFS"
 
 #: Gtk/SnapshotBackendBox.vala:165
 msgid "BTRFS Snapshots"
-msgstr ""
+msgstr "BTRFS Снимак"
 
 #: Gtk/SnapshotBackendBox.vala:119
 msgid "BTRFS Tools Not Found"
-msgstr ""
+msgstr "BTRFS Алати Нису Пронађени"
 
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
+msgstr "BTRFS уређај није монтиран"
+
+#: Gtk/BackupDeviceBox.vala:98
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
 msgstr ""
 
 #: Gtk/FinishBox.vala:92
@@ -234,46 +238,50 @@ msgid ""
 "snapshots to an external non-system disk in RSYNC mode to guard against disk "
 "failures."
 msgstr ""
+"BTRFS снимке се чувају на истом диску из којег је креиран. Ако системски "
+"диск не успе, снимци ће бити изгубљени заједно са системом. Сачувајте снимке "
+"на екстерни не-системски диск у RSYNC режиму како бисте заштитили отказивања "
+"на диску."
 
 #: Utility/Gtk/AboutWindow.vala:349 Utility/Gtk/AboutWindow.vala:381
 msgid "Back"
-msgstr ""
+msgstr "Натраг"
 
 #: Gtk/SetupWizardWindow.vala:94
 msgid "Backend"
-msgstr ""
+msgstr "Уназад"
 
 #: Console/AppConsole.vala:356 Gtk/BackupWindow.vala:91
 msgid "Backup"
-msgstr ""
+msgstr "Враћање"
 
 #: Core/Main.vala:2017
 msgid "Backup Device"
-msgstr ""
+msgstr "Враћање уређаја"
 
 #: Core/Main.vala:2012
 msgid "Backup device not specified!"
-msgstr ""
+msgstr "Није направљен резервни уређај!"
 
 #: Utility/Gtk/DonationWindow.vala:89
 msgid "Become a Patron"
-msgstr ""
+msgstr "Постаните покровитељ"
 
 #: Gtk/RestoreExcludeBox.vala:91
 msgid "Bittorrent Clients"
-msgstr ""
+msgstr "Бит-торент клијенти"
 
 #: Gtk/ScheduleBox.vala:136 Gtk/SnapshotListBox.vala:298
 msgid "Boot"
-msgstr ""
+msgstr "Оперативни систем"
 
 #: Gtk/RestoreDeviceBox.vala:499
 msgid "Boot device not selected"
-msgstr ""
+msgstr "Оперативни системски уређај није изабран"
 
 #: Core/Main.vala:1017
 msgid "Boot snapshot failed!"
-msgstr ""
+msgstr "Снимак покретања није успио!"
 
 #: Gtk/ScheduleBox.vala:169
 msgid ""
@@ -282,42 +290,42 @@ msgstr ""
 
 #: Core/Main.vala:998
 msgid "Boot snapshots are enabled"
-msgstr ""
+msgstr "Снимци са покретања су омогућени"
 
 #: Gtk/BootOptionsWindow.vala:49
 msgid "Bootloader Options"
-msgstr ""
+msgstr "Опције Боотлоадер-а"
 
 #: Gtk/RestoreDeviceBox.vala:411
 msgid "Bootloader Options (Advanced)"
-msgstr ""
+msgstr "Опције покретања оперативног система (Напредно)"
 
 #: Gtk/MainWindow.vala:171
 msgid "Browse"
-msgstr ""
+msgstr "Прегледајте"
 
 #: Gtk/SnapshotListBox.vala:336
 msgid "Browse Files"
-msgstr ""
+msgstr "Претражи фајлове"
 
 #: Gtk/MainWindow.vala:172
 msgid "Browse selected snapshot"
-msgstr ""
+msgstr "Прегледајте одабрани снимак"
 
 #: Core/Main.vala:2499
 msgid "Building file list..."
-msgstr ""
+msgstr "Израда листе датотека..."
 
 #: Utility/GtkHelper.vala:122 Utility/Gtk/CustomMessageDialog.vala:172
 #: Gtk/SetupWizardWindow.vala:214 Gtk/BackupWindow.vala:177
 #: Gtk/DeleteWindow.vala:187 Gtk/RestoreWindow.vala:206
 #: Gtk/RestoreWindow.vala:215
 msgid "Cancel"
-msgstr ""
+msgstr "Отказати"
 
 #: Gtk/RestoreWindow.vala:221
 msgid "Cancel restore?"
-msgstr ""
+msgstr "Откажи враћање?"
 
 #: Gtk/RestoreWindow.vala:223
 msgid ""
@@ -326,19 +334,23 @@ msgid ""
 "issues. After cancelling, you need to restore another snapshot, to bring the "
 "system to a consistent state. Click Yes to confirm."
 msgstr ""
+"Отказивање процеса обнављања оставиће циљани систем у неконзистентном стању. "
+"Систем се можда неће покренути или ћете се суочити са различитим проблемима. "
+"Након отказивања, потребно је вратити још један снимак како бисте довели "
+"систем у доследан положај. Кликните на Да да потврдите."
 
 #: Gtk/MainWindow.vala:563
 msgid "Cannot Delete Live Snapshot"
-msgstr ""
+msgstr "Не могу да избришем снимак уживо"
 
 #: Gtk/RsyncLogBox.vala:380 Gtk/RsyncLogBox.vala:383 Gtk/RsyncLogBox.vala:567
 #: Gtk/RsyncLogBox.vala:588 Gtk/RestoreBox.vala:125 Gtk/BackupBox.vala:87
 msgid "Changed"
-msgstr ""
+msgstr "Промењено"
 
 #: Gtk/RestoreBox.vala:127 Gtk/BackupBox.vala:89
 msgid "Changed items:"
-msgstr ""
+msgstr "Промењене ставке:"
 
 #: Gtk/RestoreWindow.vala:104
 msgid "Checking Restore Actions (Dry Run)"
@@ -346,20 +358,20 @@ msgstr ""
 
 #: Core/Main.vala:2732
 msgid "Checking file systems for errors..."
-msgstr ""
+msgstr "Провера датотека система за грешке..."
 
 #: Gtk/RsyncLogBox.vala:390 Gtk/RestoreBox.vala:130 Gtk/BackupBox.vala:92
 #, c-format
 msgid "Checksum"
-msgstr ""
+msgstr "Провера сума"
 
 #: Core/Main.vala:2388
 msgid "Cleaning up..."
-msgstr ""
+msgstr "Поспремити..."
 
 #: Gtk/UsersBox.vala:92 Gtk/ExcludeBox.vala:84
 msgid "Click to edit. Drag and drop to re-order."
-msgstr ""
+msgstr "Кликните да измените. Повуците и испустите на редослед."
 
 #: Gtk/ExcludeBox.vala:59
 msgid "Click to edit. Drag-drop to re-order."
@@ -367,31 +379,31 @@ msgstr ""
 
 #: Gtk/RestoreWindow.vala:69
 msgid "Clone System"
-msgstr ""
+msgstr "Клонски систем"
 
 #: Console/AppConsole.vala:364
 msgid "Clone current system"
-msgstr ""
+msgstr "Клон тренутни систем"
 
 #: Gtk/RestoreFinishBox.vala:68
 msgid "Cloning"
-msgstr ""
+msgstr "Клонирање"
 
 #: Core/Main.vala:2782
 msgid "Cloning system..."
-msgstr ""
+msgstr "Клонирање систем..."
 
 #: Utility/Gtk/AboutWindow.vala:326 Utility/Gtk/DonationWindow.vala:121
 #: Gtk/RsyncLogBox.vala:266 Gtk/BackupWindow.vala:168
 #: Gtk/BootOptionsWindow.vala:106 Gtk/DeleteWindow.vala:170
 #: Gtk/RestoreWindow.vala:508
 msgid "Close"
-msgstr ""
+msgstr "Затварај"
 
 #: Gtk/RestoreFinishBox.vala:106 Gtk/BackupFinishBox.vala:70
 #: Gtk/FinishBox.vala:101 Gtk/DeleteFinishBox.vala:71
 msgid "Close window to exit"
-msgstr ""
+msgstr "Затвори прозор за излазак"
 
 #: Utility/Gtk/AboutWindow.vala:425
 msgid "Code Contributions"
@@ -399,11 +411,11 @@ msgstr ""
 
 #: Core/Main.vala:347
 msgid "Commands listed below are not available on this system"
-msgstr ""
+msgstr "Команде наведене у наставку нису доступне на овом систему"
 
 #: Gtk/SnapshotListBox.vala:224
 msgid "Comments"
-msgstr ""
+msgstr "Коментари"
 
 #: Core/Main.vala:2775 Gtk/RestoreBox.vala:74 Gtk/RestoreBox.vala:187
 msgid "Comparing Files (Dry Run)..."
@@ -416,11 +428,11 @@ msgstr ""
 #: Gtk/RestoreFinishBox.vala:50 Gtk/RestoreFinishBox.vala:75
 #: Gtk/BackupFinishBox.vala:50 Gtk/DeleteFinishBox.vala:50
 msgid "Completed"
-msgstr ""
+msgstr "Завршено"
 
 #: Gtk/RestoreFinishBox.vala:78
 msgid "Completed With Errors"
-msgstr ""
+msgstr "Завршено Са Грешкама"
 
 #: Gtk/RsyncLogBox.vala:87 Gtk/RestoreWindow.vala:109
 msgid "Confirm Actions"
@@ -429,75 +441,79 @@ msgstr ""
 #: Console/AppConsole.vala:1068
 #, c-format
 msgid "Continue with restore? (y/n): "
-msgstr ""
+msgstr "Наставите са обнављањем? (д/н): "
 
 #: Console/AppConsole.vala:834 Console/AppConsole.vala:965
 msgid "Could not find device"
-msgstr ""
+msgstr "Није могуће пронаћи уређај"
 
 #: Utility/Device.vala:1187
 #, c-format
 msgid "Could not find file"
-msgstr ""
+msgstr "Не могу наћи датотеку"
 
 #: Console/AppConsole.vala:731
 msgid "Could not find snapshot"
-msgstr ""
+msgstr "Није могуће пронаћи снимак"
 
 #: Core/Main.vala:2946
 msgid "Could not find system subvolume"
-msgstr ""
+msgstr "Није могуће пронаћи системски подпрограм"
 
 #: Core/Main.vala:2974
 msgid "Could not find system subvolumes for creating pre-restore snapshot"
 msgstr ""
+"Није могуће пронаћи системске подпрограме за креирање претходног "
+"обнављајућег снимка"
 
 #: Gtk/RsyncLogBox.vala:366 Gtk/RsyncLogBox.vala:571 Gtk/MainWindow.vala:141
 #, c-format
 msgid "Create"
-msgstr ""
+msgstr "Креирати"
 
 #: Gtk/BackupWindow.vala:61
 msgid "Create Snapshot"
-msgstr ""
+msgstr "Креирај Снимак"
 
 #: Gtk/ScheduleBox.vala:136
 msgid "Create one per boot"
-msgstr ""
+msgstr "Направи једну по бооту"
 
 #: Gtk/ScheduleBox.vala:100
 msgid "Create one per day"
-msgstr ""
+msgstr "Направи једна по дану"
 
 #: Gtk/ScheduleBox.vala:118
 msgid "Create one per hour"
-msgstr ""
+msgstr "Направи једну по сату"
 
 #: Gtk/ScheduleBox.vala:64
 msgid "Create one per month"
-msgstr ""
+msgstr "Направи једна месечно"
 
 #: Gtk/ScheduleBox.vala:82
 msgid "Create one per week"
-msgstr ""
+msgstr "Направи једна недељно"
 
 #: Console/AppConsole.vala:358
 msgid "Create snapshot (even if not scheduled)"
-msgstr ""
+msgstr "Креирајте снимак (чак и ако није заказан)"
 
 #: Console/AppConsole.vala:357
 msgid "Create snapshot if scheduled"
-msgstr ""
+msgstr "Креирајте снимак ако је заказан"
 
 #: Gtk/MainWindow.vala:142
 msgid "Create snapshot of current system"
-msgstr ""
+msgstr "Креирајте снимак тренутног система"
 
 #: Gtk/MainWindow.vala:1074
 msgid ""
 "Create snapshots manually or enable scheduled snapshots to protect your "
 "system"
 msgstr ""
+"Креирајте снимке ручно или омогућите заказане снимке како бисте заштитили "
+"свој систем"
 
 #: Gtk/SnapshotBackendBox.vala:95
 msgid "Create snapshots using BTRFS"
@@ -505,114 +521,114 @@ msgstr ""
 
 #: Gtk/SnapshotBackendBox.vala:78
 msgid "Create snapshots using RSYNC tool and hard-links"
-msgstr ""
+msgstr "Направите снимке помоћу RSYNC алата и тврдих-веза"
 
 #: Gtk/RsyncLogBox.vala:366 Gtk/RsyncLogBox.vala:571 Gtk/RsyncLogBox.vala:592
 #: Gtk/RestoreBox.vala:123 Gtk/BackupBox.vala:85
 #, c-format
 msgid "Created"
-msgstr ""
+msgstr "Креирај"
 
 #: Core/Snapshot.vala:430
 msgid "Created control file"
-msgstr ""
+msgstr "Креирана контролна датотека"
 
 #: Utility/TeeJee.FileSystem.vala:351
 msgid "Created directory"
-msgstr ""
+msgstr "Креиран директоријум"
 
 #: Core/Main.vala:2996
 msgid "Created pre-restore snapshot"
-msgstr ""
+msgstr "Креиран снимак претходне обнове"
 
 #: Core/Main.vala:1499
 msgid "Created subvolume snapshot"
-msgstr ""
+msgstr "Креиран снимак подпрограма"
 
 #: Gtk/BackupBox.vala:71
 msgid "Creating Snapshot..."
-msgstr ""
+msgstr "Креирање Снимка..."
 
 #: Core/Main.vala:1437
 msgid "Creating new backup..."
-msgstr ""
+msgstr "Креирање нове резервне копије..."
 
 #: Core/Main.vala:1283
 msgid "Creating new snapshot..."
-msgstr ""
+msgstr "Креирање новог снимања..."
 
 #: Core/Main.vala:2924
 msgid "Creating pre-restore snapshot from system subvolumes..."
-msgstr ""
+msgstr "Креирање претходног обнављања снимка из подсистема..."
 
 #: Utility/Gtk/AboutWindow.vala:321 Utility/Gtk/AboutWindow.vala:387
 msgid "Credits"
-msgstr ""
+msgstr "Кредити"
 
 #: Core/Main.vala:3518
 msgid "Critical Error"
-msgstr ""
+msgstr "Критична грешка"
 
 #: Utility/CronTab.vala:136
 msgid "Cron job added"
-msgstr ""
+msgstr "Додан је Cron"
 
 #: Utility/CronTab.vala:217
 msgid "Cron job removed"
-msgstr ""
+msgstr "Cron посао уклоњена"
 
 #: Utility/CronTab.vala:304
 msgid "Cron task exists"
-msgstr ""
+msgstr "Cron задатак постоји"
 
 #: Gtk/ScheduleBox.vala:100 Gtk/SnapshotListBox.vala:300
 msgid "Daily"
-msgstr ""
+msgstr "Дневно"
 
 #: Core/Main.vala:1077
 msgid "Daily snapshot failed!"
-msgstr ""
+msgstr "Дневни снимак није успело!"
 
 #: Core/Main.vala:1058
 msgid "Daily snapshots are enabled"
-msgstr ""
+msgstr "Дневни снимци су омогућени"
 
 #: Core/Main.vala:2111
 msgid "Data will be modified on following devices:"
-msgstr ""
+msgstr "Подаци ће бити измењени на следећим уређајима:"
 
 #: Console/AppConsole.vala:370 Gtk/RsyncLogBox.vala:370
 #: Gtk/RsyncLogBox.vala:575 Gtk/MainWindow.vala:161
 #: Gtk/SnapshotListBox.vala:322 Gtk/DeleteWindow.vala:98
 #, c-format
 msgid "Delete"
-msgstr ""
+msgstr "Избрисати"
 
 #: Gtk/DeleteWindow.vala:62
 msgid "Delete Snapshots"
-msgstr ""
+msgstr "Избрисати снимке"
 
 #: Console/AppConsole.vala:372
 msgid "Delete all snapshots"
-msgstr ""
+msgstr "Избрисати све снимке"
 
 #: Gtk/MainWindow.vala:162
 msgid "Delete selected snapshot"
-msgstr ""
+msgstr "Избрисати изабран снимак"
 
 #: Console/AppConsole.vala:371
 msgid "Delete snapshot"
-msgstr ""
+msgstr "Избрисати снимак"
 
 #: Gtk/RsyncLogBox.vala:370 Gtk/RsyncLogBox.vala:575 Gtk/RsyncLogBox.vala:596
 #: Gtk/RestoreBox.vala:124 Gtk/BackupBox.vala:86
 #, c-format
 msgid "Deleted"
-msgstr ""
+msgstr "Избрисан"
 
 #: Utility/TeeJee.FileSystem.vala:381
 msgid "Deleted directory"
-msgstr ""
+msgstr "Избрисан директоријум"
 
 #: Core/Subvolume.vala:154 Core/Main.vala:2903 Core/Main.vala:2907
 #, c-format
@@ -621,7 +637,7 @@ msgstr ""
 
 #: Gtk/DeleteBox.vala:58
 msgid "Deleting Snapshots..."
-msgstr ""
+msgstr "Брисање снимака..."
 
 #: Core/Subvolume.vala:141
 #, c-format
@@ -630,21 +646,21 @@ msgstr ""
 
 #: Gtk/RestoreExcludeBox.vala:105
 msgid "Deluge, Transmission"
-msgstr ""
+msgstr "Deluge, Transmission"
 
 #: Console/AppConsole.vala:427 Console/AppConsole.vala:542
 msgid "Description"
-msgstr ""
+msgstr "Опис"
 
 #: Core/Subvolume.vala:168
 #, c-format
 msgid "Destroyed qgroup"
-msgstr ""
+msgstr "Уништена група"
 
 #: Core/Subvolume.vala:158
 #, c-format
 msgid "Destroying qgroup"
-msgstr ""
+msgstr "Уништавање група"
 
 #: Utility/Device.vala:1810 Utility/Device.vala:1820
 #: Console/AppConsole.vala:454 Console/AppConsole.vala:493
@@ -653,19 +669,19 @@ msgstr ""
 #: Core/Main.vala:2146 Gtk/RestoreDeviceBox.vala:97
 #, c-format
 msgid "Device"
-msgstr ""
+msgstr "Уређај"
 
 #: Utility/Device.vala:1269
 msgid "Device is unlocked"
-msgstr ""
+msgstr "Уређај је откључан"
 
 #: Utility/Device.vala:1164 Utility/Device.vala:1226
 msgid "Device name is empty!"
-msgstr ""
+msgstr "Уређај је откључан"
 
 #: Console/AppConsole.vala:663 Core/SnapshotRepo.vala:560 Core/Main.vala:3232
 msgid "Device not found"
-msgstr ""
+msgstr "Уређај није пронађен"
 
 #: Gtk/BackupDeviceBox.vala:97
 #, c-format
@@ -679,11 +695,11 @@ msgstr ""
 
 #: Gtk/RestoreDeviceBox.vala:84
 msgid "Devices from which snapshot was created are pre-selected."
-msgstr ""
+msgstr "Уређаји из којих је креиран снимак су унапред изабрани."
 
 #: Console/AppConsole.vala:326
 msgid "Devices with Linux file systems"
-msgstr ""
+msgstr "Уређаји са Линукс системиским датотеком"
 
 #: Gtk/BackupDeviceBox.vala:105
 msgid "Devices with Windows file systems are not supported (NTFS, FAT, etc)."
@@ -705,26 +721,41 @@ msgid ""
 "Tony George\n"
 "(teejeetech@gmail.com)"
 msgstr ""
+"Да ли сте пронашли овај софтвер корисним?\n"
+"\n"
+"\n"
+"Можете ми купити кафу или направити донацију путем PayPal како бисте "
+"показали своју подршку. Или само ми пустите е-поруку и поздравите. Ова "
+"апликација је потпуно бесплатна и наставиће да остане на тај начин. Ваши "
+"доприноси ће помоћи да се овај пројекат одржи и даље побољша.\n"
+"\n"
+"Слободно ми пошаљите е-пошту ако пронађете неке проблеме у овој апликацији "
+"или ако вам је потребна промена. Предлози и повратне информације су увек "
+"добродошли.\n"
+"\n"
+"Хвала,\n"
+"Тони Георге\n"
+"(teejeetech@gmail.com)"
 
 #: Utility/TeeJee.FileSystem.vala:518
 msgid "Dir not found"
-msgstr ""
+msgstr "Ниси пронађен"
 
 #: Core/SnapshotRepo.vala:982
 msgid "Directory not found"
-msgstr ""
+msgstr "Директоријум није пронађен"
 
 #: Core/Main.vala:2206 Gtk/RestoreSummaryBox.vala:64
 msgid "Disclaimer"
-msgstr ""
+msgstr "Одрицање од одговорности"
 
 #: Gtk/BackupDeviceBox.vala:127
 msgid "Disk"
-msgstr ""
+msgstr "Диск"
 
 #: Core/Main.vala:226
 msgid "Distribution"
-msgstr ""
+msgstr "Дистрибуција"
 
 #: Utility/Gtk/AboutWindow.vala:449
 msgid "Documentation"
@@ -732,15 +763,15 @@ msgstr ""
 
 #: Utility/Gtk/DonationWindow.vala:42 Gtk/MainWindow.vala:388
 msgid "Donate"
-msgstr ""
+msgstr "Поклонити"
 
 #: Utility/Gtk/DonationWindow.vala:81
 msgid "Donate with PayPal"
-msgstr ""
+msgstr "Донирајте са PayPal"
 
 #: Utility/Gtk/AboutWindow.vala:465
 msgid "Donations"
-msgstr ""
+msgstr "Донације"
 
 #: Gtk/UsersBox.vala:357
 msgid "Enable BTRFS qgroups (recommended)"
@@ -748,7 +779,7 @@ msgstr ""
 
 #: Gtk/MainWindow.vala:1068
 msgid "Enable scheduled snapshots to protect your system"
-msgstr ""
+msgstr "Омогућите заказане снимке како бисте заштитили свој систем"
 
 #: Core/Main.vala:4030 Core/Main.vala:4070
 msgid "Enabled subvolume quota support"
@@ -756,43 +787,43 @@ msgstr ""
 
 #: Utility/Device.vala:1333
 msgid "Encrypted Device"
-msgstr ""
+msgstr "Шифровани уређај"
 
 #: Gtk/UsersBox.vala:236
 msgid "Encrypted Home Directory"
-msgstr ""
+msgstr "Шифровани Кућни директоријум"
 
 #: Console/AppConsole.vala:884
 #, c-format
 msgid "Enter device name or number"
-msgstr ""
+msgstr "Унесите назив уређаја или број"
 
 #: Console/AppConsole.vala:682 Console/AppConsole.vala:1013
 #, c-format
 msgid "Enter device name or number (a=Abort)"
-msgstr ""
+msgstr "Унесите име или број уређаја (а=Прекини)"
 
 #: Utility/Device.vala:1334
 #, c-format
 msgid "Enter passphrase to unlock '%s'"
-msgstr ""
+msgstr "Унесите шифру за откључавање '%s'"
 
 #: Utility/GtkHelper.vala:805
 msgid "Enter path or browse for directory"
-msgstr ""
+msgstr "Унесите пут или претражите директоријум"
 
 #: Console/AppConsole.vala:754
 #, c-format
 msgid "Enter snapshot number (a=Abort, p=Previous, n=Next)"
-msgstr ""
+msgstr "Унесите број снимак-а (а=Прекини, п=Претходно, н=Следеће)"
 
 #: Gtk/ExcludeBox.vala:225
 msgid "Enter the pattern to exclude (Ex: *.mp3, *.bak)"
-msgstr ""
+msgstr "Унесите шаблон за искључивање (Ex: *.mp3, *.bak)"
 
 #: Utility/GtkHelper.vala:18 Gtk/RestoreDeviceBox.vala:534
 msgid "Error"
-msgstr ""
+msgstr "Грешка"
 
 #: Gtk/RestoreWindow.vala:488
 msgid "Error running Rsync"
@@ -800,19 +831,19 @@ msgstr ""
 
 #: Gtk/SetupWizardWindow.vala:99 Gtk/BackupWindow.vala:81
 msgid "Estimate"
-msgstr ""
+msgstr "Процена"
 
 #: Gtk/EstimateBox.vala:56
 msgid "Estimating System Size..."
-msgstr ""
+msgstr "Процена Величине Система..."
 
 #: Core/Main.vala:1279
 msgid "Estimating system size..."
-msgstr ""
+msgstr "Процена величине система..."
 
 #: Console/AppConsole.vala:386
 msgid "Examples"
-msgstr ""
+msgstr "Примери"
 
 #: Gtk/UsersBox.vala:136
 msgid "Exclude All"
@@ -820,51 +851,51 @@ msgstr ""
 
 #: Gtk/ExcludeAppsBox.vala:51 Gtk/RestoreExcludeBox.vala:55
 msgid "Exclude Application Settings"
-msgstr ""
+msgstr "Искључи Поставке Апликације"
 
 #: Gtk/RestoreWindow.vala:99
 msgid "Exclude Apps"
-msgstr ""
+msgstr "Искључи Апликације"
 
 #: Gtk/ExcludeMessageWindow.vala:70
 msgid "Exclude List"
-msgstr ""
+msgstr "Искључи Листу"
 
 #: Gtk/ExcludeListSummaryWindow.vala:49
 msgid "Exclude List Summary"
-msgstr ""
+msgstr "Изузети Резиме Листа"
 
 #: Gtk/ExcludeBox.vala:224
 msgid "Exclude Pattern"
-msgstr ""
+msgstr "Искључи Образац"
 
 #: Gtk/ExcludeMessageWindow.vala:56
 msgid "Excluded Directories"
-msgstr ""
+msgstr "Искључени Директоријуми"
 
 #: Core/Main.vala:1567
 msgid "Expected values: O, B, H, D, W, M"
-msgstr ""
+msgstr "Очекиване вредности:  O, B, H, D, W, M"
 
 #: Utility/CronTab.vala:132
 msgid "Failed to add cron job"
-msgstr ""
+msgstr "Није успело додати cron посао"
 
 #: Utility/TeeJee.FileSystem.vala:191
 msgid "Failed to copy file"
-msgstr ""
+msgstr "Није могуће копирати датотеку"
 
 #: Utility/TeeJee.FileSystem.vala:354 Utility/TeeJee.FileSystem.vala:362
 msgid "Failed to create directory"
-msgstr ""
+msgstr "Није успело креирати директоријум"
 
 #: Core/Main.vala:1405
 msgid "Failed to create new snapshot"
-msgstr ""
+msgstr "Није успело направити нови снимак"
 
 #: Core/Main.vala:1255
 msgid "Failed to create snapshot"
-msgstr ""
+msgstr "Није успело направити снимак"
 
 #: Core/Main.vala:1495
 msgid "Failed to create subvolume snapshot"
@@ -872,15 +903,15 @@ msgstr ""
 
 #: Core/SnapshotRepo.vala:1023
 msgid "Failed to create symlinks"
-msgstr ""
+msgstr "Неуспело направити симболе"
 
 #: Utility/TeeJee.FileSystem.vala:384
 msgid "Failed to delete directory"
-msgstr ""
+msgstr "Није успело брисање директоријума"
 
 #: Utility/TeeJee.FileSystem.vala:100
 msgid "Failed to delete file"
-msgstr ""
+msgstr "Неуспешно да обрисате датотеку"
 
 #: Core/Subvolume.vala:150
 msgid "Failed to delete snapshot subvolume"
@@ -888,11 +919,11 @@ msgstr ""
 
 #: Core/SnapshotRepo.vala:1049
 msgid "Failed to delete symlinks"
-msgstr ""
+msgstr "Неуспешно обрисани симболи"
 
 #: Core/Subvolume.vala:164
 msgid "Failed to destroy qgroup"
-msgstr ""
+msgstr "Није успело уништити групу"
 
 #: Core/Main.vala:4055
 msgid "Failed to enable subvolume quota"
@@ -900,37 +931,37 @@ msgstr ""
 
 #: Core/Main.vala:3733 Core/Main.vala:3739
 msgid "Failed to estimate system size"
-msgstr ""
+msgstr "Није успела проценити величину система"
 
 #: Utility/CronTab.vala:257
 msgid "Failed to export crontab file"
-msgstr ""
+msgstr "Није успело извозити crontab датотеку"
 
 #: Console/AppConsole.vala:697 Console/AppConsole.vala:761
 #: Console/AppConsole.vala:893 Console/AppConsole.vala:988
 #: Console/AppConsole.vala:1033 Console/AppConsole.vala:1074
 msgid "Failed to get input from user in 3 attempts"
-msgstr ""
+msgstr "Није успео да добије информације од корисника у 3 покушаја"
 
 #: Utility/Device.vala:615
 msgid "Failed to get partition list"
-msgstr ""
+msgstr "Није успеo да добије листу партиција"
 
 #: Core/Main.vala:3315
 msgid "Failed to get partition list."
-msgstr ""
+msgstr "Није успео да добије списак партиције."
 
 #: Utility/CronTab.vala:240
 msgid "Failed to install crontab file"
-msgstr ""
+msgstr "Није успеo инсталирати crontab датотеку"
 
 #: Gtk/RestoreDeviceBox.vala:535
 msgid "Failed to mount devices"
-msgstr ""
+msgstr "Није успео да монтира уређаје"
 
 #: Utility/TeeJee.FileSystem.vala:210
 msgid "Failed to move file"
-msgstr ""
+msgstr "Није успео премештати датотеку"
 
 #: Core/Main.vala:2961
 msgid "Failed to move system subvolume to snapshot directory"
@@ -946,23 +977,23 @@ msgstr ""
 
 #: Utility/CronTab.vala:50
 msgid "Failed to read cron tab"
-msgstr ""
+msgstr "Није могуће читати cron картицу"
 
 #: Utility/TeeJee.FileSystem.vala:148
 msgid "Failed to read file"
-msgstr ""
+msgstr "Неуспешно читање датотеке"
 
 #: Core/SnapshotRepo.vala:969
 msgid "Failed to remove"
-msgstr ""
+msgstr "Није успело уклонити"
 
 #: Utility/CronTab.vala:213
 msgid "Failed to remove cron job"
-msgstr ""
+msgstr "Није успело уклонити cron посао"
 
 #: Core/Snapshot.vala:530 Core/Snapshot.vala:542 Core/Snapshot.vala:550
 msgid "Failed to remove snapshot"
-msgstr ""
+msgstr "Није успело уклонити снимак"
 
 #: Core/Main.vala:4094
 msgid "Failed to rescan subvolume quota"
@@ -974,24 +1005,24 @@ msgstr ""
 
 #: Core/Main.vala:1355
 msgid "Failed to save exclude list"
-msgstr ""
+msgstr "Није успела да сачува листу искључивања"
 
 #: Utility/Device.vala:1260 Utility/Device.vala:1314 Utility/Device.vala:1339
 #: Utility/Device.vala:1360 Utility/Device.vala:1380
 msgid "Failed to unlock device"
-msgstr ""
+msgstr "Није успело да откључа уређај"
 
 #: Utility/Device.vala:1611
 msgid "Failed to unmount"
-msgstr ""
+msgstr "Није успело да се демонтира"
 
 #: Core/Main.vala:3519
 msgid "Failed to unmount device!"
-msgstr ""
+msgstr "Није успело да демонтира уређај!"
 
 #: Utility/TeeJee.FileSystem.vala:175
 msgid "Failed to write file"
-msgstr ""
+msgstr "Није успело написати датотеку"
 
 #: Gtk/RsyncLogBox.vala:122
 msgid "File (snapshot)"
@@ -1007,16 +1038,16 @@ msgstr ""
 
 #: Gtk/BackupBox.vala:80
 msgid "File and directory counts:"
-msgstr ""
+msgstr "Број датотека и директоријума:"
 
 #: Utility/TeeJee.FileSystem.vala:671 Utility/TeeJee.FileSystem.vala:720
 msgid "File is missing"
-msgstr ""
+msgstr "Датотека недостаје"
 
 #: Utility/TeeJee.FileSystem.vala:205 Utility/TeeJee.FileSystem.vala:547
 #: Utility/CronTab.vala:225 Utility/RsyncTask.vala:296
 msgid "File not found"
-msgstr ""
+msgstr "Датотека није пронађена"
 
 #: Gtk/ExcludeListSummaryWindow.vala:62
 msgid ""
@@ -1027,14 +1058,16 @@ msgstr ""
 #: Gtk/SnapshotBackendBox.vala:192
 msgid "Files and directories can be excluded to save disk space."
 msgstr ""
+"Датотеке и директоријуми се могу искључити да би се уштедело простор на "
+"диску."
 
 #: Gtk/RestoreBox.vala:119
 msgid "Files and directory counts:"
-msgstr ""
+msgstr "Датотеке и број директоријума:"
 
 #: Gtk/ExcludeMessageWindow.vala:76
 msgid "Files matching the following patterns will be excluded"
-msgstr ""
+msgstr "Датотеке које одговарају следећим обрасцима ће бити искључене"
 
 #: Utility/Device.vala:1828
 #, c-format
@@ -2645,3 +2678,53 @@ msgstr ""
 #: Core/SnapshotRepo.vala:831
 msgid "un-tagged"
 msgstr ""
+
+#~ msgid ""
+#~ "<b>Backup Levels</b>\n"
+#~ "\n"
+#~ "O\tOn demand (manual)\n"
+#~ "B\tBoot\n"
+#~ "H\tHourly\n"
+#~ "D\tDaily\n"
+#~ "W\tWeekly\n"
+#~ "M\tMonthly"
+#~ msgstr ""
+#~ "<b> Нивои покретања безбедности </ b>\n"
+#~ "\n"
+#~ "O \t На захтев (ручно)\n"
+#~ "B \t На почетку\n"
+#~ "H \t Сваког сата\n"
+#~ "D \t Сваког дана\n"
+#~ "W \t Недељно\n"
+#~ "M \t Месечно"
+
+#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
+#~ msgstr "<b> Датум снимања: </ b> Датум када је резервна копија направљена"
+
+#~ msgid "<b>System:</b> Installed Linux distribution"
+#~ msgstr "<b> Систем: </ b> Инсталирана Линукс дистрибуција"
+
+#~ msgid ""
+#~ "Click an item to edit the pattern.\n"
+#~ "Drag and drop items with mouse to re-order."
+#~ msgstr ""
+#~ "Кликните на ставку да бисте изменили образац.\n"
+#~ "Превуците и отпустите ставке са мишем за поновно наручивање."
+
+#~ msgid "Cloning System..."
+#~ msgstr "Клонирање Систем..."
+
+#~ msgid "Close Window"
+#~ msgstr "Затворите прозор"
+
+#~ msgid "Contributions"
+#~ msgstr "Удео"
+
+#~ msgid "Create snapshots using RSYNC"
+#~ msgstr "Креирајте снимке користећи RSYNC"
+
+#~ msgid "Documenters"
+#~ msgstr "Документарци"
+
+#~ msgid "Editing and Re-Ordering"
+#~ msgstr "Уређивање и преправка"

--- a/po/timeshift-sv.po
+++ b/po/timeshift-sv.po
@@ -1,24 +1,17 @@
-# Swedish translation for timeshift
-# Copyright (c) 2016 Rosetta Contributors and Canonical Ltd 2016
-# This file is distributed under the same license as the timeshift package.
-# FIRST AUTHOR Åke Engelbrektson <eson@svenskasprakfiler.se>, 2016.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: timeshift\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
-"PO-Revision-Date: 2018-01-14 12:11+0100\n"
-"Last-Translator: Åke Engelbrektson <eson@svenskasprakfiler.se>\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
+"PO-Revision-Date: 2017-11-17 04:14+0000\n"
+"Last-Translator: Arve Eriksson <Unknown>\n"
 "Language-Team: Svenska Språkfiler <eson@svenskasprakfiler.se>\n"
 "Language: sv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-09-18 16:44+0000\n"
-"X-Generator: Poedit 1.8.7.1\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:01+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -215,13 +208,6 @@ msgstr "Utvecklare"
 msgid "Available"
 msgstr "Tillgänglig"
 
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
-"BTRFS-avbilder sparas på systempartitionen. Andra partitioner stöds inte."
-
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr "BTRFS"
@@ -237,6 +223,14 @@ msgstr "BTRFS Tools kunde inte hittas"
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
 msgstr "Ingen BTRFS-enhet monterad"
+
+#: Gtk/BackupDeviceBox.vala:98
+#, fuzzy
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
+msgstr ""
+"BTRFS-avbilder sparas på systempartitionen. Andra partitioner stöds inte."
 
 #: Gtk/FinishBox.vala:92
 msgid ""
@@ -272,9 +266,7 @@ msgstr "Enhet för säkerhetskopior ej specificerad!"
 
 #: Utility/Gtk/DonationWindow.vala:89
 msgid "Become a Patron"
-msgstr ""
-"Hjälp oss med donationer\n"
-"Bli en beskyddare"
+msgstr "Hjälp oss med donationer"
 
 #: Gtk/RestoreExcludeBox.vala:91
 msgid "Bittorrent Clients"
@@ -487,9 +479,7 @@ msgstr "Skapa avbild"
 
 #: Gtk/ScheduleBox.vala:136
 msgid "Create one per boot"
-msgstr ""
-"Skapa en per systemstart\n"
-"Skapa en per start"
+msgstr "Skapa en per systemstart"
 
 #: Gtk/ScheduleBox.vala:100
 msgid "Create one per day"
@@ -584,9 +574,7 @@ msgstr "Kritiskt fel"
 
 #: Utility/CronTab.vala:136
 msgid "Cron job added"
-msgstr ""
-"Cron-åtgärd tillagd\n"
-"Cron-jobb tillagt"
+msgstr "Cron-åtgärd tillagd"
 
 #: Utility/CronTab.vala:217
 msgid "Cron job removed"
@@ -752,9 +740,7 @@ msgstr ""
 
 #: Utility/TeeJee.FileSystem.vala:518
 msgid "Dir not found"
-msgstr ""
-"Mapp kan inte hittas\n"
-"Mapp hittas inte"
+msgstr "Mapp kan inte hittas"
 
 #: Core/SnapshotRepo.vala:982
 msgid "Directory not found"
@@ -926,9 +912,7 @@ msgstr "Kunde inte ta bort mapp"
 
 #: Utility/TeeJee.FileSystem.vala:100
 msgid "Failed to delete file"
-msgstr ""
-"Kunde inte ta bort fil\n"
-"kunde inte ta bort fil"
+msgstr "Kunde inte ta bort fil"
 
 #: Core/Subvolume.vala:150
 msgid "Failed to delete snapshot subvolume"
@@ -1006,9 +990,7 @@ msgstr "Kunde inte ta bort"
 
 #: Utility/CronTab.vala:213
 msgid "Failed to remove cron job"
-msgstr ""
-"Kunde inte ta bort cron-jobb\n"
-"Kunde inte ta bort cron-åtgärd"
+msgstr "Kunde inte ta bort cron-jobb"
 
 #: Core/Snapshot.vala:530 Core/Snapshot.vala:542 Core/Snapshot.vala:550
 msgid "Failed to remove snapshot"
@@ -1246,10 +1228,7 @@ msgstr "Ogiltig avbild"
 
 #: Utility/Gtk/DonationWindow.vala:97
 msgid "Issue Tracker ~ Report Issues, Request Features, Ask Questions"
-msgstr ""
-"Problemspårning ~ Rapportera problem, önska funktioner, ställ frågor\n"
-"Ärendehanterare ~ Rapportera fel, efterfråga programfunktioner och ställ "
-"frågor"
+msgstr "Problemspårning ~ Rapportera problem, önska funktioner, ställ frågor"
 
 #: Gtk/ExcludeBox.vala:272
 msgid "Items Not Selected"
@@ -1893,9 +1872,7 @@ msgstr "Kör \"timeshift\", för kommandoradsversionen av detta verktyg"
 
 #: Console/AppConsole.vala:382
 msgid "Run in non-interactive mode"
-msgstr ""
-"Kör i icke-interaktivt läge\n"
-"Kör i icke interaktivt läge"
+msgstr "Kör i icke-interaktivt läge"
 
 #: Core/Main.vala:186
 msgid "Running"
@@ -2509,9 +2486,7 @@ msgid ""
 "responsibility for any damage arising from the use of this program."
 msgstr ""
 "Mjukvaran tillhandahålls UTAN några som helst garantier och utvecklaren tar "
-"inget ansvar för eventuell skada, orsakad av detta programs användning.\n"
-"Programmet tillhandahålls UTAN några som helst garantier och utvecklaren tar "
-"inget ansvar för eventuell skada orsakad av detta programs användning."
+"inget ansvar för eventuell skada, orsakad av detta programs användning."
 
 #: Gtk/MainWindow.vala:1047 Gtk/MainWindow.vala:1058
 msgid "Timeshift is active"
@@ -2535,8 +2510,7 @@ msgstr "Tidsstämpel"
 msgid "To restore with default options, press the ENTER key for all prompts!"
 msgstr ""
 "Tryck RETUR i alla dialoger, för att återställa med med "
-"standardinställningar.\n"
-"Tryck RETUR i alla dialoger, för att återställa med standardinställningar."
+"standardinställningar."
 
 #: Utility/Gtk/AboutWindow.vala:441
 msgid "Translations"
@@ -2630,9 +2604,7 @@ msgstr "Användare"
 
 #: Gtk/UsersBox.vala:63
 msgid "User Home Directories"
-msgstr ""
-"Användares hemkataloger\n"
-"Användarkataloger"
+msgstr "Användares hemkataloger"
 
 #: Utility/Device.vala:1340
 msgid "User cancelled the password prompt"
@@ -2685,9 +2657,7 @@ msgstr "Webbläsare"
 #: Utility/Gtk/DonationWindow.vala:113
 #, c-format
 msgid "Website"
-msgstr ""
-"Webbplats\n"
-"Webbsida"
+msgstr "Webbplats"
 
 #: Gtk/ScheduleBox.vala:82 Gtk/SnapshotListBox.vala:301
 msgid "Weekly"
@@ -2703,9 +2673,7 @@ msgstr "Veckoavbilder är aktiverat"
 
 #: Utility/Gtk/DonationWindow.vala:105
 msgid "Wiki ~ Documentation & Help"
-msgstr ""
-"Wiki ~ Dokument & hjälp\n"
-"Wiki ~ Dokumentation & Hjälp"
+msgstr "Wiki ~ Dokument & hjälp"
 
 #: Gtk/BackupFinishBox.vala:63 Gtk/DeleteFinishBox.vala:63
 msgid "With Errors"
@@ -2802,35 +2770,6 @@ msgstr "rsynk svarade med ett fel"
 msgid "un-tagged"
 msgstr "avtaggad"
 
-#, fuzzy
-#~ msgid "Click to edit and drag-drop to re-order"
-#~ msgstr "Klicka för att redigera. Dra och släpp för att sortera."
-
-#~ msgid ""
-#~ "Click an item to edit the pattern.\n"
-#~ "Drag and drop items with mouse to re-order."
-#~ msgstr ""
-#~ "Klicka på ett objekt för att redigera mönstret.\n"
-#~ "Dra och släpp objekt, för att sortera om."
-
-#~ msgid "Editing and Re-Ordering"
-#~ msgstr "Redigering och sortering"
-
-#~ msgid "Info"
-#~ msgstr "Info"
-
-#~ msgid "Deleted system subvolumes"
-#~ msgstr "Tog bort systemundervolymer"
-
-#~ msgid "<b>System:</b> Installed Linux distribution"
-#~ msgstr "<b>System:</b> Installerad Linux-distribution"
-
-#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
-#~ msgstr "<b>Avbildsdatum:</b> Datum då avbilden skapades"
-
-#~ msgid "Selected snapshot path"
-#~ msgstr "Vald avbildssökväg"
-
 #~ msgid ""
 #~ "<b>Backup Levels</b>\n"
 #~ "\n"
@@ -2850,25 +2789,48 @@ msgstr "avtaggad"
 #~ "W\tVarje vecka\n"
 #~ "M\tVarje månad"
 
+#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
+#~ msgstr "<b>Avbildsdatum:</b> Datum då avbilden skapades"
+
+#~ msgid "<b>System:</b> Installed Linux distribution"
+#~ msgstr "<b>System:</b> Installerad Linux-distribution"
+
+#~ msgid ""
+#~ "Click an item to edit the pattern.\n"
+#~ "Drag and drop items with mouse to re-order."
+#~ msgstr ""
+#~ "Klicka på ett objekt för att redigera mönstret.\n"
+#~ "Dra och släpp objekt, för att sortera om."
+
 #~ msgid "Cloning System..."
 #~ msgstr "Klonar systemet ..."
 
 #~ msgid "Close Window"
-#~ msgstr ""
-#~ "Stäng fönster\n"
-#~ "Stäng fönstret"
+#~ msgstr "Stäng fönster"
 
 #~ msgid "Contributions"
 #~ msgstr "Bidrag"
 
+#~ msgid "Create snapshots using RSYNC"
+#~ msgstr "Skapa avbilder med RSYNC"
+
+#~ msgid "Deleted system subvolumes"
+#~ msgstr "Tog bort systemundervolymer"
+
 #~ msgid "Documenters"
 #~ msgstr "Dokumentatörer"
+
+#~ msgid "Editing and Re-Ordering"
+#~ msgstr "Redigering och sortering"
 
 #~ msgid "Include everything"
 #~ msgstr "Ta med allt"
 
 #~ msgid "Include hidden items"
 #~ msgstr "Ta med dolda objekt"
+
+#~ msgid "Info"
+#~ msgstr "Info"
 
 #~ msgid "Log Viewer"
 #~ msgstr "Loggläsare"
@@ -2878,6 +2840,9 @@ msgstr "avtaggad"
 
 #~ msgid "Scheduled task runs once every hour"
 #~ msgstr "Schemalagd åtgärd körs en gång per timme"
+
+#~ msgid "Selected snapshot path"
+#~ msgstr "Vald avbildssökväg"
 
 #~ msgid "Third Party Tools"
 #~ msgstr "Tredjepartsverktyg"
@@ -2893,6 +2858,10 @@ msgstr "avtaggad"
 
 #~ msgid "View:"
 #~ msgstr "Visa:"
+
+#, fuzzy
+#~ msgid "Click to edit and drag-drop to re-order"
+#~ msgstr "Klicka för att redigera. Dra och släpp för att sortera."
 
 #~ msgid "Change"
 #~ msgstr "Ändrat"

--- a/po/timeshift-tr.po
+++ b/po/timeshift-tr.po
@@ -1,24 +1,17 @@
-# Turkish translation for timeshift
-# Copyright (c) 2013 Rosetta Contributors and Canonical Ltd 2013
-# This file is distributed under the same license as the timeshift package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2013.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: timeshift\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
-"PO-Revision-Date: 2017-11-07 19:52+0000\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
+"PO-Revision-Date: 2018-04-18 09:12+0000\n"
 "Last-Translator: Butterfly <Unknown>\n"
 "Language-Team: Turkish <tr@li.org>\n"
 "Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:01+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -216,12 +209,6 @@ msgstr "Geliştiriciler"
 msgid "Available"
 msgstr "Mevcut"
 
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
-
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr "BTRFS"
@@ -237,6 +224,13 @@ msgstr "BRTFS Araçları Bulunamadı"
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
 msgstr "BRTFS aygıt bağlanamadı"
+
+#: Gtk/BackupDeviceBox.vala:98
+#, fuzzy
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
+msgstr "Diğer uygulamalar (sonraki sayfa)"
 
 #: Gtk/FinishBox.vala:92
 msgid ""
@@ -1249,7 +1243,7 @@ msgstr "Öğeler Seçilmedi"
 
 #: Gtk/ScheduleBox.vala:283
 msgid "Keep"
-msgstr "Koru"
+msgstr "Koruma sayısı"
 
 #: Gtk/RestoreExcludeBox.vala:112
 msgid ""
@@ -2793,36 +2787,6 @@ msgstr "rsync bir hata döndürdü"
 msgid "un-tagged"
 msgstr "etiketsizleşti"
 
-#, fuzzy
-#~ msgid "Click to edit and drag-drop to re-order"
-#~ msgstr ""
-#~ "Düzenlemek için tıklayın. Yeniden sıralamak için sürükleyip bırakın."
-
-#~ msgid ""
-#~ "Click an item to edit the pattern.\n"
-#~ "Drag and drop items with mouse to re-order."
-#~ msgstr ""
-#~ "Şablonu düzenlemek için bir öğeye tıklayın.\n"
-#~ "Öğeleri yeniden sıralamak için fare ile taşıyıp bırakın."
-
-#~ msgid "Editing and Re-Ordering"
-#~ msgstr "Düzenleme ve Yeniden Sıralama"
-
-#~ msgid "Info"
-#~ msgstr "Bilgi"
-
-#~ msgid "Deleted system subvolumes"
-#~ msgstr "Sistem altbölümleri silindi"
-
-#~ msgid "<b>System:</b> Installed Linux distribution"
-#~ msgstr "<b>Sistem:</b> Kurulu Linux dağıtımı"
-
-#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
-#~ msgstr "<b>Anlık Görüntü Tarihi:</b> Anlık görüntünün oluşturulduğu tarih"
-
-#~ msgid "Selected snapshot path"
-#~ msgstr "Anlık görüntü yolu seçildi"
-
 #~ msgid ""
 #~ "<b>Backup Levels</b>\n"
 #~ "\n"
@@ -2842,6 +2806,19 @@ msgstr "etiketsizleşti"
 #~ "W\tHaftalık\n"
 #~ "M\tAylık"
 
+#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
+#~ msgstr "<b>Anlık Görüntü Tarihi:</b> Anlık görüntünün oluşturulduğu tarih"
+
+#~ msgid "<b>System:</b> Installed Linux distribution"
+#~ msgstr "<b>Sistem:</b> Kurulu Linux dağıtımı"
+
+#~ msgid ""
+#~ "Click an item to edit the pattern.\n"
+#~ "Drag and drop items with mouse to re-order."
+#~ msgstr ""
+#~ "Şablonu düzenlemek için bir öğeye tıklayın.\n"
+#~ "Öğeleri yeniden sıralamak için fare ile taşıyıp bırakın."
+
 #~ msgid "Cloning System..."
 #~ msgstr "Sistem Klonlanıyor..."
 
@@ -2851,14 +2828,26 @@ msgstr "etiketsizleşti"
 #~ msgid "Contributions"
 #~ msgstr "Katkıda bulunanlar"
 
+#~ msgid "Create snapshots using RSYNC"
+#~ msgstr "RSYNC kullanalarak anlık görüntü oluştur"
+
+#~ msgid "Deleted system subvolumes"
+#~ msgstr "Sistem altbölümleri silindi"
+
 #~ msgid "Documenters"
 #~ msgstr "Belgeleyenler"
+
+#~ msgid "Editing and Re-Ordering"
+#~ msgstr "Düzenleme ve Yeniden Sıralama"
 
 #~ msgid "Include everything"
 #~ msgstr "Her şeyi dahil et"
 
 #~ msgid "Include hidden items"
 #~ msgstr "Gizli öğeleri dahil et"
+
+#~ msgid "Info"
+#~ msgstr "Bilgi"
 
 #~ msgid "Log Viewer"
 #~ msgstr "Günlük Görüntüleyici"
@@ -2868,6 +2857,9 @@ msgstr "etiketsizleşti"
 
 #~ msgid "Scheduled task runs once every hour"
 #~ msgstr "Zamanlanmış görev saatte bir çalıştırılır"
+
+#~ msgid "Selected snapshot path"
+#~ msgstr "Anlık görüntü yolu seçildi"
 
 #~ msgid "Third Party Tools"
 #~ msgstr "Üçüncü Parti Araçlar"
@@ -2883,6 +2875,11 @@ msgstr "etiketsizleşti"
 
 #~ msgid "View:"
 #~ msgstr "Göster:"
+
+#, fuzzy
+#~ msgid "Click to edit and drag-drop to re-order"
+#~ msgstr ""
+#~ "Düzenlemek için tıklayın. Yeniden sıralamak için sürükleyip bırakın."
 
 #~ msgid "Change"
 #~ msgstr "Değişti"

--- a/po/timeshift-uk.po
+++ b/po/timeshift-uk.po
@@ -1,24 +1,17 @@
-# Ukrainian translation for timeshift
-# Copyright (c) 2016 Rosetta Contributors and Canonical Ltd 2016
-# This file is distributed under the same license as the timeshift package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: timeshift\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
-"PO-Revision-Date: 2017-11-03 18:39+0000\n"
-"Last-Translator: Oliver Star <ewqstar@gmail.com>\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
+"PO-Revision-Date: 2018-05-12 07:20+0000\n"
+"Last-Translator: Fedik <Unknown>\n"
 "Language-Team: Launchpad Ukrainian Translators <uk@li.org>\n"
 "Language: uk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:01+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -215,12 +208,6 @@ msgstr "Автори"
 msgid "Available"
 msgstr "Доступно"
 
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
-
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr "BTRFS"
@@ -236,6 +223,13 @@ msgstr "Інструментарію BTRFS не знайдено"
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
 msgstr "Пристрій BTRFS не підключено"
+
+#: Gtk/BackupDeviceBox.vala:98
+#, fuzzy
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
+msgstr "Інші застосунки (наступна сторінка)"
 
 #: Gtk/FinishBox.vala:92
 msgid ""
@@ -1204,7 +1198,7 @@ msgstr ""
 
 #: Gtk/ExcludeBox.vala:54
 msgid "Include / Exclude Patterns"
-msgstr "Включити / Виключити шаблони"
+msgstr "Шаблони:  Додати / Виключити"
 
 #: Gtk/UsersBox.vala:340
 msgid "Include @home subvolume in backups"
@@ -2116,7 +2110,7 @@ msgstr "Встановіть опис знімку"
 
 #: Gtk/MainWindow.vala:181 Gtk/MainWindow.vala:182 Gtk/SettingsWindow.vala:55
 msgid "Settings"
-msgstr "Налаштування"
+msgstr "Параметри"
 
 #: Gtk/MainWindow.vala:192
 msgid "Settings wizard"
@@ -2773,36 +2767,6 @@ msgstr "rsync повернув помилку"
 msgid "un-tagged"
 msgstr "не позначене"
 
-#, fuzzy
-#~ msgid "Click to edit and drag-drop to re-order"
-#~ msgstr ""
-#~ "Клацніть для редагування. Перетягніть і скиньте для перепорядкування."
-
-#~ msgid ""
-#~ "Click an item to edit the pattern.\n"
-#~ "Drag and drop items with mouse to re-order."
-#~ msgstr ""
-#~ "Клацніть на елементі для редагування шаблону.\n"
-#~ "Перетягніть і скиньте елементи мишкою для перепорядкування."
-
-#~ msgid "Editing and Re-Ordering"
-#~ msgstr "Редагування та перепорядкування"
-
-#~ msgid "Info"
-#~ msgstr "Інфо"
-
-#~ msgid "Deleted system subvolumes"
-#~ msgstr "Вилучені системні підтоми"
-
-#~ msgid "<b>System:</b> Installed Linux distribution"
-#~ msgstr "<b>Система:</b> Встановлений дистрибутив Linux"
-
-#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
-#~ msgstr "<b>Дата знімку:</b>Вказує дату створення знімку"
-
-#~ msgid "Selected snapshot path"
-#~ msgstr "Шлях до обраного знімку"
-
 #~ msgid ""
 #~ "<b>Backup Levels</b>\n"
 #~ "\n"
@@ -2822,6 +2786,19 @@ msgstr "не позначене"
 #~ "W\tЩотижнево\n"
 #~ "M\tЩомісячно"
 
+#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
+#~ msgstr "<b>Дата знімку:</b>Вказує дату створення знімку"
+
+#~ msgid "<b>System:</b> Installed Linux distribution"
+#~ msgstr "<b>Система:</b> Встановлений дистрибутив Linux"
+
+#~ msgid ""
+#~ "Click an item to edit the pattern.\n"
+#~ "Drag and drop items with mouse to re-order."
+#~ msgstr ""
+#~ "Клацніть на елементі для редагування шаблону.\n"
+#~ "Перетягніть і скиньте елементи мишкою для перепорядкування."
+
 #~ msgid "Cloning System..."
 #~ msgstr "Клонування Системи..."
 
@@ -2831,14 +2808,26 @@ msgstr "не позначене"
 #~ msgid "Contributions"
 #~ msgstr "Внески"
 
+#~ msgid "Create snapshots using RSYNC"
+#~ msgstr "Створити знімок з використанням режиму RSYNC"
+
+#~ msgid "Deleted system subvolumes"
+#~ msgstr "Вилучені системні підтоми"
+
 #~ msgid "Documenters"
 #~ msgstr "Автори документації"
+
+#~ msgid "Editing and Re-Ordering"
+#~ msgstr "Редагування та перепорядкування"
 
 #~ msgid "Include everything"
 #~ msgstr "Включити все"
 
 #~ msgid "Include hidden items"
 #~ msgstr "Включити приховані елементи"
+
+#~ msgid "Info"
+#~ msgstr "Інфо"
 
 #~ msgid "Log Viewer"
 #~ msgstr "Перегляд журналу"
@@ -2848,6 +2837,9 @@ msgstr "не позначене"
 
 #~ msgid "Scheduled task runs once every hour"
 #~ msgstr "Завдання за розкладом виконується раз в годину"
+
+#~ msgid "Selected snapshot path"
+#~ msgstr "Шлях до обраного знімку"
 
 #~ msgid "Third Party Tools"
 #~ msgstr "Інші інструменти"
@@ -2863,6 +2855,11 @@ msgstr "не позначене"
 
 #~ msgid "View:"
 #~ msgstr "Перегляд:"
+
+#, fuzzy
+#~ msgid "Click to edit and drag-drop to re-order"
+#~ msgstr ""
+#~ "Клацніть для редагування. Перетягніть і скиньте для перепорядкування."
 
 #~ msgid "Change"
 #~ msgstr "Змінено"

--- a/po/timeshift-vi.po
+++ b/po/timeshift-vi.po
@@ -1,13 +1,8 @@
-# Vietnamese translation for linuxmint
-# Copyright (c) 2017 Rosetta Contributors and Canonical Ltd 2017
-# This file is distributed under the same license as the linuxmint package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
 "PO-Revision-Date: 2017-10-10 10:48+0000\n"
 "Last-Translator: Hoang Minh Hieu <Unknown>\n"
 "Language-Team: Vietnamese <vi@li.org>\n"
@@ -15,10 +10,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:01+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -205,12 +198,6 @@ msgstr ""
 msgid "Available"
 msgstr ""
 
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
-
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr ""
@@ -225,6 +212,12 @@ msgstr ""
 
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
+msgstr ""
+
+#: Gtk/BackupDeviceBox.vala:98
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
 msgstr ""
 
 #: Gtk/FinishBox.vala:92

--- a/po/timeshift-zh_CN.po
+++ b/po/timeshift-zh_CN.po
@@ -68,7 +68,7 @@ msgstr "<b>注释</b> (双击以修改)"
 #: Gtk/ScheduleBox.vala:168
 msgid ""
 "A maintenance task runs once every hour and creates snapshots as needed."
-msgstr ""
+msgstr "维护任务每小时运行一次，并根据需要创建快照。"
 
 #: Console/AppConsole.vala:698 Console/AppConsole.vala:762
 #: Console/AppConsole.vala:894 Console/AppConsole.vala:989
@@ -224,7 +224,7 @@ msgstr "BTRFS设备未加载"
 msgid ""
 "BTRFS snapshots are saved on system partition. Other partitions are not "
 "supported."
-msgstr ""
+msgstr "BTRFS快照保存在系统分区上。不支持其他分区。"
 
 #: Gtk/FinishBox.vala:92
 msgid ""
@@ -233,7 +233,7 @@ msgid ""
 "snapshots to an external non-system disk in RSYNC mode to guard against disk "
 "failures."
 msgstr ""
-"BTRFS快照保存在它被创建时的同一个磁盘内。如果系统磁盘损坏，快照也会随此丢失。"
+"BTRFS快照保存在创建它的同一个磁盘内。如果系统磁盘损坏，快照也会随此丢失。"
 "因此建议使用RSYNC模式来把快照存贮在外部非系统磁盘。"
 
 #: Utility/Gtk/AboutWindow.vala:349 Utility/Gtk/AboutWindow.vala:381
@@ -279,7 +279,7 @@ msgstr "启动快照失败！"
 #: Gtk/ScheduleBox.vala:169
 msgid ""
 "Boot snapshots are created with a delay of 10 minutes after system startup."
-msgstr ""
+msgstr "启动快照在系统启动后延迟10分钟创建。"
 
 #: Core/Main.vala:998
 msgid "Boot snapshots are enabled"
@@ -346,7 +346,7 @@ msgstr "更改的项目："
 
 #: Gtk/RestoreWindow.vala:104
 msgid "Checking Restore Actions (Dry Run)"
-msgstr ""
+msgstr "正在检查还原操作（空运行）"
 
 #: Core/Main.vala:2732
 msgid "Checking file systems for errors..."
@@ -400,7 +400,7 @@ msgstr "关闭窗口以退出"
 
 #: Utility/Gtk/AboutWindow.vala:425
 msgid "Code Contributions"
-msgstr ""
+msgstr "代码贡献"
 
 #: Core/Main.vala:347
 msgid "Commands listed below are not available on this system"
@@ -412,11 +412,11 @@ msgstr "注释"
 
 #: Core/Main.vala:2775 Gtk/RestoreBox.vala:74 Gtk/RestoreBox.vala:187
 msgid "Comparing Files (Dry Run)..."
-msgstr ""
+msgstr "正在比较文件（空运行）..."
 
 #: Core/Main.vala:2541
 msgid "Comparing files with rsync..."
-msgstr "正在使用rsync同步文件..."
+msgstr "正在使用rsync比较文件..."
 
 #: Gtk/RestoreFinishBox.vala:50 Gtk/RestoreFinishBox.vala:75
 #: Gtk/BackupFinishBox.vala:50 Gtk/DeleteFinishBox.vala:50
@@ -429,7 +429,7 @@ msgstr "已完成，但有错误"
 
 #: Gtk/RsyncLogBox.vala:87 Gtk/RestoreWindow.vala:109
 msgid "Confirm Actions"
-msgstr ""
+msgstr "确认操作"
 
 #: Console/AppConsole.vala:1068
 #, c-format
@@ -676,12 +676,12 @@ msgstr "未找到设备"
 #: Gtk/BackupDeviceBox.vala:97
 #, c-format
 msgid "Devices displayed above have BTRFS file systems."
-msgstr ""
+msgstr "以上显示的设备有 BTRFS 文件系统。"
 
 #: Gtk/BackupDeviceBox.vala:104
 #, c-format
 msgid "Devices displayed above have Linux file systems."
-msgstr ""
+msgstr "以上显示的设备有 Linux 文件系统。"
 
 #: Gtk/RestoreDeviceBox.vala:84
 msgid "Devices from which snapshot was created are pre-selected."
@@ -689,11 +689,11 @@ msgstr "已经创建快照的设备是预选的。"
 
 #: Console/AppConsole.vala:326
 msgid "Devices with Linux file systems"
-msgstr "Linux 文件系统所在的设备"
+msgstr "Linux 文件系统的设备"
 
 #: Gtk/BackupDeviceBox.vala:105
 msgid "Devices with Windows file systems are not supported (NTFS, FAT, etc)."
-msgstr ""
+msgstr "不支持 Windows 文件系统的设备（NTFS、FAT等）"
 
 #: Utility/Gtk/DonationWindow.vala:61
 msgid ""
@@ -746,7 +746,8 @@ msgstr "发行版"
 
 #: Utility/Gtk/AboutWindow.vala:449
 msgid "Documentation"
-msgstr ""
+msgstr "文档
+"
 
 #: Utility/Gtk/DonationWindow.vala:42 Gtk/MainWindow.vala:388
 msgid "Donate"
@@ -762,7 +763,7 @@ msgstr "捐赠"
 
 #: Gtk/UsersBox.vala:357
 msgid "Enable BTRFS qgroups (recommended)"
-msgstr ""
+msgstr "启用 BTRFS 配额组（推荐）"
 
 #: Gtk/MainWindow.vala:1068
 msgid "Enable scheduled snapshots to protect your system"
@@ -814,7 +815,7 @@ msgstr "错误"
 
 #: Gtk/RestoreWindow.vala:488
 msgid "Error running Rsync"
-msgstr ""
+msgstr "运行 rsync 时出错"
 
 #: Gtk/SetupWizardWindow.vala:99 Gtk/BackupWindow.vala:81
 msgid "Estimate"
@@ -834,7 +835,7 @@ msgstr "示例"
 
 #: Gtk/UsersBox.vala:136
 msgid "Exclude All"
-msgstr ""
+msgstr "排除一切"
 
 #: Gtk/ExcludeAppsBox.vala:51 Gtk/RestoreExcludeBox.vala:55
 msgid "Exclude Application Settings"
@@ -1017,7 +1018,7 @@ msgstr "带标签的快照"
 
 #: Gtk/RsyncLogBox.vala:119
 msgid "File (system)"
-msgstr ""
+msgstr "文件（系统）"
 
 #: Gtk/ExcludeMessageWindow.vala:98
 msgid "File Pattern"
@@ -1062,7 +1063,7 @@ msgstr "文件系统"
 
 #: Gtk/RsyncLogBox.vala:302
 msgid "Filter by name or path"
-msgstr ""
+msgstr "通过文件或路径筛选"
 
 #: Gtk/SettingsWindow.vala:100
 msgid "Filters"
@@ -1162,7 +1163,7 @@ msgstr "已启用每日快照"
 
 #: Utility/Gtk/AboutWindow.vala:457
 msgid "Icon Themes & Utilities"
-msgstr ""
+msgstr "图标主题和实用程序"
 
 #: Gtk/RestoreFinishBox.vala:102
 msgid ""
@@ -1188,11 +1189,11 @@ msgstr "在备份中包含 @home 子卷"
 
 #: Gtk/UsersBox.vala:266
 msgid "Include All"
-msgstr ""
+msgstr "包含一切"
 
 #: Gtk/UsersBox.vala:194
 msgid "Include Hidden"
-msgstr ""
+msgstr "包含隐藏文件"
 
 #: Core/Main.vala:2026
 msgid "Invalid Snapshot"
@@ -1326,7 +1327,7 @@ msgstr "最新的快照"
 
 #: Utility/Gtk/AboutWindow.vala:316 Utility/Gtk/AboutWindow.vala:356
 msgid "License"
-msgstr ""
+msgstr "许可证"
 
 #: Core/Main.vala:1344
 #, c-format
@@ -1376,7 +1377,7 @@ msgstr "菜单"
 
 #: Gtk/UsersBox.vala:354
 msgid "Miscellaneous"
-msgstr ""
+msgstr "杂项"
 
 #: Core/Main.vala:235
 msgid "Missing Dependencies"
@@ -1628,7 +1629,7 @@ msgstr "请等待快照被删除。"
 
 #: Gtk/EstimateBox.vala:66
 msgid "Please wait..."
-msgstr ""
+msgstr "请稍候..."
 
 #: Gtk/RsyncLogBox.vala:188
 msgid "Populating list..."
@@ -1705,7 +1706,7 @@ msgstr "刷新"
 
 #: Gtk/BackupDeviceBox.vala:106
 msgid "Remote and network locations are not supported."
-msgstr ""
+msgstr "不支持远程和网络位置。"
 
 #: Gtk/ExcludeBox.vala:253
 msgid "Remove"
@@ -1748,7 +1749,7 @@ msgstr "正在移除快照"
 msgid ""
 "Required for displaying shared and unshared size for snapshots in the main "
 "window"
-msgstr ""
+msgstr "在主窗口中显示快照的共享大小和未共享大小时需要"
 
 #: Console/AppConsole.vala:362 Gtk/RestoreFinishBox.vala:71
 #: Gtk/RsyncLogBox.vala:377 Gtk/RsyncLogBox.vala:567 Gtk/MainWindow.vala:151
@@ -1833,7 +1834,7 @@ msgstr "未选择根设备"
 
 #: Gtk/RsyncLogWindow.vala:49
 msgid "Rsync Log Viewer"
-msgstr ""
+msgstr "Rsync 日志查看器"
 
 #: Gtk/AppGtk.vala:119
 #, c-format
@@ -2213,7 +2214,7 @@ msgstr "快照是使用 BTRFS 文件系统的内置特性创建的。"
 #: Gtk/ScheduleBox.vala:167
 #, c-format
 msgid "Snapshots are not scheduled at fixed times."
-msgstr ""
+msgstr "快照不会在计划在固定的时间。"
 
 #: Gtk/SnapshotBackendBox.vala:173
 msgid ""
@@ -2243,13 +2244,13 @@ msgstr ""
 msgid ""
 "Snapshots are saved to /timeshift on selected partition. Other locations are "
 "not supported."
-msgstr ""
+msgstr "快照保存到选定分区上的/timeeshift。不支持其他地点。"
 
 #: Gtk/BackupDeviceBox.vala:99
 msgid ""
 "Snapshots are saved to /timeshift-btrfs on selected partition. Other "
 "locations are not supported."
-msgstr ""
+msgstr "快照保存到选定分区上的/timeeshift-btrfs。不支持其他地点。"
 
 #: Gtk/MainWindow.vala:1012
 msgid "Snapshots available for restore"
@@ -2314,12 +2315,12 @@ msgstr "已停止"
 #: Core/Subvolume.vala:189
 #, c-format
 msgid "Subvolume exists at destination"
-msgstr ""
+msgstr "目标位置存在子卷"
 
 #: Gtk/SnapshotListBox.vala:275
 #, c-format
 msgid "Subvolumes"
-msgstr ""
+msgstr "子卷"
 
 #: Gtk/ExcludeAppsBox.vala:135 Gtk/ExcludeBox.vala:258
 #: Gtk/RestoreWindow.vala:120
@@ -2438,7 +2439,7 @@ msgstr "Timeshift已开启"
 msgid ""
 "Timeshift is powered by the following tools and components. Please visit the "
 "links for more information."
-msgstr ""
+msgstr "Timeshift 由下列工具和组件提供支持。请访问链接以获得更多信息。"
 
 #: Gtk/RsyncLogBox.vala:394 Gtk/RestoreBox.vala:132 Gtk/BackupBox.vala:94
 #, c-format
@@ -2452,7 +2453,7 @@ msgstr "为了恢复默认设置，请按“回车键”来处理所有提示！
 
 #: Utility/Gtk/AboutWindow.vala:441
 msgid "Translations"
-msgstr ""
+msgstr "翻译"
 
 #: Utility/Device.vala:1827 Console/AppConsole.vala:457
 #: Console/AppConsole.vala:496 Gtk/BackupDeviceBox.vala:190
@@ -2557,7 +2558,7 @@ msgstr "用户"
 
 #: Gtk/RestoreWindow.vala:114
 msgid "Users Home"
-msgstr ""
+msgstr "用户主目录"
 
 #: Utility/Device.vala:1811
 #, c-format
@@ -2566,11 +2567,11 @@ msgstr "供应商"
 
 #: Gtk/SnapshotListBox.vala:343
 msgid "View Rsync Log for Create"
-msgstr ""
+msgstr "查看 Rsync 创建日志"
 
 #: Gtk/SnapshotListBox.vala:350
 msgid "View Rsync Log for Restore"
-msgstr ""
+msgstr "查看 Rsync 恢复日志"
 
 #: Gtk/MainWindow.vala:378
 msgid "View TimeShift Logs"

--- a/po/timeshift-zh_CN.po
+++ b/po/timeshift-zh_CN.po
@@ -1,24 +1,17 @@
-# Chinese (Simplified) translation for linuxmint
-# Copyright (c) 2017 Rosetta Contributors and Canonical Ltd 2017
-# This file is distributed under the same license as the linuxmint package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
-"POT-Creation-Date: 2018-06-24 17:21+0530\n"
-"PO-Revision-Date: 2017-10-17 04:40+0000\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
+"PO-Revision-Date: 2018-06-10 08:27+0000\n"
 "Last-Translator: AlephAlpha <alephalpha911@gmail.com>\n"
 "Language-Team: Chinese (Simplified) <zh_CN@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-02-03 14:28+0000\n"
-"X-Generator: Launchpad (build 18544)\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:00+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
 #: Console/AppConsole.vala:613
 #, c-format
@@ -27,12 +20,12 @@ msgid ""
 "Press ENTER to continue..."
 msgstr ""
 "\n"
-"按“回车键”继续..."
+"按回车键以继续..."
 
 #: Core/SnapshotRepo.vala:641
 #, c-format
 msgid "%d snapshots, %s free"
-msgstr ""
+msgstr "%d 快照， %s 可用"
 
 #: Console/AppConsole.vala:914
 #, c-format
@@ -122,17 +115,15 @@ msgstr "添加标签到快照 (默认：O)"
 
 #: Utility/CronTab.vala:312
 msgid "Added cron task"
-msgstr ""
-"Cron 任务已添加\n"
-"Cron任务已添加"
+msgstr "Cron 任务已添加"
 
 #: Gtk/AppGtk.vala:131
 msgid "Admin Access Required"
-msgstr "需使用管理员身份运行"
+msgstr "需要管理员权限"
 
 #: Gtk/AppGtk.vala:126
 msgid "Admin access is required to backup and restore system files."
-msgstr "需使用管理员身份来备份和恢复系统文件。"
+msgstr "备份和恢复系统文件需要管理员权限"
 
 #: Gtk/RsyncLogBox.vala:363
 msgid "All Files"
@@ -144,12 +135,12 @@ msgid ""
 "are incremental. Unchanged files will be hard-linked from the previous "
 "snapshot if available."
 msgstr ""
-"当首个快照生成时，系统所有文件已被复制。接下来的快照所产生的数据将在此基础上"
-"增加，前后无变化的文件仍使用以前的数据。"
+"在创建首个快照时，所有文件都会被复制。后续的快照将在此基础上增加，未更改的文"
+"件会硬链接到以前的快照。"
 
 #: Gtk/ExcludeMessageWindow.vala:130
 msgid "All other files and folders are excluded."
-msgstr "不包括所有其他文件和文件夹。"
+msgstr "其他文件和文件夹将被排除。"
 
 #: Gtk/RestoreDeviceBox.vala:500
 msgid ""
@@ -160,10 +151,10 @@ msgid ""
 "Either select a non-encrypted device for boot directory or select a non-"
 "encrypted device for root filesystem."
 msgstr ""
-"被加密的设备会使用根文件目录（/）。启动目录（/boot）必须加载到非加密设备以保"
-"证系统顺利启动。\n"
+"已为根文件系统(/)选择加密设备。启动目录（/boot）必须加载到非加密设备，系统才"
+"能顺利启动。\n"
 "\n"
-"请为启动目录或根文件目录选择一个非加密的设备。"
+"请为启动目录或根文件目录选择一个非加密设备。"
 
 #: Core/Main.vala:249
 msgid "Another instance of Timeshift is creating a snapshot."
@@ -171,7 +162,7 @@ msgstr "Timeshift 的另一个实例正在创建快照。"
 
 #: Utility/AppLock.vala:49
 msgid "Another instance of this application is running"
-msgstr "这一应用的另一实例正在运行"
+msgstr "此应用的另一实例正在运行"
 
 #: Core/Main.vala:253
 msgid "Another instance of timeshift is currently running!"
@@ -199,7 +190,7 @@ msgstr "应用将会退出"
 
 #: Core/Main.vala:378
 msgid "Application will exit."
-msgstr "程序将会关闭。"
+msgstr "应用将会退出。"
 
 #: Utility/Gtk/AboutWindow.vala:433
 msgid "Artists"
@@ -213,12 +204,6 @@ msgstr "作者"
 msgid "Available"
 msgstr "可用"
 
-#: Gtk/BackupDeviceBox.vala:98
-msgid ""
-"BRTFS snapshots are saved on system partition. Other partitions are not "
-"supported."
-msgstr ""
-
 #: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr "BTRFS"
@@ -229,11 +214,17 @@ msgstr "BTRFS快照"
 
 #: Gtk/SnapshotBackendBox.vala:119
 msgid "BTRFS Tools Not Found"
-msgstr "BTRFS工具丢失"
+msgstr "未找到BTRFS工具"
 
 #: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
 msgstr "BTRFS设备未加载"
+
+#: Gtk/BackupDeviceBox.vala:98
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
+msgstr ""
 
 #: Gtk/FinishBox.vala:92
 msgid ""
@@ -279,7 +270,7 @@ msgstr "启动"
 
 #: Gtk/RestoreDeviceBox.vala:499
 msgid "Boot device not selected"
-msgstr "启动设备未被选定"
+msgstr "未选择启动设备"
 
 #: Core/Main.vala:1017
 msgid "Boot snapshot failed!"
@@ -292,15 +283,15 @@ msgstr ""
 
 #: Core/Main.vala:998
 msgid "Boot snapshots are enabled"
-msgstr "启动快照已被开启"
+msgstr "已启用启动快照"
 
 #: Gtk/BootOptionsWindow.vala:49
 msgid "Bootloader Options"
-msgstr "启动引导程序选项"
+msgstr "引导加载程序选项"
 
 #: Gtk/RestoreDeviceBox.vala:411
 msgid "Bootloader Options (Advanced)"
-msgstr "启动引导程序选项（高级）"
+msgstr "引导加载程序选项（高级）"
 
 #: Gtk/MainWindow.vala:171
 msgid "Browse"
@@ -337,7 +328,7 @@ msgid ""
 "system to a consistent state. Click Yes to confirm."
 msgstr ""
 "取消此恢复过程会导致所恢复的系统数据不一致。系统可能无法启动或者出现诸多问"
-"题。当取消恢复后，您必须恢复其他的快照来保证系统数据的一致。请点击“确定”以确"
+"题。在取消恢复后，您必须恢复其他的快照来保证系统数据的一致。请点击“确定”以确"
 "认。"
 
 #: Gtk/MainWindow.vala:563
@@ -464,7 +455,7 @@ msgstr "无法找到系统子卷"
 
 #: Core/Main.vala:2974
 msgid "Could not find system subvolumes for creating pre-restore snapshot"
-msgstr ""
+msgstr "无法找到系统子卷以创造预恢复快照"
 
 #: Gtk/RsyncLogBox.vala:366 Gtk/RsyncLogBox.vala:571 Gtk/MainWindow.vala:141
 #, c-format
@@ -538,7 +529,7 @@ msgstr "已创建目录"
 
 #: Core/Main.vala:2996
 msgid "Created pre-restore snapshot"
-msgstr ""
+msgstr "已创建预恢复快照"
 
 #: Core/Main.vala:1499
 msgid "Created subvolume snapshot"
@@ -558,7 +549,7 @@ msgstr "创建新的快照..."
 
 #: Core/Main.vala:2924
 msgid "Creating pre-restore snapshot from system subvolumes..."
-msgstr ""
+msgstr "正在为子卷创建预恢复快照..."
 
 #: Utility/Gtk/AboutWindow.vala:321 Utility/Gtk/AboutWindow.vala:387
 msgid "Credits"
@@ -590,7 +581,7 @@ msgstr "每日快照失败！"
 
 #: Core/Main.vala:1058
 msgid "Daily snapshots are enabled"
-msgstr "每日快照已启用"
+msgstr "已启用每日快照"
 
 #: Core/Main.vala:2111
 msgid "Data will be modified on following devices:"
@@ -654,12 +645,12 @@ msgstr "描述"
 #: Core/Subvolume.vala:168
 #, c-format
 msgid "Destroyed qgroup"
-msgstr ""
+msgstr "已销毁配额组"
 
 #: Core/Subvolume.vala:158
 #, c-format
 msgid "Destroying qgroup"
-msgstr ""
+msgstr "正在销毁配额组"
 
 #: Utility/Device.vala:1810 Utility/Device.vala:1820
 #: Console/AppConsole.vala:454 Console/AppConsole.vala:493
@@ -676,11 +667,11 @@ msgstr "设备已解锁"
 
 #: Utility/Device.vala:1164 Utility/Device.vala:1226
 msgid "Device name is empty!"
-msgstr ""
+msgstr "设备名称是空的！"
 
 #: Console/AppConsole.vala:663 Core/SnapshotRepo.vala:560 Core/Main.vala:3232
 msgid "Device not found"
-msgstr "设备未找到"
+msgstr "未找到设备"
 
 #: Gtk/BackupDeviceBox.vala:97
 #, c-format
@@ -694,7 +685,7 @@ msgstr ""
 
 #: Gtk/RestoreDeviceBox.vala:84
 msgid "Devices from which snapshot was created are pre-selected."
-msgstr ""
+msgstr "已经创建快照的设备是预选的。"
 
 #: Console/AppConsole.vala:326
 msgid "Devices with Linux file systems"
@@ -720,14 +711,26 @@ msgid ""
 "Tony George\n"
 "(teejeetech@gmail.com)"
 msgstr ""
+"你觉得这个软件有用吗？\n"
+"\n"
+"你可以给我买一杯咖啡或者通过PayPal捐款来表示你的支持。 或者给我发一封电子邮件"
+"问声好。 这个应用程序是完全免费的，并将继续保持这种状态。 你的贡献将有助于保"
+"持这个项目的活力，并进一步改进它。\n"
+"\n"
+"如果您在此应用程序中发现任何问题或需要任何更改，请随时给我发送电子邮件。 欢迎"
+"提出建议和反馈。\n"
+"\n"
+"谢谢，\n"
+"Tony George\n"
+"（teejeetech@gmail.com）"
 
 #: Utility/TeeJee.FileSystem.vala:518
 msgid "Dir not found"
-msgstr "目录未找到"
+msgstr "未找到目录"
 
 #: Core/SnapshotRepo.vala:982
 msgid "Directory not found"
-msgstr "目录未找到"
+msgstr "未找到目录"
 
 #: Core/Main.vala:2206 Gtk/RestoreSummaryBox.vala:64
 msgid "Disclaimer"
@@ -763,11 +766,11 @@ msgstr ""
 
 #: Gtk/MainWindow.vala:1068
 msgid "Enable scheduled snapshots to protect your system"
-msgstr "启用计划快照已保护您的系统"
+msgstr "启用计划快照以保护您的系统"
 
 #: Core/Main.vala:4030 Core/Main.vala:4070
 msgid "Enabled subvolume quota support"
-msgstr ""
+msgstr "启用子卷配额支持"
 
 #: Utility/Device.vala:1333
 msgid "Encrypted Device"
@@ -794,7 +797,7 @@ msgstr "输入密码以解锁'%s'"
 
 #: Utility/GtkHelper.vala:805
 msgid "Enter path or browse for directory"
-msgstr ""
+msgstr "输入路径或浏览以选取目录"
 
 #: Console/AppConsole.vala:754
 #, c-format
@@ -803,7 +806,7 @@ msgstr "输入快照编号 (a=中断, p=前一个, n=后一个)"
 
 #: Gtk/ExcludeBox.vala:225
 msgid "Enter the pattern to exclude (Ex: *.mp3, *.bak)"
-msgstr "输入排除的模式 (例如：*.mp3, *.bak)"
+msgstr "输入要排除的模式 (例如：*.mp3, *.bak)"
 
 #: Utility/GtkHelper.vala:18 Gtk/RestoreDeviceBox.vala:534
 msgid "Error"
@@ -847,7 +850,7 @@ msgstr "排除列表"
 
 #: Gtk/ExcludeListSummaryWindow.vala:49
 msgid "Exclude List Summary"
-msgstr ""
+msgstr "排除列表摘要"
 
 #: Gtk/ExcludeBox.vala:224
 msgid "Exclude Pattern"
@@ -907,11 +910,11 @@ msgstr "删除符号链接失败"
 
 #: Core/Subvolume.vala:164
 msgid "Failed to destroy qgroup"
-msgstr ""
+msgstr "销毁配额组失败"
 
 #: Core/Main.vala:4055
 msgid "Failed to enable subvolume quota"
-msgstr ""
+msgstr "启用子卷配额失败"
 
 #: Core/Main.vala:3733 Core/Main.vala:3739
 msgid "Failed to estimate system size"
@@ -925,7 +928,7 @@ msgstr "导出 crontab 文件失败"
 #: Console/AppConsole.vala:893 Console/AppConsole.vala:988
 #: Console/AppConsole.vala:1033 Console/AppConsole.vala:1074
 msgid "Failed to get input from user in 3 attempts"
-msgstr ""
+msgstr "在3次尝试中未能获得用户的输入"
 
 #: Utility/Device.vala:615
 msgid "Failed to get partition list"
@@ -957,7 +960,7 @@ msgstr "查询子卷列表失败"
 
 #: Core/Main.vala:3947
 msgid "Failed to query subvolume quota"
-msgstr ""
+msgstr "查询子卷配额失败"
 
 #: Utility/CronTab.vala:50
 msgid "Failed to read cron tab"
@@ -981,7 +984,7 @@ msgstr "移除快照失败"
 
 #: Core/Main.vala:4094
 msgid "Failed to rescan subvolume quota"
-msgstr ""
+msgstr "重新扫描子卷配额失败"
 
 #: Core/Subvolume.vala:202
 msgid "Failed to restore system subvolume"
@@ -1022,7 +1025,7 @@ msgstr "文件模式"
 
 #: Gtk/BackupBox.vala:80
 msgid "File and directory counts:"
-msgstr ""
+msgstr "文件和目录计数："
 
 #: Utility/TeeJee.FileSystem.vala:671 Utility/TeeJee.FileSystem.vala:720
 msgid "File is missing"
@@ -1031,13 +1034,14 @@ msgstr "文件丢失"
 #: Utility/TeeJee.FileSystem.vala:205 Utility/TeeJee.FileSystem.vala:547
 #: Utility/CronTab.vala:225 Utility/RsyncTask.vala:296
 msgid "File not found"
-msgstr "无法找到文件"
+msgstr "未找到文件"
 
 #: Gtk/ExcludeListSummaryWindow.vala:62
 msgid ""
 "Files &amp; directories matching the patterns below will be excluded. "
 "Patterns starting with a + will include the item instead of excluding."
 msgstr ""
+"与以下模式匹配的文件和目录将被排除。以 a + 开头的模式将包含项目，而非排除。"
 
 #: Gtk/SnapshotBackendBox.vala:192
 msgid "Files and directories can be excluded to save disk space."
@@ -1045,11 +1049,11 @@ msgstr "您可以排除文件和目录以节省磁盘空间。"
 
 #: Gtk/RestoreBox.vala:119
 msgid "Files and directory counts:"
-msgstr ""
+msgstr "文件和目录计数："
 
 #: Gtk/ExcludeMessageWindow.vala:76
 msgid "Files matching the following patterns will be excluded"
-msgstr "排除匹配以下模式的文件"
+msgstr "与下列模式匹配的文件将被排除"
 
 #: Utility/Device.vala:1828
 #, c-format
@@ -1079,15 +1083,15 @@ msgstr "Firefox, Chromium, Chrome, Opera, Epiphany, Midori"
 
 #: Core/SnapshotRepo.vala:667
 msgid "First snapshot requires:"
-msgstr ""
+msgstr "第一次快照需要："
 
 #: Core/Main.vala:2894
 msgid "Found existing pre-restore snapshot"
-msgstr ""
+msgstr "找到现有的预恢复快照"
 
 #: Gtk/BackupDeviceBox.vala:215
 msgid "Free"
-msgstr ""
+msgstr "空闲"
 
 #: Core/SnapshotRepo.vala:77 Core/SnapshotRepo.vala:147
 msgid "Free space"
@@ -1103,7 +1107,7 @@ msgstr "未选取 GRUB 设备"
 
 #: Console/AppConsole.vala:1047
 msgid "GRUB will NOT be reinstalled"
-msgstr ""
+msgstr "不会重新安装 GRUB"
 
 #: Core/Main.vala:2348
 msgid "Generating initramfs..."
@@ -1122,7 +1126,7 @@ msgstr "组"
 msgid ""
 "Hidden files and folders are included by default since they contain user-"
 "specific configuration files."
-msgstr ""
+msgstr "默认包含隐藏的文件与目录，因为它们包括用户特定的设置文件。"
 
 #: Gtk/DeleteWindow.vala:178
 msgid "Hide"
@@ -1154,7 +1158,7 @@ msgstr "每小时快照失败！"
 
 #: Core/Main.vala:1028
 msgid "Hourly snapshots are enabled"
-msgstr "已启用每小时快照"
+msgstr "已启用每日快照"
 
 #: Utility/Gtk/AboutWindow.vala:457
 msgid "Icon Themes & Utilities"
@@ -1172,7 +1176,7 @@ msgstr ""
 msgid ""
 "If these terms are not acceptable to you, please do not proceed beyond this "
 "point!"
-msgstr ""
+msgstr "如果您无法接受这些条款，请不要继续进行下去！"
 
 #: Gtk/ExcludeBox.vala:54
 msgid "Include / Exclude Patterns"
@@ -1180,7 +1184,7 @@ msgstr "包含/排除模式"
 
 #: Gtk/UsersBox.vala:340
 msgid "Include @home subvolume in backups"
-msgstr ""
+msgstr "在备份中包含 @home 子卷"
 
 #: Gtk/UsersBox.vala:266
 msgid "Include All"
@@ -1192,24 +1196,24 @@ msgstr ""
 
 #: Core/Main.vala:2026
 msgid "Invalid Snapshot"
-msgstr ""
+msgstr "无效的快照"
 
 #: Console/AppConsole.vala:251
 #, c-format
 msgid "Invalid command line arguments"
-msgstr ""
+msgstr "无效的命令行参数"
 
 #: Gtk/MainWindow.vala:824
 msgid "Invalid snapshot"
-msgstr ""
+msgstr "无效的快照"
 
 #: Utility/Gtk/DonationWindow.vala:97
 msgid "Issue Tracker ~ Report Issues, Request Features, Ask Questions"
-msgstr ""
+msgstr "问题跟踪器 ~ 报告问题，请求特性，询问问题"
 
 #: Gtk/ExcludeBox.vala:272
 msgid "Items Not Selected"
-msgstr ""
+msgstr "未选择的项目"
 
 #: Gtk/ScheduleBox.vala:283
 msgid "Keep"
@@ -1221,24 +1225,28 @@ msgid ""
 "etc. If un-checked, previous configuration files will be restored from "
 "snapshot."
 msgstr ""
+"保留 BitTorrent 客户端（如 Deluge，Transmission 等）的配置文件。如果没有选中"
+"此项，将从快照恢复以前的配置文件。"
 
 #: Gtk/RestoreExcludeBox.vala:85
 msgid ""
 "Keep configuration files for web browsers like Firefox and Chrome. If un-"
 "checked, previous configuration files will be restored from snapshot"
 msgstr ""
+"保留网页浏览器（如 Firefox，Chrome 等）的配置文件。如果没有选中此项，将从快照"
+"恢复以前的配置文件。"
 
 #: Gtk/RestoreDeviceBox.vala:244
 msgid "Keep on Root Device"
-msgstr ""
+msgstr "保存于根设备"
 
 #: Gtk/RestoreDeviceBox.vala:229
 msgid "Keep this mount path on the root filesystem"
-msgstr ""
+msgstr "在根文件系统上保存此挂载路径"
 
 #: Gtk/SnapshotListBox.vala:519
 msgid "LIVE"
-msgstr ""
+msgstr "实时"
 
 #: Utility/Device.vala:1829 Console/AppConsole.vala:458
 #: Console/AppConsole.vala:497 Gtk/BackupDeviceBox.vala:254
@@ -1249,72 +1257,72 @@ msgstr "标签"
 #: Core/Main.vala:1010
 #, c-format
 msgid "Last boot snapshot is %d hours old"
-msgstr ""
+msgstr "上一次启动快照是在 %d 小时之前"
 
 #: Core/Main.vala:1005
 msgid "Last boot snapshot is older than system start time"
-msgstr ""
+msgstr "上一次启动快照早于系统启动时间"
 
 #: Core/Main.vala:1001
 msgid "Last boot snapshot not found"
-msgstr ""
+msgstr "未找到上一次启动快照"
 
 #: Core/Main.vala:1070
 #, c-format
 msgid "Last daily snapshot is %d hours old"
-msgstr ""
+msgstr "上一次每日快照是在 %d 小时之前"
 
 #: Core/Main.vala:1065
 msgid "Last daily snapshot is more than 1 day old"
-msgstr ""
+msgstr "上一次每日快照早于一天之前"
 
 #: Core/Main.vala:1061
 msgid "Last daily snapshot not found"
-msgstr ""
+msgstr "未找到上一次每日快照"
 
 #: Core/Main.vala:1040
 #, c-format
 msgid "Last hourly snapshot is %d minutes old"
-msgstr ""
+msgstr "上一次每小时快照是在 %d 分钟之前"
 
 #: Core/Main.vala:1035
 msgid "Last hourly snapshot is more than 1 hour old"
-msgstr ""
+msgstr "上一次每小时快照早于一小时之前"
 
 #: Core/Main.vala:1031
 msgid "Last hourly snapshot not found"
-msgstr ""
+msgstr "未找到上一次每小时快照"
 
 #: Core/Main.vala:1130
 #, c-format
 msgid "Last monthly snapshot is %d days old"
-msgstr ""
+msgstr "上一次每月快照是在 %d 天之前"
 
 #: Core/Main.vala:1125
 msgid "Last monthly snapshot is more than 1 month old"
-msgstr ""
+msgstr "上一次每月快照早于一个月之前"
 
 #: Core/Main.vala:1121
 msgid "Last monthly snapshot not found"
-msgstr ""
+msgstr "未找到上一次每月快照"
 
 #: Core/Main.vala:1100
 #, c-format
 msgid "Last weekly snapshot is %d days old"
-msgstr ""
+msgstr "上一次每周快照是在 %d 天之前"
 
 #: Core/Main.vala:1095
 msgid "Last weekly snapshot is more than 1 week old"
-msgstr ""
+msgstr "上一次每周快照早于一周之前"
 
 #: Core/Main.vala:1091
 msgid "Last weekly snapshot not found"
-msgstr ""
+msgstr "未找到上一次每周快照"
 
 #: Gtk/MainWindow.vala:1049
 #, c-format
 msgid "Latest snapshot"
-msgstr ""
+msgstr "最新的快照"
 
 #: Utility/Gtk/AboutWindow.vala:316 Utility/Gtk/AboutWindow.vala:356
 msgid "License"
@@ -1323,48 +1331,48 @@ msgstr ""
 #: Core/Main.vala:1344
 #, c-format
 msgid "Linking from snapshot"
-msgstr ""
+msgstr "从快照链接"
 
 #: Console/AppConsole.vala:352
 msgid "List"
-msgstr ""
+msgstr "列表"
 
 #: Console/AppConsole.vala:354
 msgid "List devices"
-msgstr ""
+msgstr "列出设备"
 
 #: Console/AppConsole.vala:353
 msgid "List snapshots"
-msgstr ""
+msgstr "列出快照"
 
 #: Gtk/MainWindow.vala:1000
 msgid "Live USB Mode (Restore Only)"
-msgstr ""
+msgstr "实时 USB 模式（仅恢复）"
 
 #: Gtk/SetupWizardWindow.vala:104 Gtk/BackupWindow.vala:86
 #: Gtk/SettingsWindow.vala:89
 msgid "Location"
-msgstr ""
+msgstr "位置"
 
 #: Gtk/MainWindow.vala:459
 msgid "Main window closed by user"
-msgstr ""
+msgstr "主窗口被用户关闭"
 
 #: Gtk/SnapshotListBox.vala:329
 msgid "Mark for Deletion"
-msgstr ""
+msgstr "标记为删除"
 
 #: Gtk/MainWindow.vala:641
 msgid "Marked for deletion"
-msgstr ""
+msgstr "已标记为删除"
 
 #: Core/SnapshotRepo.vala:711 Core/SnapshotRepo.vala:748
 msgid "Maximum backups exceeded for backup level"
-msgstr ""
+msgstr "超过备份等级的最大备份数"
 
 #: Gtk/MainWindow.vala:208
 msgid "Menu"
-msgstr ""
+msgstr "菜单"
 
 #: Gtk/UsersBox.vala:354
 msgid "Miscellaneous"
@@ -1372,92 +1380,92 @@ msgstr ""
 
 #: Core/Main.vala:235
 msgid "Missing Dependencies"
-msgstr ""
+msgstr "依赖关系丢失"
 
 #: Core/SnapshotRepo.vala:689
 #, c-format
 msgid "Mode"
-msgstr ""
+msgstr "模式"
 
 #: Utility/Device.vala:1812
 #, c-format
 msgid "Model"
-msgstr ""
+msgstr "模型"
 
 #: Gtk/ScheduleBox.vala:64 Gtk/SnapshotListBox.vala:302
 msgid "Monthly"
-msgstr ""
+msgstr "每月"
 
 #: Core/Main.vala:1118
 msgid "Monthly snapshot are enabled"
-msgstr ""
+msgstr "已启用每月快照"
 
 #: Core/Main.vala:1137
 msgid "Monthly snapshot failed!"
-msgstr ""
+msgstr "每月快照失败！"
 
 #: Core/Main.vala:2113 Core/Main.vala:2146
 msgid "Mount"
-msgstr ""
+msgstr "挂载"
 
 #: Core/Main.vala:2968
 msgid "Moved system subvolume to snapshot directory"
-msgstr ""
+msgstr "把系统子卷移动道快照目录"
 
 #: Gtk/MainWindow.vala:800
 msgid "Multiple snapshots selected"
-msgstr ""
+msgstr "选取了多个快照"
 
 #: Console/AppConsole.vala:425 Gtk/RsyncLogBox.vala:492
 #: Gtk/BackupDeviceBox.vala:235
 msgid "Name"
-msgstr ""
+msgstr "名称"
 
 #: Gtk/SetupWizardWindow.vala:197 Gtk/BackupWindow.vala:160
 #: Gtk/DeleteWindow.vala:162 Gtk/RestoreWindow.vala:198
 msgid "Next"
-msgstr ""
+msgstr "下一个"
 
 #: Utility/Gtk/CustomMessageDialog.vala:177
 msgid "No"
-msgstr ""
+msgstr "否"
 
 #: Gtk/RestoreBox.vala:122 Gtk/BackupBox.vala:84
 msgid "No Change"
-msgstr ""
+msgstr "无更改"
 
 #: Gtk/MainWindow.vala:615 Gtk/DeleteWindow.vala:341
 msgid "No Snapshots Selected"
-msgstr ""
+msgstr "未选取任何快照"
 
 #: Gtk/MainWindow.vala:1073
 msgid "No snapshots available"
-msgstr ""
+msgstr "没有可用的快照"
 
 #: Console/AppConsole.vala:320 Core/SnapshotRepo.vala:898
 #: Gtk/MainWindow.vala:1017
 msgid "No snapshots found"
-msgstr ""
+msgstr "找不到快照"
 
 #: Console/AppConsole.vala:740
 msgid "No snapshots found on device"
-msgstr ""
+msgstr "设备上找不到快照"
 
 #: Gtk/MainWindow.vala:553
 msgid "No snapshots on device"
-msgstr ""
+msgstr "设备上没有快照"
 
 #: Core/SnapshotRepo.vala:665
 msgid "No snapshots on this device"
-msgstr ""
+msgstr "此设备上没有快照"
 
 #: Gtk/MainWindow.vala:793
 msgid "No snapshots selected"
-msgstr ""
+msgstr "未选取任何快照"
 
 #: Gtk/MainWindow.vala:1050 Gtk/MainWindow.vala:1052
 msgid "None"
-msgstr ""
+msgstr "无"
 
 #: Core/Subvolume.vala:184
 #, fuzzy, c-format
@@ -1466,54 +1474,58 @@ msgstr "目录未找到"
 
 #: Core/SnapshotRepo.vala:683
 msgid "Not Selected"
-msgstr ""
+msgstr "未选定"
 
 #: Core/Main.vala:379
 msgid "Not Supported"
-msgstr ""
+msgstr "不支持"
 
 #: Core/SnapshotRepo.vala:629 Core/SnapshotRepo.vala:656
 msgid "Not enough disk space"
-msgstr ""
+msgstr "可用磁盘空间不足"
 
 #: Console/AppConsole.vala:397 Gtk/FinishBox.vala:55
 msgid "Notes"
-msgstr ""
+msgstr "备注"
 
 #: Core/Main.vala:1147
 msgid "Nothing to do!"
-msgstr ""
+msgstr "无事可做！"
 
 #: Console/AppConsole.vala:423 Console/AppConsole.vala:452
 #: Console/AppConsole.vala:491 Console/AppConsole.vala:539
 msgid "Num"
-msgstr ""
+msgstr "编号"
 
 #: Gtk/ScheduleBox.vala:282
 msgid ""
 "Number of snapshots to keep.\n"
 "Older snapshots will be removed once this limit is exceeded."
 msgstr ""
+"要保留的快照数。\n"
+"一旦超过此限制，旧的快照将被移除。"
 
 #: Utility/GtkHelper.vala:121 Utility/Gtk/CustomMessageDialog.vala:167
 #: Utility/Gtk/CustomMessageDialog.vala:171
 #: Gtk/ExcludeListSummaryWindow.vala:84
 msgid "OK"
-msgstr ""
+msgstr "确定"
 
 #: Gtk/SnapshotBackendBox.vala:179
 msgid ""
 "OS must be installed on a BTRFS partition with Ubuntu-type subvolume layout "
 "(@ and @home subvolumes). Other layouts are not supported."
 msgstr ""
+"操作系统必须安装在具有Ubuntu类型的子卷布局（@ 和 @home 子卷）的BTRFS分区上。 "
+"不支持其他布局。"
 
 #: Core/Main.vala:4201
 msgid "Older log files removed"
-msgstr ""
+msgstr "更早的日志文件已被移除"
 
 #: Gtk/MainWindow.vala:1051
 msgid "Oldest snapshot"
-msgstr ""
+msgstr "最早的快照"
 
 #: Gtk/SnapshotListBox.vala:297
 msgid "On demand (manual)"
@@ -1522,97 +1534,97 @@ msgstr ""
 #: Core/Main.vala:377 Core/Main.vala:3432 Gtk/RestoreDeviceBox.vala:525
 msgid ""
 "Only ubuntu-type layouts with @ and @home subvolumes are currently supported."
-msgstr ""
+msgstr "目前只支持具有 @ 和 @home 子卷的Ubuntu类型布局。"
 
 #: Gtk/MainWindow.vala:209
 msgid "Open Menu"
-msgstr ""
+msgstr "打开菜单"
 
 #: Core/Main.vala:3214
 msgid ""
 "Option --snapshot-device should not be specified for creating snapshots in "
 "BTRFS mode"
-msgstr ""
+msgstr "在BTRFS模式下创建快照时，请勿指定 --snapshot-device 选项"
 
 #: Console/AppConsole.vala:350 Gtk/AppGtk.vala:114
 msgid "Options"
-msgstr ""
+msgstr "选项"
 
 #: Gtk/RestoreExcludeBox.vala:118
 msgid "Other applications (next page)"
-msgstr ""
+msgstr "其它应用（下一页）"
 
 #: Gtk/RsyncLogBox.vala:398 Gtk/RestoreBox.vala:134 Gtk/BackupBox.vala:96
 #, c-format
 msgid "Owner"
-msgstr ""
+msgstr "拥有者"
 
 #: Utility/Device.vala:1824
 #, c-format
 msgid "Parent Device"
-msgstr ""
+msgstr "母设备"
 
 #: Core/Main.vala:2469 Core/Main.vala:2560 Gtk/RsyncLogBox.vala:222
 msgid "Parsing log file..."
-msgstr ""
+msgstr "正在解析日志文件…"
 
 #: Gtk/RestoreDeviceBox.vala:524
 msgid "Partition has an unsupported subvolume layout."
-msgstr ""
+msgstr "分区具有不支持的子卷布局。"
 
 #: Core/SnapshotRepo.vala:688 Gtk/RestoreDeviceBox.vala:93
 #, c-format
 msgid "Path"
-msgstr ""
+msgstr "路径"
 
 #: Gtk/ExcludeBox.vala:162
 msgid "Pattern"
-msgstr ""
+msgstr "模式"
 
 #: Gtk/RsyncLogBox.vala:396 Gtk/RestoreBox.vala:133 Gtk/BackupBox.vala:95
 #, c-format
 msgid "Permissions"
-msgstr ""
+msgstr "权限"
 
 #: Core/Main.vala:254
 msgid "Please check if you have multiple windows open."
-msgstr ""
+msgstr "请检查是否有打开了多个窗口。"
 
 #: Core/Main.vala:2244
 msgid "Please do not interrupt the restore process!"
-msgstr ""
+msgstr "请不要中断恢复过程！"
 
 #: Core/Main.vala:348
 msgid "Please install required packages and try running TimeShift again"
-msgstr ""
+msgstr "请安装所需的软件包，并尝试再次运行TimeShift"
 
 #: Gtk/AppGtk.vala:127
 msgid "Please re-run the application as admin (using 'sudo' or 'su')"
-msgstr ""
+msgstr "请以管理员身份重新运行此应用程序（使用sudo或su）"
 
 #: Console/AppConsole.vala:103
 msgid "Please run the application as admin (using 'sudo' or 'su')"
-msgstr ""
+msgstr "请以管理员身份运行此应用程序（使用sudo或su）"
 
 #: Core/Main.vala:2194
 msgid "Please save your work and close all applications."
-msgstr ""
+msgstr "请保存您的工作并关闭所有应用程序。"
 
 #: Gtk/MainWindow.vala:695
 msgid "Please select a snapshot to view the log!"
-msgstr ""
+msgstr "请选择一个快照以查看日志！"
 
 #: Gtk/RestoreDeviceBox.vala:512
 msgid "Please select the GRUB device"
-msgstr ""
+msgstr "请选择 GRUB 设备"
 
 #: Core/Main.vala:250
 msgid "Please wait a few minutes and try again."
-msgstr ""
+msgstr "请稍等几分钟，然后再试一次。"
 
 #: Gtk/MainWindow.vala:762
 msgid "Please wait for snapshots to be deleted."
-msgstr ""
+msgstr "请等待快照被删除。"
 
 #: Gtk/EstimateBox.vala:66
 msgid "Please wait..."
@@ -1620,74 +1632,76 @@ msgstr ""
 
 #: Gtk/RsyncLogBox.vala:188
 msgid "Populating list..."
-msgstr ""
+msgstr "正在填充列表..."
 
 #: Core/Main.vala:1579 Gtk/RsyncLogBox.vala:232 Gtk/DeleteBox.vala:68
 #: Gtk/RestoreBox.vala:88 Gtk/BackupBox.vala:114
 msgid "Preparing..."
-msgstr ""
+msgstr "正在准备..."
 
 #: Gtk/SetupWizardWindow.vala:189 Gtk/BackupWindow.vala:152
 #: Gtk/DeleteWindow.vala:154 Gtk/RestoreWindow.vala:190
 msgid "Previous"
-msgstr ""
+msgstr "上一个"
 
 #: Gtk/AppGtk.vala:116
 msgid "Print debug information"
-msgstr ""
+msgstr "输出调试信息"
 
 #: Core/Main.vala:3794
 msgid "Query completed"
-msgstr ""
+msgstr "查询已完成"
 
 #: Core/Main.vala:3777
 msgid "Querying subvolume info..."
-msgstr ""
+msgstr "正在查询子卷信息..."
 
 #: Gtk/SnapshotBackendBox.vala:77
 msgid "RSYNC"
-msgstr ""
+msgstr "RSYNC"
 
 #: Gtk/SnapshotBackendBox.vala:184
 msgid "RSYNC Snapshots"
-msgstr ""
+msgstr "RSYNC 快照"
 
 #: Gtk/BootOptionsBox.vala:137
 msgid ""
 "Re-generates initramfs for all installed kernels. This is generally not "
 "needed. Select this only if the restored system fails to boot."
 msgstr ""
+"为所有已安装的内核重新生成initramfs。这通常是不需要的。只有在恢复的系统无法启"
+"动时才选择此选项。"
 
 #: Console/AppConsole.vala:982
 #, c-format
 msgid "Re-install GRUB2 bootloader?"
-msgstr ""
+msgstr "是否重新安装 GRUB2 引导加载程序？"
 
 #: Core/Main.vala:2307
 msgid "Re-installing GRUB2 bootloader..."
-msgstr ""
+msgstr "正在重新安装 GRUB2 引导加载程序..."
 
 #: Gtk/BootOptionsBox.vala:120
 msgid "Re-installs the GRUB2 bootloader on the selected device."
-msgstr ""
+msgstr "在选择的设备上重新安装 GRUB2 引导加载程序。"
 
 #: Gtk/RsyncLogBox.vala:181
 #, c-format
 msgid "Read %'d of %'d lines..."
-msgstr ""
+msgstr "读取第 %'d 行，共 %'d 行..."
 
 #: Core/Main.vala:2400
 msgid "Rebooting system..."
-msgstr ""
+msgstr "正在重启系统..."
 
 #: Gtk/RestoreExcludeBox.vala:61 Gtk/RestoreExcludeBox.vala:91
 #, c-format
 msgid "Recommended"
-msgstr ""
+msgstr "推荐"
 
 #: Gtk/BackupDeviceBox.vala:65 Gtk/RestoreDeviceBox.vala:70
 msgid "Refresh"
-msgstr ""
+msgstr "刷新"
 
 #: Gtk/BackupDeviceBox.vala:106
 msgid "Remote and network locations are not supported."
@@ -1695,40 +1709,40 @@ msgstr ""
 
 #: Gtk/ExcludeBox.vala:253
 msgid "Remove"
-msgstr ""
+msgstr "移除"
 
 #: Core/SnapshotRepo.vala:975 Core/Main.vala:1617 Core/Main.vala:1628
 #: Core/Main.vala:4197 Core/Snapshot.vala:509
 #, c-format
 msgid "Removed"
-msgstr ""
+msgstr "已移除"
 
 #: Utility/CronTab.vala:341
 msgid "Removed cron task"
-msgstr ""
+msgstr "已移除 cron 任务"
 
 #: Core/Main.vala:3582
 #, c-format
 msgid "Removed mount directory: '%s'"
-msgstr ""
+msgstr "已移除挂载目录：'%s'"
 
 #: Core/Snapshot.vala:555
 msgid "Removed snapshot"
-msgstr ""
+msgstr "已移除快照"
 
 #: Core/Snapshot.vala:484
 msgid "Removing"
-msgstr ""
+msgstr "正在移除"
 
 #: Core/Snapshot.vala:521
 msgid "Removing snapshot"
-msgstr ""
+msgstr "正在移除快照"
 
 #: Core/SnapshotRepo.vala:831 Core/SnapshotRepo.vala:850
 #: Core/SnapshotRepo.vala:868 Core/SnapshotRepo.vala:882
 #, c-format
 msgid "Removing snapshots"
-msgstr ""
+msgstr "正在移除快照"
 
 #: Gtk/UsersBox.vala:360
 msgid ""
@@ -1740,7 +1754,7 @@ msgstr ""
 #: Gtk/RsyncLogBox.vala:377 Gtk/RsyncLogBox.vala:567 Gtk/MainWindow.vala:151
 #: Gtk/RestoreWindow.vala:125
 msgid "Restore"
-msgstr ""
+msgstr "恢复"
 
 #: Gtk/UsersBox.vala:329
 #, fuzzy
@@ -1749,39 +1763,39 @@ msgstr "删除子卷"
 
 #: Gtk/RestoreWindow.vala:89
 msgid "Restore Device"
-msgstr ""
+msgstr "恢复设备"
 
 #: Gtk/RestoreWindow.vala:94
 msgid "Restore Exclude"
-msgstr ""
+msgstr "恢复排除"
 
 #: Gtk/RestoreWindow.vala:69
 msgid "Restore Snapshot"
-msgstr ""
+msgstr "恢复快照"
 
 #: Core/Main.vala:2809 Core/Main.vala:2851
 msgid "Restore completed"
-msgstr ""
+msgstr "恢复完成"
 
 #: Gtk/MainWindow.vala:152
 msgid "Restore selected snapshot"
-msgstr ""
+msgstr "恢复选中的快照"
 
 #: Console/AppConsole.vala:363
 msgid "Restore snapshot"
-msgstr ""
+msgstr "恢复快照"
 
 #: Gtk/RestoreFinishBox.vala:96
 msgid "Restored subvolumes will become active after system is restarted."
-msgstr ""
+msgstr "恢复的子卷将在系统重新启动后变为活动状态。"
 
 #: Core/Subvolume.vala:206
 msgid "Restored system subvolume"
-msgstr ""
+msgstr "已恢复系统子卷"
 
 #: Gtk/RestoreBox.vala:77 Gtk/RestoreBox.vala:190
 msgid "Restoring Snapshot..."
-msgstr ""
+msgstr "正在恢复快照..."
 
 #: Gtk/FinishBox.vala:85
 msgid ""
@@ -1789,10 +1803,12 @@ msgid ""
 "currently in use will be preserved as a new snapshot. If required, this "
 "snapshot can be restored later to 'undo' the restore."
 msgstr ""
+"恢复快照时会替换系统子卷，而当前正在使用的系统子卷将作为新快照保留。如果需"
+"要，以后可以恢复此快照以“撤消”恢复。"
 
 #: Core/Main.vala:2778
 msgid "Restoring snapshot..."
-msgstr ""
+msgstr "正在恢复快照..."
 
 #: Gtk/FinishBox.vala:88
 msgid ""
@@ -1802,15 +1818,18 @@ msgid ""
 "files will be backed up when snapshot is created, and replaced when snapshot "
 "is restored."
 msgstr ""
+"恢复快照时只替换系统文件和设置。不会触及用户主目录中的非隐藏文件和目录。要想"
+"更改此行为，可以通过添加筛选器来包含这些文件。所包含的文件将在创建快照时备"
+"份，在恢复快照时将被替换。"
 
 #: Utility/Device.vala:1814
 #, c-format
 msgid "Revision"
-msgstr ""
+msgstr "修订版"
 
 #: Gtk/RestoreDeviceBox.vala:452
 msgid "Root device not selected"
-msgstr ""
+msgstr "未选择根设备"
 
 #: Gtk/RsyncLogWindow.vala:49
 msgid "Rsync Log Viewer"
@@ -1819,21 +1838,21 @@ msgstr ""
 #: Gtk/AppGtk.vala:119
 #, c-format
 msgid "Run 'timeshift' for the command-line version of this tool"
-msgstr ""
+msgstr "运行 \"timeshift\" 以启动此工具的命令行版本"
 
 #: Console/AppConsole.vala:382
 msgid "Run in non-interactive mode"
-msgstr ""
+msgstr "以非交互模式运行"
 
 #: Core/Main.vala:186
 msgid "Running"
-msgstr ""
+msgstr "正在运行"
 
 #: Gtk/FinishBox.vala:95
 msgid ""
 "Save snapshots to an external disk instead of the system disk to guard "
 "against drive failures."
-msgstr ""
+msgstr "为防止驱动器故障，请将快照保存到外部磁盘，而不是系统磁盘。"
 
 #: Gtk/FinishBox.vala:97
 msgid ""
@@ -1842,245 +1861,248 @@ msgid ""
 "even install another Linux distribution and later roll-back the previous "
 "distribution by restoring a snapshot."
 msgstr ""
+"请将快照保存到非系统磁盘，这样您可以格式化系统磁盘，或者在它上面重新安装操作"
+"系统，而不会丢失存储在系统磁盘上的快照。您甚至可以安装另一个 Linux 发行版，然"
+"后通过恢复快照来回滚以前的发行版。"
 
 #: Core/Main.vala:1285 Core/Main.vala:1439 Core/Main.vala:1441
 msgid "Saving to device"
-msgstr ""
+msgstr "正在保存到设备"
 
 #: Gtk/SetupWizardWindow.vala:109 Gtk/SettingsWindow.vala:92
 msgid "Schedule"
-msgstr ""
+msgstr "计划"
 
 #: Core/Main.vala:257
 msgid "Scheduled snapshot in progress..."
-msgstr ""
+msgstr "计划的快照正在进行中..."
 
 #: Core/Main.vala:1147 Gtk/MainWindow.vala:1067 Gtk/ScheduleBox.vala:312
 msgid "Scheduled snapshots are disabled"
-msgstr ""
+msgstr "已禁用计划的快照"
 
 #: Gtk/FinishBox.vala:78
 msgid "Scheduled snapshots are disabled. It's recommended to enable it."
-msgstr ""
+msgstr "已禁用计划的快照。建议启用它。"
 
 #: Gtk/ScheduleBox.vala:305
 msgid "Scheduled snapshots are enabled"
-msgstr ""
+msgstr "已启用计划的快照"
 
 #: Gtk/FinishBox.vala:75
 msgid ""
 "Scheduled snapshots are enabled. Snapshots will be created automatically for "
 "selected levels."
-msgstr ""
+msgstr "已启用计划的快照。将自动按选定的等级创建快照。"
 
 #: Console/AppConsole.vala:870
 #, c-format
 msgid "Select '%s' device (default = %s)"
-msgstr ""
+msgstr "选择 \"%s\" 设备（默认 = %s）"
 
 #: Console/AppConsole.vala:689 Core/SnapshotRepo.vala:593
 msgid "Select BTRFS system disk with root subvolume (@)"
-msgstr ""
+msgstr "选择具有根子卷（@）的BTRFS系统磁盘"
 
 #: Console/AppConsole.vala:998
 msgid "Select GRUB device"
-msgstr ""
+msgstr "选择 GRUB 设备"
 
 #: Utility/GtkHelper.vala:815
 msgid "Select Path"
-msgstr ""
+msgstr "选择路径"
 
 #: Gtk/MainWindow.vala:694
 msgid "Select Snapshot"
-msgstr ""
+msgstr "选择快照"
 
 #: Gtk/ScheduleBox.vala:57
 msgid "Select Snapshot Levels"
-msgstr ""
+msgstr "选择快照等级"
 
 #: Gtk/BackupDeviceBox.vala:56
 msgid "Select Snapshot Location"
-msgstr ""
+msgstr "选择快照位置"
 
 #: Gtk/SnapshotBackendBox.vala:62
 msgid "Select Snapshot Type"
-msgstr ""
+msgstr "选择快照类型"
 
 #: Gtk/DeleteWindow.vala:85
 msgid "Select Snapshots"
-msgstr ""
+msgstr "选择快照"
 
 #: Gtk/RestoreDeviceBox.vala:61
 msgid "Select Target Device"
-msgstr ""
+msgstr "选择目标设备"
 
 #: Gtk/BackupDeviceBox.vala:392
 #, c-format
 msgid "Select a partition on this disk"
-msgstr ""
+msgstr "在这个磁盘上选择一个分区"
 
 #: Gtk/MainWindow.vala:801
 msgid "Select a single snapshot to restore"
-msgstr ""
+msgstr "选择一个要还原的快照"
 
 #: Gtk/RestoreDeviceBox.vala:481
 msgid "Select another device for root file system (/)"
-msgstr ""
+msgstr "为根文件系统（/）选择另一个设备"
 
 #: Core/SnapshotRepo.vala:632 Core/SnapshotRepo.vala:659
 msgid "Select another device or free up some space"
-msgstr ""
+msgstr "请选择另一个设备或腾出一些空间"
 
 #: Gtk/MainWindow.vala:547 Gtk/MainWindow.vala:554
 msgid "Select another device to delete snasphots"
-msgstr ""
+msgstr "选择另一个要删除快照的设备"
 
 #: Gtk/MainWindow.vala:481
 msgid "Select another device?"
-msgstr ""
+msgstr "是否选择另一个设备？"
 
 #: Gtk/RestoreExcludeBox.vala:57
 msgid "Select applications to exclude from restore"
-msgstr ""
+msgstr "选择要从恢复中排除的应用程序"
 
 #: Console/AppConsole.vala:672
 msgid "Select backup device"
-msgstr ""
+msgstr "选择备份设备"
 
 #: Gtk/ExcludeBox.vala:433
 msgid "Select directory"
-msgstr ""
+msgstr "选择目录"
 
 #: Gtk/ExcludeBox.vala:406
 msgid "Select file(s)"
-msgstr ""
+msgstr "选择文件"
 
 #: Console/AppConsole.vala:746
 msgid "Select snapshot"
-msgstr ""
+msgstr "选择快照"
 
 #: Gtk/DeleteWindow.vala:342
 msgid "Select snapshots to delete"
-msgstr ""
+msgstr "选择要删除的快照"
 
 #: Gtk/RestoreDeviceBox.vala:453
 msgid "Select the device for root file system (/)"
-msgstr ""
+msgstr "为根文件系统（/）选择设备"
 
 #: Gtk/RestoreDeviceBox.vala:83
 msgid "Select the devices where files will be restored."
-msgstr ""
+msgstr "选择要恢复文件的设备"
 
 #: Gtk/ScheduleBox.vala:313
 msgid "Select the intervals for creating snapshots"
-msgstr ""
+msgstr "选择创建快照的时间间隔"
 
 #: Gtk/ExcludeBox.vala:273
 msgid "Select the items to be removed from the list"
-msgstr ""
+msgstr "选择要从列表中移除的项目"
 
 #: Core/SnapshotRepo.vala:553
 msgid "Select the snapshot device"
-msgstr ""
+msgstr "选择快照设备"
 
 #: Gtk/MainWindow.vala:794
 msgid "Select the snapshot to restore"
-msgstr ""
+msgstr "选择要恢复的快照"
 
 #: Gtk/DeleteWindow.vala:87
 msgid "Select the snapshots to be deleted"
-msgstr ""
+msgstr "选择要删除的快照"
 
 #: Gtk/MainWindow.vala:616
 msgid "Select the snapshots to mark for deletion"
-msgstr ""
+msgstr "选择要标记为删除的快照"
 
 #: Gtk/RestoreDeviceBox.vala:79
 msgid "Select the target devices where system will be cloned."
-msgstr ""
+msgstr "选择复制系统的目标设备"
 
 #: Core/Main.vala:3242
 msgid "Selected default snapshot device"
-msgstr ""
+msgstr "已选择默认的快照设备"
 
 #: Core/Main.vala:3193 Core/Main.vala:3197
 msgid "Selected default snapshot type"
-msgstr ""
+msgstr "已选择默认的快照类型"
 
 #: Gtk/BackupDeviceBox.vala:373
 msgid "Selected device does not have BTRFS partition"
-msgstr ""
+msgstr "选中的设备没有 BTRFS 分区"
 
 #: Gtk/BackupDeviceBox.vala:371
 msgid "Selected device does not have Linux partition"
-msgstr ""
+msgstr "选中的设备没有 Linux 分区"
 
 #: Core/SnapshotRepo.vala:146
 msgid "Selected snapshot device"
-msgstr ""
+msgstr "已选择快照设备"
 
 #: Console/AppConsole.vala:688 Core/SnapshotRepo.vala:592
 msgid "Selected snapshot device is not a system disk"
-msgstr ""
+msgstr "选中的快照设备不是系统磁盘"
 
 #: Core/Main.vala:2027
 msgid "Selected snapshot is marked for deletion"
-msgstr ""
+msgstr "选中的快照被标记为删除"
 
 #: Gtk/MainWindow.vala:825
 msgid "Selected snapshot is marked for deletion and cannot be restored"
-msgstr ""
+msgstr "选中的快照被标记为删除，无法恢复"
 
 #: Gtk/UsersBox.vala:238
 msgid ""
 "Selected user has an encrypted home directory. It's not possible to include "
 "only hidden files."
-msgstr ""
+msgstr "选中的用户的主目录已加密。不可能只包含隐藏文件。"
 
 #: Utility/Device.vala:1813
 #, c-format
 msgid "Serial"
-msgstr ""
+msgstr "序列号"
 
 #: Core/Main.vala:214
 msgid "Session log file"
-msgstr ""
+msgstr "会话日志文件"
 
 #: Console/AppConsole.vala:359
 msgid "Set snapshot description"
-msgstr ""
+msgstr "设置快照描述"
 
 #: Gtk/MainWindow.vala:181 Gtk/MainWindow.vala:182 Gtk/SettingsWindow.vala:55
 msgid "Settings"
-msgstr ""
+msgstr "设定"
 
 #: Gtk/MainWindow.vala:192
 msgid "Settings wizard"
-msgstr ""
+msgstr "设定向导"
 
 #: Gtk/FinishBox.vala:58
 msgid "Setup Complete"
-msgstr ""
+msgstr "设置完成"
 
 #: Gtk/SetupWizardWindow.vala:64
 msgid "Setup Wizard"
-msgstr ""
+msgstr "设置向导"
 
 #: Console/AppConsole.vala:379
 msgid "Show additional debug messages"
-msgstr ""
+msgstr "显示其他调试消息"
 
 #: Console/AppConsole.vala:383 Gtk/AppGtk.vala:117
 msgid "Show all options"
-msgstr ""
+msgstr "显示全部选项"
 
 #: Gtk/RestoreExcludeBox.vala:121
 msgid "Show more applications to exclude on the next page"
-msgstr ""
+msgstr "在下一页显示要排除的更多应用程序"
 
 #: Console/AppConsole.vala:380
 msgid "Show rsync output (default)"
-msgstr ""
+msgstr "显示 rsync 输出（默认）"
 
 #: Utility/Device.vala:1816 Utility/Device.vala:1831
 #: Console/AppConsole.vala:456 Console/AppConsole.vala:495
@@ -2089,7 +2111,7 @@ msgstr ""
 #: Gtk/SnapshotListBox.vala:174
 #, c-format
 msgid "Size"
-msgstr ""
+msgstr "大小"
 
 #: Gtk/SnapshotBackendBox.vala:177
 msgid ""
@@ -2098,27 +2120,29 @@ msgid ""
 "(copy-on-write). Files in the snapshot continue to point to original data "
 "blocks."
 msgstr ""
+"BTRFS 快照的初始大小为零。随着系统文件随时间逐渐变化，数据将被写入到占用磁盘"
+"空间的新数据块（复制写入）。快照中的文件继续指向原始数据块。"
 
 #: Console/AppConsole.vala:368
 msgid "Skip GRUB2 reinstall"
-msgstr ""
+msgstr "跳过 GRUB2 安装"
 
 #: Core/SnapshotRepo.vala:714 Core/SnapshotRepo.vala:752 Core/Main.vala:2032
 #: Gtk/SnapshotListBox.vala:95
 #, c-format
 msgid "Snapshot"
-msgstr ""
+msgstr "快照"
 
 #: Gtk/MainWindow.vala:564
 #, c-format
 msgid ""
 "Snapshot '%s' is being used by the system and cannot be deleted. Restart the "
 "system to activate the restored snapshot."
-msgstr ""
+msgstr "系统正在使用快照\"%s\"，无法删除。重新启动系统以激活已还原的快照。"
 
 #: Gtk/BackupFinishBox.vala:60
 msgid "Snapshot Created"
-msgstr ""
+msgstr "快照已创建"
 
 #: Gtk/SnapshotListBox.vala:296
 #, c-format
@@ -2127,62 +2151,64 @@ msgstr "BTRFS快照"
 
 #: Gtk/MainWindow.vala:761
 msgid "Snapshot deletion in progress..."
-msgstr ""
+msgstr "快照删除正在进行中..."
 
 #: Core/SnapshotRepo.vala:470
 #, c-format
 msgid "Snapshot device"
-msgstr ""
+msgstr "快照设备"
 
 #: Console/AppConsole.vala:662 Core/SnapshotRepo.vala:559
 msgid "Snapshot device not available"
-msgstr ""
+msgstr "快照设备不可用"
 
 #: Console/AppConsole.vala:658 Core/SnapshotRepo.vala:552
 msgid "Snapshot device not selected"
-msgstr ""
+msgstr "未选择快照设备"
 
 #: Core/SnapshotRepo.vala:474
 #, c-format
 msgid "Snapshot location"
-msgstr ""
+msgstr "快照位置"
 
 #: Core/Main.vala:1252
 msgid "Snapshot saved successfully"
-msgstr ""
+msgstr "成功保存快照"
 
 #: Core/Main.vala:2022
 msgid "Snapshot to restore not specified!"
-msgstr ""
+msgstr "未指定要恢复的快照！"
 
 #: Core/Main.vala:2855
 msgid "Snapshot will become active after system is rebooted."
-msgstr ""
+msgstr "快照将在系统重启后变为活动状态。"
 
 #: Gtk/DeleteFinishBox.vala:60
 msgid "Snapshot(s) Deleted"
-msgstr ""
+msgstr "已删除快照"
 
 #: Gtk/MainWindow.vala:310 Gtk/DeleteWindow.vala:89
 msgid "Snapshots"
-msgstr ""
+msgstr "快照"
 
 #: Gtk/SnapshotBackendBox.vala:169
 msgid ""
 "Snapshots are created and restored instantly. Snapshot creation is an atomic "
 "transaction at the file system level."
-msgstr ""
+msgstr "直接创建并储存快照。创建快照为文件系统层面上的原子事务。"
 
 #: Gtk/SnapshotBackendBox.vala:186
 msgid ""
 "Snapshots are created by creating copies of system files using rsync, and "
 "hard-linking unchanged files from previous snapshot."
 msgstr ""
+"快照是通过使用rsync创建系统文件的副本，以及从以前的快照中硬链接未更改的文件来"
+"创建的。"
 
 #: Gtk/SnapshotBackendBox.vala:167
 msgid ""
 "Snapshots are created using the built-in features of the BTRFS file system."
-msgstr ""
+msgstr "快照是使用 BTRFS 文件系统的内置特性创建的。"
 
 #: Gtk/ScheduleBox.vala:167
 #, c-format
@@ -2193,7 +2219,7 @@ msgstr ""
 msgid ""
 "Snapshots are perfect, byte-for-byte copies of the system. Nothing is "
 "excluded."
-msgstr ""
+msgstr "快照是系统的完美、字节对字节的副本。没有排除任何内容。"
 
 #: Gtk/SnapshotBackendBox.vala:171
 msgid ""
@@ -2201,6 +2227,8 @@ msgid ""
 "copied, deleted or overwritten, there is no risk of data loss. The existing "
 "system is preserved as a new snapshot after restore."
 msgstr ""
+"快照是通过替换系统子卷来恢复的。由于文件不被复制、删除或覆盖，所以不存在数据"
+"丢失的风险。在恢复后，现有系统将保存为新快照。"
 
 #: Gtk/SnapshotBackendBox.vala:175
 msgid ""
@@ -2208,6 +2236,8 @@ msgid ""
 "disk). Storage on other disks is not supported. If system disk fails then "
 "snapshots stored on it will be lost along with the system."
 msgstr ""
+"快照保存在创建快照的同一个磁盘上（系统磁盘）。不支持存储在其他磁盘上。如果系"
+"统磁盘出现故障，存储在系统上的快照将随系统一起丢失。"
 
 #: Gtk/BackupDeviceBox.vala:107
 msgid ""
@@ -2223,7 +2253,7 @@ msgstr ""
 
 #: Gtk/MainWindow.vala:1012
 msgid "Snapshots available for restore"
-msgstr ""
+msgstr "可用于还原的快照"
 
 #: Gtk/SnapshotBackendBox.vala:190
 msgid ""
@@ -2231,53 +2261,55 @@ msgid ""
 "Saving snapshots to non-system or external disk allows the system to be "
 "restored even if system disk is damaged or re-formatted."
 msgstr ""
+"快照可以保存到任一个格式化为Linux文件系统的磁盘。请将快照保存到非系统或外部磁"
+"盘，这样即使系统磁盘损坏或重新格式化，也可恢复系统。"
 
 #: Console/AppConsole.vala:283
 msgid "Snapshots cannot be created in Live CD mode"
-msgstr ""
+msgstr "无法在实时 CD 模式下创建快照"
 
 #: Gtk/MainWindow.vala:1059
 msgid "Snapshots will be created at selected intervals"
-msgstr ""
+msgstr "将以选定的时间间隔创建快照"
 
 #: Gtk/ScheduleBox.vala:306
 msgid ""
 "Snapshots will be created at selected intervals if snapshot disk has enough "
 "space (> 1 GB)"
-msgstr ""
+msgstr "如果快照磁盘具有足够的空间（>1GB），将以选定的时间间隔创建快照"
 
 #: Gtk/MainWindow.vala:642
 msgid "Snapshots will be removed during the next scheduled run"
-msgstr ""
+msgstr "快照将在下一次计划运行期间移除"
 
 #: Console/AppConsole.vala:375
 msgid "Specify backup device (default: config)"
-msgstr ""
+msgstr "指定备份设备（默认：config）"
 
 #: Console/AppConsole.vala:367
 msgid "Specify device for installing GRUB2 bootloader"
-msgstr ""
+msgstr "指定要安装 GRUB2 引导加载程序的设备"
 
 #: Console/AppConsole.vala:365
 msgid "Specify snapshot to restore"
-msgstr ""
+msgstr "指定要恢复的快照"
 
 #: Console/AppConsole.vala:366
 msgid "Specify target device"
-msgstr ""
+msgstr "指定目标设备"
 
 #: Core/SnapshotRepo.vala:480 Gtk/RsyncLogBox.vala:472
 #, c-format
 msgid "Status"
-msgstr ""
+msgstr "状态"
 
 #: Gtk/ScheduleBox.vala:154
 msgid "Stop cron emails for scheduled tasks"
-msgstr ""
+msgstr "停止计划任务的cron电子邮件"
 
 #: Utility/TeeJee.Process.vala:511
 msgid "Stopped"
-msgstr ""
+msgstr "已停止"
 
 #: Core/Subvolume.vala:189
 #, c-format
@@ -2292,23 +2324,23 @@ msgstr ""
 #: Gtk/ExcludeAppsBox.vala:135 Gtk/ExcludeBox.vala:258
 #: Gtk/RestoreWindow.vala:120
 msgid "Summary"
-msgstr ""
+msgstr "摘要"
 
 #: Console/AppConsole.vala:377
 msgid "Switch to BTRFS mode (default: config)"
-msgstr ""
+msgstr "切换到 BTRFS 模式（默认：config）"
 
 #: Console/AppConsole.vala:378
 msgid "Switch to RSYNC mode (default: config)"
-msgstr ""
+msgstr "切换到 RSYNC 模式（默认：config）"
 
 #: Core/SnapshotRepo.vala:1029
 msgid "Symlinks updated"
-msgstr ""
+msgstr "符号链接已更新"
 
 #: Core/Main.vala:2382
 msgid "Synching file systems..."
-msgstr ""
+msgstr "正在同步文件系统..."
 
 #: Core/Main.vala:1361 Core/Main.vala:2544 Core/Main.vala:2785
 msgid "Synching files with rsync..."
@@ -2316,12 +2348,12 @@ msgstr "正在使用rsync同步文件..."
 
 #: Gtk/AppGtk.vala:112
 msgid "Syntax"
-msgstr ""
+msgstr "语法"
 
 #: Utility/Device.vala:1837 Gtk/SnapshotListBox.vala:127
 #, c-format
 msgid "System"
-msgstr ""
+msgstr "系统"
 
 #: Gtk/MainWindow.vala:957
 msgid "System Restore Utility"
@@ -2345,7 +2377,7 @@ msgstr "带标签的快照"
 
 #: Console/AppConsole.vala:426 Gtk/SnapshotListBox.vala:151
 msgid "Tags"
-msgstr ""
+msgstr "标签"
 
 #: Core/Main.vala:2057
 msgid "Target device is not mounted"
@@ -2371,8 +2403,8 @@ msgid ""
 "current user. Select this option to suppress the emails for cron tasks "
 "created by Timeshift."
 msgstr ""
-"Cron服务将发送电子邮件（内容为，程序的计划任务）发送给当前用户。 选择此选项以"
-"禁止由Timeshift创建的cron任务的电子邮件服务。"
+"Cron 服务会将计划任务的输出作为电子邮件发送给当前用户。 选择此选项以取消由 "
+"Timeshift 创建的 cron 任务的电子邮件。"
 
 #: Core/Main.vala:376
 msgid "The system partition has an unsupported subvolume layout."
@@ -2411,7 +2443,7 @@ msgstr ""
 #: Gtk/RsyncLogBox.vala:394 Gtk/RestoreBox.vala:132 Gtk/BackupBox.vala:94
 #, c-format
 msgid "Timestamp"
-msgstr ""
+msgstr "时间戳"
 
 #: Console/AppConsole.vala:611
 #, c-format
@@ -2427,16 +2459,16 @@ msgstr ""
 #: Gtk/SettingsWindow.vala:86
 #, c-format
 msgid "Type"
-msgstr ""
+msgstr "类型"
 
 #: Utility/Device.vala:1826
 #, c-format
 msgid "UUID"
-msgstr ""
+msgstr "UUID"
 
 #: Gtk/AppGtk.vala:99
 msgid "Unknown option"
-msgstr ""
+msgstr "未知选项"
 
 #: Core/Main.vala:1203
 msgid "Unknown snapshot type"
@@ -2444,7 +2476,7 @@ msgstr "未知快照类型"
 
 #: Core/Main.vala:1566
 msgid "Unknown value specified for option --tags"
-msgstr "指定选项的值未知 -- 标签"
+msgstr "为 --tags 选项指定的值未知"
 
 #: Utility/Device.vala:1270 Utility/Device.vala:1386
 #, c-format
@@ -2465,7 +2497,7 @@ msgstr "不共享"
 
 #: Core/Main.vala:3435 Gtk/RestoreDeviceBox.vala:522
 msgid "Unsupported Subvolume Layout"
-msgstr ""
+msgstr "不支持的子卷布局"
 
 #: Gtk/BootOptionsBox.vala:150
 msgid "Update GRUB menu"
@@ -2500,11 +2532,11 @@ msgstr "更新引导加载程序配置..."
 #: Utility/Device.vala:1834
 #, c-format
 msgid "Used"
-msgstr ""
+msgstr "已使用"
 
 #: Gtk/SetupWizardWindow.vala:114 Gtk/UsersBox.vala:105
 msgid "User"
-msgstr ""
+msgstr "用户"
 
 #: Gtk/UsersBox.vala:63
 msgid "User Home Directories"
@@ -2517,11 +2549,11 @@ msgstr "用户已取消密码提示"
 #: Gtk/UsersBox.vala:67
 msgid ""
 "User home directories are excluded by default unless you enable them here"
-msgstr "用户默认不使用主目录，除非您手动设置到此"
+msgstr "默认情况下，除非您在这里开启，否则会排除用户主目录。"
 
 #: Gtk/SettingsWindow.vala:98
 msgid "Users"
-msgstr ""
+msgstr "用户"
 
 #: Gtk/RestoreWindow.vala:114
 msgid "Users Home"
@@ -2530,7 +2562,7 @@ msgstr ""
 #: Utility/Device.vala:1811
 #, c-format
 msgid "Vendor"
-msgstr ""
+msgstr "供应商"
 
 #: Gtk/SnapshotListBox.vala:343
 msgid "View Rsync Log for Create"
@@ -2546,36 +2578,36 @@ msgstr "查看TimeShift日志文件"
 
 #: Gtk/RestoreDeviceBox.vala:101
 msgid "Volume"
-msgstr ""
+msgstr "卷"
 
 #: Core/Main.vala:2106 Gtk/RestoreSummaryBox.vala:53
 msgid "Warning"
-msgstr ""
+msgstr "警告"
 
 #: Gtk/RestoreExcludeBox.vala:61
 msgid "Web Browsers"
-msgstr ""
+msgstr "网页浏览器"
 
 #: Utility/Gtk/DonationWindow.vala:113
 #, c-format
 msgid "Website"
-msgstr ""
+msgstr "网站"
 
 #: Gtk/ScheduleBox.vala:82 Gtk/SnapshotListBox.vala:301
 msgid "Weekly"
-msgstr ""
+msgstr "每周"
 
 #: Core/Main.vala:1107
 msgid "Weekly snapshot failed!"
-msgstr "每周快照任务失败！"
+msgstr "每周快照失败！"
 
 #: Core/Main.vala:1088
 msgid "Weekly snapshots are enabled"
-msgstr "每周快照任务已开启"
+msgstr "已启用每周快照"
 
 #: Utility/Gtk/DonationWindow.vala:105
 msgid "Wiki ~ Documentation & Help"
-msgstr ""
+msgstr "维基 - 文档和帮助"
 
 #: Gtk/BackupFinishBox.vala:63 Gtk/DeleteFinishBox.vala:63
 msgid "With Errors"
@@ -2583,11 +2615,11 @@ msgstr "有错误"
 
 #: Gtk/MainWindow.vala:191
 msgid "Wizard"
-msgstr ""
+msgstr "向导"
 
 #: Utility/Device.vala:1313 Utility/Device.vala:1359
 msgid "Wrong password"
-msgstr ""
+msgstr "密码错误"
 
 #: Utility/Gtk/CustomMessageDialog.vala:176
 msgid "Yes"
@@ -2633,7 +2665,7 @@ msgstr "btrfs返回一个错误"
 
 #: Core/Main.vala:1393 Core/Snapshot.vala:500
 msgid "complete"
-msgstr ""
+msgstr "完整"
 
 #: Utility/CronTab.vala:261
 msgid "crontab file exported"
@@ -2645,7 +2677,7 @@ msgstr "crontab文件已安装"
 
 #: Core/SnapshotRepo.vala:868
 msgid "incomplete"
-msgstr ""
+msgstr "不完整"
 
 #: Core/SnapshotRepo.vala:850
 msgid "marked for deletion"
@@ -2658,7 +2690,7 @@ msgstr "挂载到指定路径"
 #: Core/Main.vala:1393 Core/Snapshot.vala:501 Gtk/DeleteBox.vala:149
 #: Gtk/RestoreBox.vala:237 Gtk/BackupBox.vala:234
 msgid "remaining"
-msgstr ""
+msgstr "剩余"
 
 #: Core/Main.vala:1404
 msgid "rsync returned an error"
@@ -2668,32 +2700,6 @@ msgstr "rsync返回一个错误"
 #: Core/SnapshotRepo.vala:831
 msgid "un-tagged"
 msgstr "未标记"
-
-#, fuzzy
-#~ msgid "Click to edit and drag-drop to re-order"
-#~ msgstr "点击以修改。拖放以排序。"
-
-#~ msgid ""
-#~ "Click an item to edit the pattern.\n"
-#~ "Drag and drop items with mouse to re-order."
-#~ msgstr ""
-#~ "点击项目以修改模式。\n"
-#~ "用鼠标拖放项目以调整顺序。"
-
-#~ msgid "Editing and Re-Ordering"
-#~ msgstr "更改与重排"
-
-#~ msgid "Info"
-#~ msgstr "信息"
-
-#~ msgid "Deleted system subvolumes"
-#~ msgstr "删除系统子卷"
-
-#~ msgid "<b>System:</b> Installed Linux distribution"
-#~ msgstr "<b>系统：</b> 安装的 Linux 发行包"
-
-#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
-#~ msgstr "<b>快照日期：</b> 快照的创建日期"
 
 #~ msgid ""
 #~ "<b>Backup Levels</b>\n"
@@ -2710,9 +2716,22 @@ msgstr "未标记"
 #~ "O\t手动\n"
 #~ "B\t启动时\n"
 #~ "H\t每小时\n"
-#~ "D\t每天\n"
+#~ "D\t每日\n"
 #~ "W\t每周\n"
 #~ "M\t每月"
+
+#~ msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
+#~ msgstr "<b>快照日期：</b> 快照的创建日期"
+
+#~ msgid "<b>System:</b> Installed Linux distribution"
+#~ msgstr "<b>系统：</b> 安装的 Linux 发行包"
+
+#~ msgid ""
+#~ "Click an item to edit the pattern.\n"
+#~ "Drag and drop items with mouse to re-order."
+#~ msgstr ""
+#~ "点击项目以修改模式。\n"
+#~ "用鼠标拖放项目以调整顺序。"
 
 #~ msgid "Cloning System..."
 #~ msgstr "正在复制系统……"
@@ -2723,8 +2742,57 @@ msgstr "未标记"
 #~ msgid "Contributions"
 #~ msgstr "贡献"
 
+#~ msgid "Create snapshots using RSYNC"
+#~ msgstr "用 RSYNC 创建快照"
+
+#~ msgid "Deleted system subvolumes"
+#~ msgstr "删除系统子卷"
+
 #~ msgid "Documenters"
 #~ msgstr "文档编写者"
+
+#~ msgid "Editing and Re-Ordering"
+#~ msgstr "更改与重排"
+
+#~ msgid "Include everything"
+#~ msgstr "包含一切"
+
+#~ msgid "Include hidden items"
+#~ msgstr "包含隐藏的项目"
+
+#~ msgid "Info"
+#~ msgstr "信息"
+
+#~ msgid "Log Viewer"
+#~ msgstr "日志查看器"
+
+#~ msgid "Refresh Snapshot List"
+#~ msgstr "刷新快照列表"
+
+#~ msgid "Scheduled task runs once every hour"
+#~ msgstr "计划的任务每小时运行一次"
+
+#~ msgid "Selected snapshot path"
+#~ msgstr "已选择快照路径"
+
+#~ msgid "Third Party Tools"
+#~ msgstr "第三方工具"
+
+#~ msgid "Translators"
+#~ msgstr "翻译者"
+
+#~ msgid "View Log for Create"
+#~ msgstr "查看创建日志"
+
+#~ msgid "View Log for Restore"
+#~ msgstr "查看恢复日志"
+
+#~ msgid "View:"
+#~ msgstr "查看:"
+
+#, fuzzy
+#~ msgid "Click to edit and drag-drop to re-order"
+#~ msgstr "点击以修改。拖放以排序。"
 
 #~ msgid "Change"
 #~ msgstr "已更改"

--- a/po/timeshift-zh_TW.po
+++ b/po/timeshift-zh_TW.po
@@ -1,128 +1,115 @@
-# Chinese (Traditional) translation for linuxmint
-# Copyright (c) 2017 Rosetta Contributors and Canonical Ltd 2017
-# This file is distributed under the same license as the linuxmint package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
-"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
-"POT-Creation-Date: 2017-10-01 15:06+0530\n"
-"PO-Revision-Date: 2017-11-09 10:29+0000\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Report-Msgid-Bugs-To: teejeetech@gmail.com\n"
+"POT-Creation-Date: 2018-06-24 17:55+0530\n"
+"PO-Revision-Date: 2018-02-26 16:16+0000\n"
+"Last-Translator: Cheng-Chia Tseng <pswo10680@gmail.com>\n"
 "Language-Team: Chinese (Traditional) <zh_TW@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2017-11-23 10:47+0000\n"
-"X-Generator: Launchpad (build 18509)\n"
+"X-Launchpad-Export-Date: 2018-06-29 08:01+0000\n"
+"X-Generator: Launchpad (build 18704)\n"
 
-#: Console/AppConsole.vala:611
+#: Console/AppConsole.vala:613
 #, c-format
 msgid ""
 "\n"
 "Press ENTER to continue..."
 msgstr ""
+"\n"
+"請按 ENTER 繼續..."
 
-#: Core/SnapshotRepo.vala:597
+#: Core/SnapshotRepo.vala:641
 #, c-format
 msgid "%d snapshots, %s free"
 msgstr ""
 
-#: Console/AppConsole.vala:912
+#: Console/AppConsole.vala:914
 #, c-format
 msgid "'%s' will be on '%s'"
 msgstr ""
 
-#: Console/AppConsole.vala:909
+#: Console/AppConsole.vala:911
 #, c-format
 msgid "'%s' will be on root device"
 msgstr ""
 
-#: Gtk/BootOptionsBox.vala:119
+#: Gtk/BootOptionsBox.vala:118
 msgid "(Re)install GRUB2 on:"
-msgstr ""
+msgstr "(重新) 在此安裝 GRUB2："
 
-#: Core/Main.vala:353
+#: Core/Main.vala:362
 msgid "** Uninstalled Timeshift BTRFS **"
 msgstr ""
 
-#: Core/Main.vala:3203
+#: Core/Main.vala:3342
 msgid "/ is mapped to device"
 msgstr ""
 
-#: Core/Main.vala:3225
+#: Core/Main.vala:3364
 msgid "/boot is mapped to device"
 msgstr ""
 
-#: Core/Main.vala:3236
+#: Core/Main.vala:3375
 msgid "/boot/efi is mapped to device"
 msgstr ""
 
-#: Core/Main.vala:3214
+#: Core/Main.vala:3353
 msgid "/home is mapped to device"
 msgstr ""
 
-#: Gtk/SnapshotListBox.vala:274
-msgid ""
-"<b>Backup Levels</b>\n"
-"\n"
-"O\tOn demand (manual)\n"
-"B\tBoot\n"
-"H\tHourly\n"
-"D\tDaily\n"
-"W\tWeekly\n"
-"M\tMonthly"
-msgstr ""
-
-#: Gtk/SnapshotListBox.vala:266
+#: Gtk/SnapshotListBox.vala:290
 msgid "<b>Comments</b> (double-click to edit)"
 msgstr ""
 
-#: Gtk/SnapshotListBox.vala:262
-msgid "<b>Snapshot Date:</b> Date on which snapshot was created"
+#: Gtk/ScheduleBox.vala:168
+msgid ""
+"A maintenance task runs once every hour and creates snapshots as needed."
 msgstr ""
 
-#: Gtk/SnapshotListBox.vala:270
-msgid "<b>System:</b> Installed Linux distribution"
-msgstr ""
-
-#: Console/AppConsole.vala:696 Console/AppConsole.vala:760
-#: Console/AppConsole.vala:892 Console/AppConsole.vala:987
-#: Console/AppConsole.vala:1032 Console/AppConsole.vala:1073
-#: Console/AppConsole.vala:1090
+#: Console/AppConsole.vala:698 Console/AppConsole.vala:762
+#: Console/AppConsole.vala:894 Console/AppConsole.vala:989
+#: Console/AppConsole.vala:1034 Console/AppConsole.vala:1075
+#: Console/AppConsole.vala:1093
 msgid "Aborted."
 msgstr ""
 
-#: Gtk/MainWindow.vala:384
+#: Gtk/MainWindow.vala:393
 msgid "About"
 msgstr ""
 
-#: Gtk/ExcludeBox.vala:223
+#: Gtk/RsyncLogBox.vala:472
+msgid "Action"
+msgstr ""
+
+#: Gtk/ExcludeBox.vala:219
 msgid "Add"
 msgstr ""
 
-#: Gtk/ExcludeBox.vala:237
+#: Gtk/ExcludeBox.vala:233
 msgid "Add Files"
 msgstr ""
 
-#: Gtk/ExcludeBox.vala:243
+#: Gtk/ExcludeBox.vala:239
 msgid "Add Folders"
 msgstr ""
 
-#: Gtk/ExcludeBox.vala:223
+#: Gtk/ExcludeBox.vala:219
 msgid "Add custom pattern"
 msgstr ""
 
-#: Gtk/ExcludeBox.vala:243
+#: Gtk/ExcludeBox.vala:239
 msgid "Add directories"
 msgstr ""
 
-#: Gtk/ExcludeBox.vala:237
+#: Gtk/ExcludeBox.vala:233
 msgid "Add files"
 msgstr ""
 
-#: Console/AppConsole.vala:358
+#: Console/AppConsole.vala:360
 msgid "Add tags to snapshot (default: O)"
 msgstr ""
 
@@ -130,26 +117,30 @@ msgstr ""
 msgid "Added cron task"
 msgstr ""
 
-#: Gtk/AppGtk.vala:129
+#: Gtk/AppGtk.vala:131
 msgid "Admin Access Required"
 msgstr ""
 
-#: Gtk/AppGtk.vala:124
+#: Gtk/AppGtk.vala:126
 msgid "Admin access is required to backup and restore system files."
 msgstr ""
 
-#: Gtk/SnapshotBackendBox.vala:182
+#: Gtk/RsyncLogBox.vala:363
+msgid "All Files"
+msgstr ""
+
+#: Gtk/SnapshotBackendBox.vala:188
 msgid ""
 "All files are copied when first snapshot is created. Subsequent snapshots "
 "are incremental. Unchanged files will be hard-linked from the previous "
 "snapshot if available."
 msgstr ""
 
-#: Gtk/ExcludeMessageWindow.vala:137
+#: Gtk/ExcludeMessageWindow.vala:130
 msgid "All other files and folders are excluded."
 msgstr ""
 
-#: Gtk/RestoreDeviceBox.vala:497
+#: Gtk/RestoreDeviceBox.vala:500
 msgid ""
 "An encrypted device is selected for root file system (/). The boot directory "
 "(/boot) must be mounted on a non-encrypted device for the system to boot "
@@ -159,73 +150,77 @@ msgid ""
 "encrypted device for root filesystem."
 msgstr ""
 
-#: Core/Main.vala:243
+#: Core/Main.vala:249
 msgid "Another instance of Timeshift is creating a snapshot."
 msgstr ""
 
-#: Utility/AppLock.vala:50
+#: Utility/AppLock.vala:49
 msgid "Another instance of this application is running"
 msgstr ""
 
-#: Core/Main.vala:247
+#: Core/Main.vala:253
 msgid "Another instance of timeshift is currently running!"
 msgstr ""
 
-#: Console/AppConsole.vala:374
+#: Console/AppConsole.vala:376
 msgid "Answer YES to all confirmation prompts"
 msgstr ""
 
-#: Core/Main.vala:3042
+#: Core/Main.vala:3179
 msgid "App config loaded"
 msgstr ""
 
-#: Core/Main.vala:2948
+#: Core/Main.vala:3076
 msgid "App config saved"
 msgstr ""
 
-#: Console/AppConsole.vala:100
+#: Console/AppConsole.vala:102
 msgid "Application needs admin access."
 msgstr ""
 
-#: Core/Main.vala:3380
+#: Core/Main.vala:3519
 msgid "Application will exit"
 msgstr ""
 
-#: Core/Main.vala:369
+#: Core/Main.vala:378
 msgid "Application will exit."
 msgstr ""
 
-#: Utility/Gtk/AboutWindow.vala:344
-#, c-format
+#: Utility/Gtk/AboutWindow.vala:433
 msgid "Artists"
 msgstr ""
 
-#: Utility/Gtk/AboutWindow.vala:320
-#, c-format
+#: Utility/Gtk/AboutWindow.vala:417
 msgid "Authors"
 msgstr ""
 
-#: Gtk/MainWindow.vala:332
+#: Gtk/MainWindow.vala:346
 msgid "Available"
 msgstr ""
 
-#: Gtk/SnapshotBackendBox.vala:95
+#: Gtk/SnapshotBackendBox.vala:94
 msgid "BTRFS"
 msgstr ""
 
-#: Gtk/SnapshotBackendBox.vala:159
+#: Gtk/SnapshotBackendBox.vala:165
 msgid "BTRFS Snapshots"
 msgstr ""
 
-#: Gtk/SnapshotBackendBox.vala:118
+#: Gtk/SnapshotBackendBox.vala:119
 msgid "BTRFS Tools Not Found"
 msgstr ""
 
-#: Core/Main.vala:1915 Core/Main.vala:1919
+#: Core/Main.vala:2041 Core/Main.vala:2045
 msgid "BTRFS device is not mounted"
 msgstr ""
 
-#: Gtk/FinishBox.vala:91
+#: Gtk/BackupDeviceBox.vala:98
+msgid ""
+"BTRFS snapshots are saved on system partition. Other partitions are not "
+"supported."
+msgstr ""
+
+#: Gtk/FinishBox.vala:92
 msgid ""
 "BTRFS snapshots are saved on the same disk from which it is created. If the "
 "system disk fails, snapshots will be lost along with the system. Save "
@@ -233,85 +228,91 @@ msgid ""
 "failures."
 msgstr ""
 
-#: Utility/Gtk/AboutWindow.vala:294
+#: Utility/Gtk/AboutWindow.vala:349 Utility/Gtk/AboutWindow.vala:381
 msgid "Back"
 msgstr ""
 
-#: Gtk/SetupWizardWindow.vala:89
+#: Gtk/SetupWizardWindow.vala:94
 msgid "Backend"
 msgstr ""
 
-#: Console/AppConsole.vala:354 Gtk/BackupWindow.vala:89
+#: Console/AppConsole.vala:356 Gtk/BackupWindow.vala:91
 msgid "Backup"
 msgstr ""
 
-#: Core/Main.vala:1891
+#: Core/Main.vala:2017
 msgid "Backup Device"
 msgstr ""
 
-#: Core/Main.vala:1886
+#: Core/Main.vala:2012
 msgid "Backup device not specified!"
 msgstr ""
 
-#: Utility/Gtk/DonationWindow.vala:85
+#: Utility/Gtk/DonationWindow.vala:89
 msgid "Become a Patron"
 msgstr ""
 
-#: Gtk/RestoreExcludeBox.vala:116
+#: Gtk/RestoreExcludeBox.vala:91
 msgid "Bittorrent Clients"
 msgstr ""
 
-#: Gtk/ScheduleBox.vala:133
+#: Gtk/ScheduleBox.vala:136 Gtk/SnapshotListBox.vala:298
 msgid "Boot"
 msgstr ""
 
-#: Gtk/RestoreDeviceBox.vala:496
+#: Gtk/RestoreDeviceBox.vala:499
 msgid "Boot device not selected"
 msgstr ""
 
-#: Core/Main.vala:925
+#: Core/Main.vala:1017
 msgid "Boot snapshot failed!"
 msgstr ""
 
-#: Core/Main.vala:906
+#: Gtk/ScheduleBox.vala:169
+msgid ""
+"Boot snapshots are created with a delay of 10 minutes after system startup."
+msgstr ""
+
+#: Core/Main.vala:998
 msgid "Boot snapshots are enabled"
 msgstr ""
 
-#: Gtk/BootOptionsWindow.vala:48
+#: Gtk/BootOptionsWindow.vala:49
 msgid "Bootloader Options"
 msgstr ""
 
-#: Gtk/RestoreDeviceBox.vala:409
+#: Gtk/RestoreDeviceBox.vala:411
 msgid "Bootloader Options (Advanced)"
 msgstr ""
 
-#: Gtk/MainWindow.vala:168
+#: Gtk/MainWindow.vala:171
 msgid "Browse"
 msgstr ""
 
-#: Gtk/SnapshotListBox.vala:306
+#: Gtk/SnapshotListBox.vala:336
 msgid "Browse Files"
 msgstr ""
 
-#: Gtk/MainWindow.vala:169
+#: Gtk/MainWindow.vala:172
 msgid "Browse selected snapshot"
 msgstr ""
 
-#: Core/Main.vala:2353
+#: Core/Main.vala:2499
 msgid "Building file list..."
 msgstr ""
 
-#: Utility/Gtk/CustomMessageDialog.vala:173 Utility/GtkHelper.vala:122
-#: Gtk/DeleteWindow.vala:184 Gtk/SetupWizardWindow.vala:202
-#: Gtk/RestoreWindow.vala:185 Gtk/BackupWindow.vala:173
+#: Utility/GtkHelper.vala:122 Utility/Gtk/CustomMessageDialog.vala:172
+#: Gtk/SetupWizardWindow.vala:214 Gtk/BackupWindow.vala:177
+#: Gtk/DeleteWindow.vala:187 Gtk/RestoreWindow.vala:206
+#: Gtk/RestoreWindow.vala:215
 msgid "Cancel"
 msgstr ""
 
-#: Gtk/RestoreWindow.vala:189
+#: Gtk/RestoreWindow.vala:221
 msgid "Cancel restore?"
 msgstr ""
 
-#: Gtk/RestoreWindow.vala:191
+#: Gtk/RestoreWindow.vala:223
 msgid ""
 "Cancelling the restore process will leave the target system in an "
 "inconsistent state. The system may fail to boot or you may run into various "
@@ -319,77 +320,77 @@ msgid ""
 "system to a consistent state. Click Yes to confirm."
 msgstr ""
 
-#: Gtk/MainWindow.vala:554
+#: Gtk/MainWindow.vala:563
 msgid "Cannot Delete Live Snapshot"
 msgstr ""
 
-#: Gtk/BackupBox.vala:87 Gtk/RestoreBox.vala:124
+#: Gtk/RsyncLogBox.vala:380 Gtk/RsyncLogBox.vala:383 Gtk/RsyncLogBox.vala:567
+#: Gtk/RsyncLogBox.vala:588 Gtk/RestoreBox.vala:125 Gtk/BackupBox.vala:87
 msgid "Changed"
 msgstr ""
 
-#: Gtk/BackupBox.vala:89 Gtk/RestoreBox.vala:126
+#: Gtk/RestoreBox.vala:127 Gtk/BackupBox.vala:89
 msgid "Changed items:"
 msgstr ""
 
-#: Core/Main.vala:2574
+#: Gtk/RestoreWindow.vala:104
+msgid "Checking Restore Actions (Dry Run)"
+msgstr ""
+
+#: Core/Main.vala:2732
 msgid "Checking file systems for errors..."
 msgstr ""
 
-#: Gtk/BackupBox.vala:92 Gtk/RestoreBox.vala:129
+#: Gtk/RsyncLogBox.vala:390 Gtk/RestoreBox.vala:130 Gtk/BackupBox.vala:92
+#, c-format
 msgid "Checksum"
 msgstr ""
 
-#: Core/Main.vala:2242
+#: Core/Main.vala:2388
 msgid "Cleaning up..."
 msgstr ""
 
-#: Gtk/ExcludeBox.vala:265
-msgid ""
-"Click an item to edit the pattern.\n"
-"Drag and drop items with mouse to re-order."
-msgstr ""
-
-#: Gtk/ExcludeBox.vala:80 Gtk/UsersBox.vala:85
+#: Gtk/UsersBox.vala:92 Gtk/ExcludeBox.vala:84
 msgid "Click to edit. Drag and drop to re-order."
 msgstr ""
 
-#: Gtk/RestoreWindow.vala:63
+#: Gtk/ExcludeBox.vala:59
+msgid "Click to edit. Drag-drop to re-order."
+msgstr ""
+
+#: Gtk/RestoreWindow.vala:69
 msgid "Clone System"
 msgstr ""
 
-#: Console/AppConsole.vala:362
+#: Console/AppConsole.vala:364
 msgid "Clone current system"
 msgstr ""
 
-#: Gtk/RestoreFinishBox.vala:61
+#: Gtk/RestoreFinishBox.vala:68
 msgid "Cloning"
 msgstr ""
 
-#: Gtk/RestoreBox.vala:73
-msgid "Cloning System..."
-msgstr ""
-
-#: Core/Main.vala:2619
+#: Core/Main.vala:2782
 msgid "Cloning system..."
 msgstr ""
 
-#: Utility/Gtk/AboutWindow.vala:302 Gtk/BootOptionsWindow.vala:105
-#: Gtk/DeleteWindow.vala:167 Gtk/SettingsWindow.vala:85
-#: Gtk/RestoreWindow.vala:176 Gtk/RsyncLogWindow.vala:247
-#: Gtk/BackupWindow.vala:164
+#: Utility/Gtk/AboutWindow.vala:326 Utility/Gtk/DonationWindow.vala:121
+#: Gtk/RsyncLogBox.vala:266 Gtk/BackupWindow.vala:168
+#: Gtk/BootOptionsWindow.vala:106 Gtk/DeleteWindow.vala:170
+#: Gtk/RestoreWindow.vala:508
 msgid "Close"
 msgstr ""
 
-#: Utility/Gtk/DonationWindow.vala:117
-msgid "Close Window"
-msgstr ""
-
-#: Gtk/FinishBox.vala:100 Gtk/DeleteFinishBox.vala:71
-#: Gtk/BackupFinishBox.vala:70 Gtk/RestoreFinishBox.vala:90
+#: Gtk/RestoreFinishBox.vala:106 Gtk/BackupFinishBox.vala:70
+#: Gtk/FinishBox.vala:101 Gtk/DeleteFinishBox.vala:71
 msgid "Close window to exit"
 msgstr ""
 
-#: Core/Main.vala:339
+#: Utility/Gtk/AboutWindow.vala:425
+msgid "Code Contributions"
+msgstr ""
+
+#: Core/Main.vala:347
 msgid "Commands listed below are not available on this system"
 msgstr ""
 
@@ -397,47 +398,55 @@ msgstr ""
 msgid "Comments"
 msgstr ""
 
-#: Gtk/DeleteFinishBox.vala:50 Gtk/BackupFinishBox.vala:50
-#: Gtk/RestoreFinishBox.vala:50 Gtk/RestoreFinishBox.vala:68
+#: Core/Main.vala:2775 Gtk/RestoreBox.vala:74 Gtk/RestoreBox.vala:187
+msgid "Comparing Files (Dry Run)..."
+msgstr ""
+
+#: Core/Main.vala:2541
+msgid "Comparing files with rsync..."
+msgstr ""
+
+#: Gtk/RestoreFinishBox.vala:50 Gtk/RestoreFinishBox.vala:75
+#: Gtk/BackupFinishBox.vala:50 Gtk/DeleteFinishBox.vala:50
 msgid "Completed"
 msgstr ""
 
-#: Gtk/RestoreFinishBox.vala:71
+#: Gtk/RestoreFinishBox.vala:78
 msgid "Completed With Errors"
 msgstr ""
 
-#: Console/AppConsole.vala:1066
+#: Gtk/RsyncLogBox.vala:87 Gtk/RestoreWindow.vala:109
+msgid "Confirm Actions"
+msgstr ""
+
+#: Console/AppConsole.vala:1068
 #, c-format
 msgid "Continue with restore? (y/n): "
 msgstr ""
 
-#: Utility/Gtk/AboutWindow.vala:328
-#, c-format
-msgid "Contributions"
-msgstr ""
-
-#: Console/AppConsole.vala:832 Console/AppConsole.vala:963
+#: Console/AppConsole.vala:834 Console/AppConsole.vala:965
 msgid "Could not find device"
 msgstr ""
 
-#: Utility/Device.vala:1119
+#: Utility/Device.vala:1187
 #, c-format
 msgid "Could not find file"
 msgstr ""
 
-#: Console/AppConsole.vala:729
+#: Console/AppConsole.vala:731
 msgid "Could not find snapshot"
 msgstr ""
 
-#: Core/Main.vala:2820
+#: Core/Main.vala:2946
 msgid "Could not find system subvolume"
 msgstr ""
 
-#: Core/Main.vala:2848
+#: Core/Main.vala:2974
 msgid "Could not find system subvolumes for creating pre-restore snapshot"
 msgstr ""
 
-#: Gtk/MainWindow.vala:138
+#: Gtk/RsyncLogBox.vala:366 Gtk/RsyncLogBox.vala:571 Gtk/MainWindow.vala:141
+#, c-format
 msgid "Create"
 msgstr ""
 
@@ -445,69 +454,71 @@ msgstr ""
 msgid "Create Snapshot"
 msgstr ""
 
-#: Gtk/ScheduleBox.vala:133
+#: Gtk/ScheduleBox.vala:136
 msgid "Create one per boot"
 msgstr ""
 
-#: Gtk/ScheduleBox.vala:97
+#: Gtk/ScheduleBox.vala:100
 msgid "Create one per day"
 msgstr ""
 
-#: Gtk/ScheduleBox.vala:115
+#: Gtk/ScheduleBox.vala:118
 msgid "Create one per hour"
 msgstr ""
 
-#: Gtk/ScheduleBox.vala:61
+#: Gtk/ScheduleBox.vala:64
 msgid "Create one per month"
 msgstr ""
 
-#: Gtk/ScheduleBox.vala:79
+#: Gtk/ScheduleBox.vala:82
 msgid "Create one per week"
 msgstr ""
 
-#: Console/AppConsole.vala:356
+#: Console/AppConsole.vala:358
 msgid "Create snapshot (even if not scheduled)"
 msgstr ""
 
-#: Console/AppConsole.vala:355
+#: Console/AppConsole.vala:357
 msgid "Create snapshot if scheduled"
 msgstr ""
 
-#: Gtk/MainWindow.vala:139
+#: Gtk/MainWindow.vala:142
 msgid "Create snapshot of current system"
 msgstr ""
 
-#: Gtk/MainWindow.vala:1044
+#: Gtk/MainWindow.vala:1074
 msgid ""
 "Create snapshots manually or enable scheduled snapshots to protect your "
 "system"
 msgstr ""
 
-#: Gtk/SnapshotBackendBox.vala:96
-msgid "Create snapshots using RSYNC"
+#: Gtk/SnapshotBackendBox.vala:95
+msgid "Create snapshots using BTRFS"
 msgstr ""
 
-#: Gtk/SnapshotBackendBox.vala:79
+#: Gtk/SnapshotBackendBox.vala:78
 msgid "Create snapshots using RSYNC tool and hard-links"
 msgstr ""
 
-#: Gtk/BackupBox.vala:85 Gtk/RestoreBox.vala:122
+#: Gtk/RsyncLogBox.vala:366 Gtk/RsyncLogBox.vala:571 Gtk/RsyncLogBox.vala:592
+#: Gtk/RestoreBox.vala:123 Gtk/BackupBox.vala:85
+#, c-format
 msgid "Created"
 msgstr ""
 
-#: Core/Snapshot.vala:360
+#: Core/Snapshot.vala:430
 msgid "Created control file"
 msgstr ""
 
-#: Utility/TeeJee.FileSystem.vala:325
+#: Utility/TeeJee.FileSystem.vala:351
 msgid "Created directory"
 msgstr ""
 
-#: Core/Main.vala:2870
+#: Core/Main.vala:2996
 msgid "Created pre-restore snapshot"
 msgstr ""
 
-#: Core/Main.vala:1389
+#: Core/Main.vala:1499
 msgid "Created subvolume snapshot"
 msgstr ""
 
@@ -515,23 +526,23 @@ msgstr ""
 msgid "Creating Snapshot..."
 msgstr ""
 
-#: Core/Main.vala:1343
+#: Core/Main.vala:1437
 msgid "Creating new backup..."
 msgstr ""
 
-#: Core/Main.vala:1191
+#: Core/Main.vala:1283
 msgid "Creating new snapshot..."
 msgstr ""
 
-#: Core/Main.vala:2798
+#: Core/Main.vala:2924
 msgid "Creating pre-restore snapshot from system subvolumes..."
 msgstr ""
 
-#: Utility/Gtk/AboutWindow.vala:282 Utility/Gtk/AboutWindow.vala:297
+#: Utility/Gtk/AboutWindow.vala:321 Utility/Gtk/AboutWindow.vala:387
 msgid "Credits"
 msgstr ""
 
-#: Core/Main.vala:3379
+#: Core/Main.vala:3518
 msgid "Critical Error"
 msgstr ""
 
@@ -547,24 +558,26 @@ msgstr ""
 msgid "Cron task exists"
 msgstr ""
 
-#: Gtk/ScheduleBox.vala:97
+#: Gtk/ScheduleBox.vala:100 Gtk/SnapshotListBox.vala:300
 msgid "Daily"
 msgstr ""
 
-#: Core/Main.vala:985
+#: Core/Main.vala:1077
 msgid "Daily snapshot failed!"
 msgstr ""
 
-#: Core/Main.vala:966
+#: Core/Main.vala:1058
 msgid "Daily snapshots are enabled"
 msgstr ""
 
-#: Core/Main.vala:1983
+#: Core/Main.vala:2111
 msgid "Data will be modified on following devices:"
 msgstr ""
 
-#: Console/AppConsole.vala:368 Gtk/DeleteWindow.vala:96 Gtk/MainWindow.vala:158
-#: Gtk/SnapshotListBox.vala:292
+#: Console/AppConsole.vala:370 Gtk/RsyncLogBox.vala:370
+#: Gtk/RsyncLogBox.vala:575 Gtk/MainWindow.vala:161
+#: Gtk/SnapshotListBox.vala:322 Gtk/DeleteWindow.vala:98
+#, c-format
 msgid "Delete"
 msgstr ""
 
@@ -572,88 +585,104 @@ msgstr ""
 msgid "Delete Snapshots"
 msgstr ""
 
-#: Console/AppConsole.vala:370
+#: Console/AppConsole.vala:372
 msgid "Delete all snapshots"
 msgstr ""
 
-#: Gtk/MainWindow.vala:159
+#: Gtk/MainWindow.vala:162
 msgid "Delete selected snapshot"
 msgstr ""
 
-#: Console/AppConsole.vala:369
+#: Console/AppConsole.vala:371
 msgid "Delete snapshot"
 msgstr ""
 
-#: Gtk/BackupBox.vala:86 Gtk/RestoreBox.vala:123
+#: Gtk/RsyncLogBox.vala:370 Gtk/RsyncLogBox.vala:575 Gtk/RsyncLogBox.vala:596
+#: Gtk/RestoreBox.vala:124 Gtk/BackupBox.vala:86
+#, c-format
 msgid "Deleted"
 msgstr ""
 
-#: Utility/TeeJee.FileSystem.vala:355
+#: Utility/TeeJee.FileSystem.vala:381
 msgid "Deleted directory"
 msgstr ""
 
-#: Core/Subvolume.vala:102
+#: Core/Subvolume.vala:154 Core/Main.vala:2903 Core/Main.vala:2907
+#, c-format
 msgid "Deleted subvolume"
 msgstr ""
 
-#: Core/Main.vala:2778 Core/Main.vala:2781
-msgid "Deleted system subvolumes"
-msgstr ""
-
-#: Gtk/DeleteBox.vala:59
+#: Gtk/DeleteBox.vala:58
 msgid "Deleting Snapshots..."
 msgstr ""
 
-#: Core/Subvolume.vala:89
+#: Core/Subvolume.vala:141
+#, c-format
 msgid "Deleting subvolume"
 msgstr ""
 
-#: Gtk/RestoreExcludeBox.vala:130
+#: Gtk/RestoreExcludeBox.vala:105
 msgid "Deluge, Transmission"
 msgstr ""
 
-#: Console/AppConsole.vala:425 Console/AppConsole.vala:540
+#: Console/AppConsole.vala:427 Console/AppConsole.vala:542
 msgid "Description"
 msgstr ""
 
-#: Core/Subvolume.vala:116
+#: Core/Subvolume.vala:168
+#, c-format
 msgid "Destroyed qgroup"
 msgstr ""
 
-#: Core/Subvolume.vala:106
+#: Core/Subvolume.vala:158
+#, c-format
 msgid "Destroying qgroup"
 msgstr ""
 
-#: Console/AppConsole.vala:452 Console/AppConsole.vala:491
-#: Console/AppConsole.vala:539 Core/Main.vala:1986 Core/Main.vala:2014
-#: Core/SnapshotRepo.vala:49 Core/SnapshotRepo.vala:639
-#: Core/SnapshotRepo.vala:642 Utility/Device.vala:1742 Utility/Device.vala:1752
-#: Gtk/RestoreDeviceBox.vala:97
+#: Utility/Device.vala:1810 Utility/Device.vala:1820
+#: Console/AppConsole.vala:454 Console/AppConsole.vala:493
+#: Console/AppConsole.vala:541 Core/SnapshotRepo.vala:76
+#: Core/SnapshotRepo.vala:683 Core/SnapshotRepo.vala:686 Core/Main.vala:2114
+#: Core/Main.vala:2146 Gtk/RestoreDeviceBox.vala:97
 #, c-format
 msgid "Device"
 msgstr ""
 
-#: Utility/Device.vala:1201
+#: Utility/Device.vala:1269
 msgid "Device is unlocked"
 msgstr ""
 
-#: Utility/Device.vala:1096 Utility/Device.vala:1158
+#: Utility/Device.vala:1164 Utility/Device.vala:1226
 msgid "Device name is empty!"
 msgstr ""
 
-#: Console/AppConsole.vala:661 Core/Main.vala:3095 Core/SnapshotRepo.vala:516
+#: Console/AppConsole.vala:663 Core/SnapshotRepo.vala:560 Core/Main.vala:3232
 msgid "Device not found"
+msgstr ""
+
+#: Gtk/BackupDeviceBox.vala:97
+#, c-format
+msgid "Devices displayed above have BTRFS file systems."
+msgstr ""
+
+#: Gtk/BackupDeviceBox.vala:104
+#, c-format
+msgid "Devices displayed above have Linux file systems."
 msgstr ""
 
 #: Gtk/RestoreDeviceBox.vala:84
 msgid "Devices from which snapshot was created are pre-selected."
 msgstr ""
 
-#: Console/AppConsole.vala:324
+#: Console/AppConsole.vala:326
 msgid "Devices with Linux file systems"
 msgstr ""
 
-#: Utility/Gtk/DonationWindow.vala:57
+#: Gtk/BackupDeviceBox.vala:105
+msgid "Devices with Windows file systems are not supported (NTFS, FAT, etc)."
+msgstr ""
+
+#: Utility/Gtk/DonationWindow.vala:61
 msgid ""
 "Did you find this software useful?\n"
 "\n"
@@ -670,75 +699,73 @@ msgid ""
 "(teejeetech@gmail.com)"
 msgstr ""
 
-#: Utility/TeeJee.FileSystem.vala:492
+#: Utility/TeeJee.FileSystem.vala:518
 msgid "Dir not found"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:938
+#: Core/SnapshotRepo.vala:982
 msgid "Directory not found"
 msgstr ""
 
-#: Core/Main.vala:2071 Gtk/RestoreSummaryBox.vala:64
+#: Core/Main.vala:2206 Gtk/RestoreSummaryBox.vala:64
 msgid "Disclaimer"
 msgstr ""
 
-#: Gtk/BackupDeviceBox.vala:108
+#: Gtk/BackupDeviceBox.vala:127
 msgid "Disk"
 msgstr ""
 
-#: Core/Main.vala:220
+#: Core/Main.vala:226
 msgid "Distribution"
 msgstr ""
 
-#: Utility/Gtk/AboutWindow.vala:360
-#, c-format
-msgid "Documenters"
+#: Utility/Gtk/AboutWindow.vala:449
+msgid "Documentation"
 msgstr ""
 
-#: Utility/Gtk/DonationWindow.vala:40 Gtk/MainWindow.vala:379
+#: Utility/Gtk/DonationWindow.vala:42 Gtk/MainWindow.vala:388
 msgid "Donate"
 msgstr ""
 
-#: Utility/Gtk/DonationWindow.vala:77
+#: Utility/Gtk/DonationWindow.vala:81
 msgid "Donate with PayPal"
 msgstr ""
 
-#: Utility/Gtk/AboutWindow.vala:368
-#, c-format
+#: Utility/Gtk/AboutWindow.vala:465
 msgid "Donations"
 msgstr ""
 
-#: Gtk/ExcludeBox.vala:264
-msgid "Editing and Re-Ordering"
+#: Gtk/UsersBox.vala:357
+msgid "Enable BTRFS qgroups (recommended)"
 msgstr ""
 
-#: Gtk/MainWindow.vala:1038
+#: Gtk/MainWindow.vala:1068
 msgid "Enable scheduled snapshots to protect your system"
 msgstr ""
 
-#: Core/Main.vala:3878 Core/Main.vala:3911
+#: Core/Main.vala:4030 Core/Main.vala:4070
 msgid "Enabled subvolume quota support"
 msgstr ""
 
-#: Utility/Device.vala:1265
+#: Utility/Device.vala:1333
 msgid "Encrypted Device"
 msgstr ""
 
-#: Gtk/UsersBox.vala:163
+#: Gtk/UsersBox.vala:236
 msgid "Encrypted Home Directory"
 msgstr ""
 
-#: Console/AppConsole.vala:882
+#: Console/AppConsole.vala:884
 #, c-format
 msgid "Enter device name or number"
 msgstr ""
 
-#: Console/AppConsole.vala:680 Console/AppConsole.vala:1011
+#: Console/AppConsole.vala:682 Console/AppConsole.vala:1013
 #, c-format
 msgid "Enter device name or number (a=Abort)"
 msgstr ""
 
-#: Utility/Device.vala:1266
+#: Utility/Device.vala:1334
 #, c-format
 msgid "Enter passphrase to unlock '%s'"
 msgstr ""
@@ -747,20 +774,24 @@ msgstr ""
 msgid "Enter path or browse for directory"
 msgstr ""
 
-#: Console/AppConsole.vala:752
+#: Console/AppConsole.vala:754
 #, c-format
 msgid "Enter snapshot number (a=Abort, p=Previous, n=Next)"
 msgstr ""
 
-#: Gtk/ExcludeBox.vala:229
+#: Gtk/ExcludeBox.vala:225
 msgid "Enter the pattern to exclude (Ex: *.mp3, *.bak)"
 msgstr ""
 
-#: Utility/GtkHelper.vala:18 Gtk/RestoreDeviceBox.vala:533
+#: Utility/GtkHelper.vala:18 Gtk/RestoreDeviceBox.vala:534
 msgid "Error"
 msgstr ""
 
-#: Gtk/SetupWizardWindow.vala:94 Gtk/BackupWindow.vala:79
+#: Gtk/RestoreWindow.vala:488
+msgid "Error running Rsync"
+msgstr ""
+
+#: Gtk/SetupWizardWindow.vala:99 Gtk/BackupWindow.vala:81
 msgid "Estimate"
 msgstr ""
 
@@ -768,39 +799,43 @@ msgstr ""
 msgid "Estimating System Size..."
 msgstr ""
 
-#: Core/Main.vala:1187
+#: Core/Main.vala:1279
 msgid "Estimating system size..."
 msgstr ""
 
-#: Console/AppConsole.vala:384
+#: Console/AppConsole.vala:386
 msgid "Examples"
 msgstr ""
 
-#: Gtk/ExcludeAppsBox.vala:51 Gtk/RestoreExcludeBox.vala:80
+#: Gtk/UsersBox.vala:136
+msgid "Exclude All"
+msgstr ""
+
+#: Gtk/ExcludeAppsBox.vala:51 Gtk/RestoreExcludeBox.vala:55
 msgid "Exclude Application Settings"
 msgstr ""
 
-#: Gtk/RestoreWindow.vala:91
+#: Gtk/RestoreWindow.vala:99
 msgid "Exclude Apps"
 msgstr ""
 
-#: Gtk/ExcludeMessageWindow.vala:77
+#: Gtk/ExcludeMessageWindow.vala:70
 msgid "Exclude List"
 msgstr ""
 
-#: Gtk/ExcludeListSummaryWindow.vala:48
+#: Gtk/ExcludeListSummaryWindow.vala:49
 msgid "Exclude List Summary"
 msgstr ""
 
-#: Gtk/ExcludeBox.vala:228
+#: Gtk/ExcludeBox.vala:224
 msgid "Exclude Pattern"
 msgstr ""
 
-#: Gtk/ExcludeMessageWindow.vala:55
+#: Gtk/ExcludeMessageWindow.vala:56
 msgid "Excluded Directories"
 msgstr ""
 
-#: Core/Main.vala:1457
+#: Core/Main.vala:1567
 msgid "Expected values: O, B, H, D, W, M"
 msgstr ""
 
@@ -812,27 +847,27 @@ msgstr ""
 msgid "Failed to copy file"
 msgstr ""
 
-#: Utility/TeeJee.FileSystem.vala:328 Utility/TeeJee.FileSystem.vala:336
+#: Utility/TeeJee.FileSystem.vala:354 Utility/TeeJee.FileSystem.vala:362
 msgid "Failed to create directory"
 msgstr ""
 
-#: Core/Main.vala:1313
+#: Core/Main.vala:1405
 msgid "Failed to create new snapshot"
 msgstr ""
 
-#: Core/Main.vala:1163
+#: Core/Main.vala:1255
 msgid "Failed to create snapshot"
 msgstr ""
 
-#: Core/Main.vala:1385
+#: Core/Main.vala:1495
 msgid "Failed to create subvolume snapshot"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:979
+#: Core/SnapshotRepo.vala:1023
 msgid "Failed to create symlinks"
 msgstr ""
 
-#: Utility/TeeJee.FileSystem.vala:358
+#: Utility/TeeJee.FileSystem.vala:384
 msgid "Failed to delete directory"
 msgstr ""
 
@@ -840,23 +875,23 @@ msgstr ""
 msgid "Failed to delete file"
 msgstr ""
 
-#: Core/Subvolume.vala:98
+#: Core/Subvolume.vala:150
 msgid "Failed to delete snapshot subvolume"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:1005
+#: Core/SnapshotRepo.vala:1049
 msgid "Failed to delete symlinks"
 msgstr ""
 
-#: Core/Subvolume.vala:112
+#: Core/Subvolume.vala:164
 msgid "Failed to destroy qgroup"
 msgstr ""
 
-#: Core/Main.vala:3898
+#: Core/Main.vala:4055
 msgid "Failed to enable subvolume quota"
 msgstr ""
 
-#: Core/Main.vala:3594 Core/Main.vala:3600
+#: Core/Main.vala:3733 Core/Main.vala:3739
 msgid "Failed to estimate system size"
 msgstr ""
 
@@ -864,17 +899,17 @@ msgstr ""
 msgid "Failed to export crontab file"
 msgstr ""
 
-#: Console/AppConsole.vala:695 Console/AppConsole.vala:759
-#: Console/AppConsole.vala:891 Console/AppConsole.vala:986
-#: Console/AppConsole.vala:1031 Console/AppConsole.vala:1072
+#: Console/AppConsole.vala:697 Console/AppConsole.vala:761
+#: Console/AppConsole.vala:893 Console/AppConsole.vala:988
+#: Console/AppConsole.vala:1033 Console/AppConsole.vala:1074
 msgid "Failed to get input from user in 3 attempts"
 msgstr ""
 
-#: Utility/Device.vala:559
+#: Utility/Device.vala:615
 msgid "Failed to get partition list"
 msgstr ""
 
-#: Core/Main.vala:3178
+#: Core/Main.vala:3315
 msgid "Failed to get partition list."
 msgstr ""
 
@@ -882,7 +917,7 @@ msgstr ""
 msgid "Failed to install crontab file"
 msgstr ""
 
-#: Gtk/RestoreDeviceBox.vala:534
+#: Gtk/RestoreDeviceBox.vala:535
 msgid "Failed to mount devices"
 msgstr ""
 
@@ -890,15 +925,15 @@ msgstr ""
 msgid "Failed to move file"
 msgstr ""
 
-#: Core/Main.vala:2835
+#: Core/Main.vala:2961
 msgid "Failed to move system subvolume to snapshot directory"
 msgstr ""
 
-#: Core/Main.vala:3717
+#: Core/Main.vala:3863
 msgid "Failed to query subvolume list"
 msgstr ""
 
-#: Core/Main.vala:3800
+#: Core/Main.vala:3947
 msgid "Failed to query subvolume quota"
 msgstr ""
 
@@ -910,7 +945,7 @@ msgstr ""
 msgid "Failed to read file"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:925
+#: Core/SnapshotRepo.vala:969
 msgid "Failed to remove"
 msgstr ""
 
@@ -918,32 +953,32 @@ msgstr ""
 msgid "Failed to remove cron job"
 msgstr ""
 
-#: Core/Snapshot.vala:446 Core/Snapshot.vala:457 Core/Snapshot.vala:464
+#: Core/Snapshot.vala:530 Core/Snapshot.vala:542 Core/Snapshot.vala:550
 msgid "Failed to remove snapshot"
 msgstr ""
 
-#: Core/Main.vala:3931
+#: Core/Main.vala:4094
 msgid "Failed to rescan subvolume quota"
 msgstr ""
 
-#: Core/Main.vala:2715
+#: Core/Subvolume.vala:202
 msgid "Failed to restore system subvolume"
 msgstr ""
 
-#: Core/Main.vala:1263
+#: Core/Main.vala:1355
 msgid "Failed to save exclude list"
 msgstr ""
 
-#: Utility/Device.vala:1192 Utility/Device.vala:1246 Utility/Device.vala:1271
-#: Utility/Device.vala:1292 Utility/Device.vala:1312
+#: Utility/Device.vala:1260 Utility/Device.vala:1314 Utility/Device.vala:1339
+#: Utility/Device.vala:1360 Utility/Device.vala:1380
 msgid "Failed to unlock device"
 msgstr ""
 
-#: Utility/Device.vala:1543
+#: Utility/Device.vala:1611
 msgid "Failed to unmount"
 msgstr ""
 
-#: Core/Main.vala:3380
+#: Core/Main.vala:3519
 msgid "Failed to unmount device!"
 msgstr ""
 
@@ -951,7 +986,15 @@ msgstr ""
 msgid "Failed to write file"
 msgstr ""
 
-#: Gtk/ExcludeMessageWindow.vala:105
+#: Gtk/RsyncLogBox.vala:122
+msgid "File (snapshot)"
+msgstr ""
+
+#: Gtk/RsyncLogBox.vala:119
+msgid "File (system)"
+msgstr ""
+
+#: Gtk/ExcludeMessageWindow.vala:98
 msgid "File Pattern"
 msgstr ""
 
@@ -959,637 +1002,661 @@ msgstr ""
 msgid "File and directory counts:"
 msgstr ""
 
-#: Utility/TeeJee.FileSystem.vala:645 Utility/TeeJee.FileSystem.vala:694
+#: Utility/TeeJee.FileSystem.vala:671 Utility/TeeJee.FileSystem.vala:720
 msgid "File is missing"
 msgstr ""
 
-#: Utility/RsyncTask.vala:249 Utility/CronTab.vala:225
-#: Utility/TeeJee.FileSystem.vala:205 Utility/TeeJee.FileSystem.vala:521
+#: Utility/TeeJee.FileSystem.vala:205 Utility/TeeJee.FileSystem.vala:547
+#: Utility/CronTab.vala:225 Utility/RsyncTask.vala:296
 msgid "File not found"
 msgstr ""
 
-#: Gtk/ExcludeListSummaryWindow.vala:61
+#: Gtk/ExcludeListSummaryWindow.vala:62
 msgid ""
 "Files &amp; directories matching the patterns below will be excluded. "
 "Patterns starting with a + will include the item instead of excluding."
 msgstr ""
 
-#: Gtk/SnapshotBackendBox.vala:186
+#: Gtk/SnapshotBackendBox.vala:192
 msgid "Files and directories can be excluded to save disk space."
 msgstr ""
 
-#: Gtk/RestoreBox.vala:118
+#: Gtk/RestoreBox.vala:119
 msgid "Files and directory counts:"
 msgstr ""
 
-#: Gtk/ExcludeMessageWindow.vala:83
+#: Gtk/ExcludeMessageWindow.vala:76
 msgid "Files matching the following patterns will be excluded"
 msgstr ""
 
-#: Utility/Device.vala:1760
+#: Utility/Device.vala:1828
 #, c-format
 msgid "Filesystem"
 msgstr ""
 
-#: Gtk/SettingsWindow.vala:111
+#: Gtk/RsyncLogBox.vala:302
+msgid "Filter by name or path"
+msgstr ""
+
+#: Gtk/SettingsWindow.vala:100
 msgid "Filters"
 msgstr ""
 
-#: Gtk/DeleteWindow.vala:101 Gtk/SetupWizardWindow.vala:193
-#: Gtk/BackupWindow.vala:94
+#: Gtk/SetupWizardWindow.vala:205 Gtk/BackupWindow.vala:96
+#: Gtk/DeleteWindow.vala:103
 msgid "Finish"
 msgstr ""
 
-#: Gtk/SetupWizardWindow.vala:109 Gtk/RestoreWindow.vala:106
+#: Gtk/SetupWizardWindow.vala:120 Gtk/RestoreWindow.vala:130
 msgid "Finished"
 msgstr ""
 
-#: Gtk/RestoreExcludeBox.vala:103
+#: Gtk/RestoreExcludeBox.vala:78
 msgid "Firefox, Chromium, Chrome, Opera, Epiphany, Midori"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:623
+#: Core/SnapshotRepo.vala:667
 msgid "First snapshot requires:"
 msgstr ""
 
-#: Core/Main.vala:2768
+#: Core/Main.vala:2894
 msgid "Found existing pre-restore snapshot"
 msgstr ""
 
-#: Gtk/BackupDeviceBox.vala:198
+#: Gtk/BackupDeviceBox.vala:215
 msgid "Free"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:50 Core/SnapshotRepo.vala:118
+#: Core/SnapshotRepo.vala:77 Core/SnapshotRepo.vala:147
 msgid "Free space"
 msgstr ""
 
-#: Console/AppConsole.vala:1040
+#: Console/AppConsole.vala:1042
 msgid "GRUB Device"
 msgstr ""
 
-#: Gtk/RestoreDeviceBox.vala:510
+#: Gtk/RestoreDeviceBox.vala:511
 msgid "GRUB device not selected"
 msgstr ""
 
-#: Console/AppConsole.vala:1045
+#: Console/AppConsole.vala:1047
 msgid "GRUB will NOT be reinstalled"
 msgstr ""
 
-#: Core/Main.vala:2202
+#: Core/Main.vala:2348
 msgid "Generating initramfs..."
 msgstr ""
 
-#: Console/AppConsole.vala:372
+#: Console/AppConsole.vala:374
 msgid "Global"
 msgstr ""
 
-#: Gtk/BackupBox.vala:97 Gtk/RestoreBox.vala:134
+#: Gtk/RsyncLogBox.vala:400 Gtk/RestoreBox.vala:135 Gtk/BackupBox.vala:97
+#, c-format
 msgid "Group"
 msgstr ""
 
-#: Gtk/ExcludeMessageWindow.vala:136
+#: Gtk/ExcludeMessageWindow.vala:129
 msgid ""
 "Hidden files and folders are included by default since they contain user-"
 "specific configuration files."
 msgstr ""
 
-#: Gtk/DeleteWindow.vala:175
+#: Gtk/DeleteWindow.vala:178
 msgid "Hide"
 msgstr ""
 
-#: Console/AppConsole.vala:379
+#: Console/AppConsole.vala:381
 msgid "Hide rsync output"
 msgstr ""
 
-#: Gtk/DeleteWindow.vala:176
+#: Gtk/DeleteWindow.vala:179
 msgid "Hide this window (files will be deleted in background)"
 msgstr ""
 
-#: Gtk/UsersBox.vala:113
+#: Gtk/UsersBox.vala:120
 msgid "Home"
 msgstr ""
 
-#: Gtk/ExcludeMessageWindow.vala:123
+#: Gtk/ExcludeMessageWindow.vala:116
 msgid "Home Directory"
 msgstr ""
 
-#: Gtk/ScheduleBox.vala:115
+#: Gtk/ScheduleBox.vala:118 Gtk/SnapshotListBox.vala:299
 msgid "Hourly"
 msgstr ""
 
-#: Core/Main.vala:955
+#: Core/Main.vala:1047
 msgid "Hourly snapshot failed!"
 msgstr ""
 
-#: Core/Main.vala:936
+#: Core/Main.vala:1028
 msgid "Hourly snapshots are enabled"
 msgstr ""
 
-#: Gtk/RestoreFinishBox.vala:86
+#: Utility/Gtk/AboutWindow.vala:457
+msgid "Icon Themes & Utilities"
+msgstr ""
+
+#: Gtk/RestoreFinishBox.vala:102
 msgid ""
 "If the restored system fails to boot, then boot from the Live CD/USB, "
 "install Timeshift, and try restoring another snapshot."
 msgstr ""
 
-#: Core/Main.vala:2077
+#: Core/Main.vala:2212
 msgid ""
 "If these terms are not acceptable to you, please do not proceed beyond this "
 "point!"
 msgstr ""
 
-#: Gtk/ExcludeBox.vala:52
+#: Gtk/ExcludeBox.vala:54
 msgid "Include / Exclude Patterns"
 msgstr ""
 
-#: Gtk/UsersBox.vala:243
+#: Gtk/UsersBox.vala:340
 msgid "Include @home subvolume in backups"
 msgstr ""
 
-#: Gtk/UsersBox.vala:189
-msgid "Include everything"
+#: Gtk/UsersBox.vala:266
+msgid "Include All"
 msgstr ""
 
-#: Gtk/UsersBox.vala:128
-msgid "Include hidden items"
+#: Gtk/UsersBox.vala:194
+msgid "Include Hidden"
 msgstr ""
 
-#: Gtk/ExcludeBox.vala:262
-msgid "Info"
-msgstr ""
-
-#: Core/Main.vala:1900
+#: Core/Main.vala:2026
 msgid "Invalid Snapshot"
 msgstr ""
 
-#: Console/AppConsole.vala:249
+#: Console/AppConsole.vala:251
 #, c-format
 msgid "Invalid command line arguments"
 msgstr ""
 
-#: Gtk/MainWindow.vala:798
+#: Gtk/MainWindow.vala:824
 msgid "Invalid snapshot"
 msgstr ""
 
-#: Utility/Gtk/DonationWindow.vala:93
+#: Utility/Gtk/DonationWindow.vala:97
 msgid "Issue Tracker ~ Report Issues, Request Features, Ask Questions"
 msgstr ""
 
-#: Gtk/ExcludeBox.vala:278
+#: Gtk/ExcludeBox.vala:272
 msgid "Items Not Selected"
 msgstr ""
 
-#: Gtk/ScheduleBox.vala:263
+#: Gtk/ScheduleBox.vala:283
 msgid "Keep"
 msgstr ""
 
-#: Gtk/RestoreExcludeBox.vala:137
+#: Gtk/RestoreExcludeBox.vala:112
 msgid ""
 "Keep configuration files for bittorrent clients like Deluge, Transmission, "
 "etc. If un-checked, previous configuration files will be restored from "
 "snapshot."
 msgstr ""
 
-#: Gtk/RestoreExcludeBox.vala:110
+#: Gtk/RestoreExcludeBox.vala:85
 msgid ""
 "Keep configuration files for web browsers like Firefox and Chrome. If un-"
 "checked, previous configuration files will be restored from snapshot"
 msgstr ""
 
-#: Gtk/RestoreDeviceBox.vala:242
+#: Gtk/RestoreDeviceBox.vala:244
 msgid "Keep on Root Device"
 msgstr ""
 
-#: Gtk/RestoreDeviceBox.vala:227
+#: Gtk/RestoreDeviceBox.vala:229
 msgid "Keep this mount path on the root filesystem"
 msgstr ""
 
-#: Gtk/SnapshotListBox.vala:474
+#: Gtk/SnapshotListBox.vala:519
 msgid "LIVE"
 msgstr ""
 
-#: Console/AppConsole.vala:456 Console/AppConsole.vala:495
-#: Utility/Device.vala:1761
+#: Utility/Device.vala:1829 Console/AppConsole.vala:458
+#: Console/AppConsole.vala:497 Gtk/BackupDeviceBox.vala:254
 #, c-format
 msgid "Label"
 msgstr ""
 
-#: Core/Main.vala:918
+#: Core/Main.vala:1010
 #, c-format
 msgid "Last boot snapshot is %d hours old"
 msgstr ""
 
-#: Core/Main.vala:913
+#: Core/Main.vala:1005
 msgid "Last boot snapshot is older than system start time"
 msgstr ""
 
-#: Core/Main.vala:909
+#: Core/Main.vala:1001
 msgid "Last boot snapshot not found"
 msgstr ""
 
-#: Core/Main.vala:978
+#: Core/Main.vala:1070
 #, c-format
 msgid "Last daily snapshot is %d hours old"
 msgstr ""
 
-#: Core/Main.vala:973
+#: Core/Main.vala:1065
 msgid "Last daily snapshot is more than 1 day old"
 msgstr ""
 
-#: Core/Main.vala:969
+#: Core/Main.vala:1061
 msgid "Last daily snapshot not found"
 msgstr ""
 
-#: Core/Main.vala:948
+#: Core/Main.vala:1040
 #, c-format
 msgid "Last hourly snapshot is %d minutes old"
 msgstr ""
 
-#: Core/Main.vala:943
+#: Core/Main.vala:1035
 msgid "Last hourly snapshot is more than 1 hour old"
 msgstr ""
 
-#: Core/Main.vala:939
+#: Core/Main.vala:1031
 msgid "Last hourly snapshot not found"
 msgstr ""
 
-#: Core/Main.vala:1038
+#: Core/Main.vala:1130
 #, c-format
 msgid "Last monthly snapshot is %d days old"
 msgstr ""
 
-#: Core/Main.vala:1033
+#: Core/Main.vala:1125
 msgid "Last monthly snapshot is more than 1 month old"
 msgstr ""
 
-#: Core/Main.vala:1029
+#: Core/Main.vala:1121
 msgid "Last monthly snapshot not found"
 msgstr ""
 
-#: Core/Main.vala:1008
+#: Core/Main.vala:1100
 #, c-format
 msgid "Last weekly snapshot is %d days old"
 msgstr ""
 
-#: Core/Main.vala:1003
+#: Core/Main.vala:1095
 msgid "Last weekly snapshot is more than 1 week old"
 msgstr ""
 
-#: Core/Main.vala:999
+#: Core/Main.vala:1091
 msgid "Last weekly snapshot not found"
 msgstr ""
 
-#: Gtk/MainWindow.vala:1019
+#: Gtk/MainWindow.vala:1049
 #, c-format
 msgid "Latest snapshot"
 msgstr ""
 
-#: Core/Main.vala:1252
+#: Utility/Gtk/AboutWindow.vala:316 Utility/Gtk/AboutWindow.vala:356
+msgid "License"
+msgstr ""
+
+#: Core/Main.vala:1344
 #, c-format
 msgid "Linking from snapshot"
 msgstr ""
 
-#: Console/AppConsole.vala:350
+#: Console/AppConsole.vala:352
 msgid "List"
 msgstr ""
 
-#: Console/AppConsole.vala:352
+#: Console/AppConsole.vala:354
 msgid "List devices"
 msgstr ""
 
-#: Console/AppConsole.vala:351
+#: Console/AppConsole.vala:353
 msgid "List snapshots"
 msgstr ""
 
-#: Gtk/MainWindow.vala:970
+#: Gtk/MainWindow.vala:1000
 msgid "Live USB Mode (Restore Only)"
 msgstr ""
 
-#: Gtk/SettingsWindow.vala:100 Gtk/SetupWizardWindow.vala:99
-#: Gtk/BackupWindow.vala:84
+#: Gtk/SetupWizardWindow.vala:104 Gtk/BackupWindow.vala:86
+#: Gtk/SettingsWindow.vala:89
 msgid "Location"
 msgstr ""
 
-#: Gtk/RsyncLogWindow.vala:75
-msgid "Log Viewer"
-msgstr ""
-
-#: Gtk/MainWindow.vala:450
+#: Gtk/MainWindow.vala:459
 msgid "Main window closed by user"
 msgstr ""
 
-#: Gtk/SnapshotListBox.vala:299
+#: Gtk/SnapshotListBox.vala:329
 msgid "Mark for Deletion"
 msgstr ""
 
-#: Gtk/MainWindow.vala:626
+#: Gtk/MainWindow.vala:641
 msgid "Marked for deletion"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:667 Core/SnapshotRepo.vala:704
+#: Core/SnapshotRepo.vala:711 Core/SnapshotRepo.vala:748
 msgid "Maximum backups exceeded for backup level"
 msgstr ""
 
-#: Gtk/MainWindow.vala:205
+#: Gtk/MainWindow.vala:208
 msgid "Menu"
 msgstr ""
 
-#: Core/Main.vala:229
+#: Gtk/UsersBox.vala:354
+msgid "Miscellaneous"
+msgstr ""
+
+#: Core/Main.vala:235
 msgid "Missing Dependencies"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:645
+#: Core/SnapshotRepo.vala:689
 #, c-format
 msgid "Mode"
 msgstr ""
 
-#: Utility/Device.vala:1744
+#: Utility/Device.vala:1812
 #, c-format
 msgid "Model"
 msgstr ""
 
-#: Gtk/ScheduleBox.vala:61
+#: Gtk/ScheduleBox.vala:64 Gtk/SnapshotListBox.vala:302
 msgid "Monthly"
 msgstr ""
 
-#: Core/Main.vala:1026
+#: Core/Main.vala:1118
 msgid "Monthly snapshot are enabled"
 msgstr ""
 
-#: Core/Main.vala:1045
+#: Core/Main.vala:1137
 msgid "Monthly snapshot failed!"
 msgstr ""
 
-#: Core/Main.vala:1985 Core/Main.vala:2014
+#: Core/Main.vala:2113 Core/Main.vala:2146
 msgid "Mount"
 msgstr ""
 
-#: Core/Main.vala:2842
+#: Core/Main.vala:2968
 msgid "Moved system subvolume to snapshot directory"
 msgstr ""
 
-#: Gtk/MainWindow.vala:776
+#: Gtk/MainWindow.vala:800
 msgid "Multiple snapshots selected"
 msgstr ""
 
-#: Console/AppConsole.vala:423 Gtk/RsyncLogWindow.vala:284
+#: Console/AppConsole.vala:425 Gtk/RsyncLogBox.vala:492
+#: Gtk/BackupDeviceBox.vala:235
 msgid "Name"
 msgstr ""
 
-#: Gtk/DeleteWindow.vala:159 Gtk/SetupWizardWindow.vala:185
-#: Gtk/RestoreWindow.vala:168 Gtk/BackupWindow.vala:156
+#: Gtk/SetupWizardWindow.vala:197 Gtk/BackupWindow.vala:160
+#: Gtk/DeleteWindow.vala:162 Gtk/RestoreWindow.vala:198
 msgid "Next"
 msgstr ""
 
-#: Utility/Gtk/CustomMessageDialog.vala:178
+#: Utility/Gtk/CustomMessageDialog.vala:177
 msgid "No"
 msgstr ""
 
-#: Gtk/BackupBox.vala:84 Gtk/RestoreBox.vala:121
+#: Gtk/RestoreBox.vala:122 Gtk/BackupBox.vala:84
 msgid "No Change"
 msgstr ""
 
-#: Gtk/DeleteWindow.vala:331 Gtk/MainWindow.vala:603
+#: Gtk/MainWindow.vala:615 Gtk/DeleteWindow.vala:341
 msgid "No Snapshots Selected"
 msgstr ""
 
-#: Gtk/MainWindow.vala:1043
+#: Gtk/MainWindow.vala:1073
 msgid "No snapshots available"
 msgstr ""
 
-#: Console/AppConsole.vala:318 Core/SnapshotRepo.vala:854
-#: Gtk/MainWindow.vala:987
+#: Console/AppConsole.vala:320 Core/SnapshotRepo.vala:898
+#: Gtk/MainWindow.vala:1017
 msgid "No snapshots found"
 msgstr ""
 
-#: Console/AppConsole.vala:738
+#: Console/AppConsole.vala:740
 msgid "No snapshots found on device"
 msgstr ""
 
-#: Gtk/MainWindow.vala:544
+#: Gtk/MainWindow.vala:553
 msgid "No snapshots on device"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:621
+#: Core/SnapshotRepo.vala:665
 msgid "No snapshots on this device"
 msgstr ""
 
-#: Gtk/MainWindow.vala:769
+#: Gtk/MainWindow.vala:793
 msgid "No snapshots selected"
 msgstr ""
 
-#: Gtk/MainWindow.vala:1020 Gtk/MainWindow.vala:1022
+#: Gtk/MainWindow.vala:1050 Gtk/MainWindow.vala:1052
 msgid "None"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:639
+#: Core/Subvolume.vala:184
+#, c-format
+msgid "Not Found"
+msgstr ""
+
+#: Core/SnapshotRepo.vala:683
 msgid "Not Selected"
 msgstr ""
 
-#: Core/Main.vala:370
+#: Core/Main.vala:379
 msgid "Not Supported"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:585 Core/SnapshotRepo.vala:612
+#: Core/SnapshotRepo.vala:629 Core/SnapshotRepo.vala:656
 msgid "Not enough disk space"
 msgstr ""
 
-#: Console/AppConsole.vala:395 Gtk/FinishBox.vala:54
+#: Console/AppConsole.vala:397 Gtk/FinishBox.vala:55
 msgid "Notes"
 msgstr ""
 
-#: Core/Main.vala:1055
+#: Core/Main.vala:1147
 msgid "Nothing to do!"
 msgstr ""
 
-#: Console/AppConsole.vala:421 Console/AppConsole.vala:450
-#: Console/AppConsole.vala:489 Console/AppConsole.vala:537
+#: Console/AppConsole.vala:423 Console/AppConsole.vala:452
+#: Console/AppConsole.vala:491 Console/AppConsole.vala:539
 msgid "Num"
 msgstr ""
 
-#: Gtk/ScheduleBox.vala:262
+#: Gtk/ScheduleBox.vala:282
 msgid ""
 "Number of snapshots to keep.\n"
 "Older snapshots will be removed once this limit is exceeded."
 msgstr ""
 
-#: Utility/Gtk/CustomMessageDialog.vala:168
-#: Utility/Gtk/CustomMessageDialog.vala:172 Utility/GtkHelper.vala:121
-#: Gtk/ExcludeListSummaryWindow.vala:85
+#: Utility/GtkHelper.vala:121 Utility/Gtk/CustomMessageDialog.vala:167
+#: Utility/Gtk/CustomMessageDialog.vala:171
+#: Gtk/ExcludeListSummaryWindow.vala:84
 msgid "OK"
 msgstr ""
 
-#: Gtk/SnapshotBackendBox.vala:173
+#: Gtk/SnapshotBackendBox.vala:179
 msgid ""
 "OS must be installed on a BTRFS partition with Ubuntu-type subvolume layout "
 "(@ and @home subvolumes). Other layouts are not supported."
 msgstr ""
 
-#: Core/Main.vala:4027
+#: Core/Main.vala:4201
 msgid "Older log files removed"
 msgstr ""
 
-#: Gtk/MainWindow.vala:1021
+#: Gtk/MainWindow.vala:1051
 msgid "Oldest snapshot"
 msgstr ""
 
-#: Core/Main.vala:368 Core/Main.vala:3293 Gtk/RestoreDeviceBox.vala:524
+#: Gtk/SnapshotListBox.vala:297
+msgid "On demand (manual)"
+msgstr ""
+
+#: Core/Main.vala:377 Core/Main.vala:3432 Gtk/RestoreDeviceBox.vala:525
 msgid ""
 "Only ubuntu-type layouts with @ and @home subvolumes are currently supported."
 msgstr ""
 
-#: Gtk/MainWindow.vala:206
+#: Gtk/MainWindow.vala:209
 msgid "Open Menu"
 msgstr ""
 
-#: Core/Main.vala:3077
+#: Core/Main.vala:3214
 msgid ""
 "Option --snapshot-device should not be specified for creating snapshots in "
 "BTRFS mode"
 msgstr ""
 
-#: Console/AppConsole.vala:348 Gtk/AppGtk.vala:112
+#: Console/AppConsole.vala:350 Gtk/AppGtk.vala:114
 msgid "Options"
 msgstr ""
 
-#: Gtk/RestoreExcludeBox.vala:143
+#: Gtk/RestoreExcludeBox.vala:118
 msgid "Other applications (next page)"
 msgstr ""
 
-#: Gtk/BackupBox.vala:96 Gtk/RestoreBox.vala:133
+#: Gtk/RsyncLogBox.vala:398 Gtk/RestoreBox.vala:134 Gtk/BackupBox.vala:96
+#, c-format
 msgid "Owner"
 msgstr ""
 
-#: Utility/Device.vala:1756
+#: Utility/Device.vala:1824
 #, c-format
 msgid "Parent Device"
 msgstr ""
 
-#: Core/Main.vala:1326 Core/Main.vala:2323 Core/Main.vala:2402
-#: Gtk/RsyncLogWindow.vala:121
+#: Core/Main.vala:2469 Core/Main.vala:2560 Gtk/RsyncLogBox.vala:222
 msgid "Parsing log file..."
 msgstr ""
 
-#: Gtk/RestoreDeviceBox.vala:523
+#: Gtk/RestoreDeviceBox.vala:524
 msgid "Partition has an unsupported subvolume layout."
 msgstr ""
 
-#: Core/SnapshotRepo.vala:644 Gtk/RestoreDeviceBox.vala:93
+#: Core/SnapshotRepo.vala:688 Gtk/RestoreDeviceBox.vala:93
 #, c-format
 msgid "Path"
 msgstr ""
 
-#: Gtk/ExcludeBox.vala:158
+#: Gtk/ExcludeBox.vala:162
 msgid "Pattern"
 msgstr ""
 
-#: Gtk/BackupBox.vala:95 Gtk/RestoreBox.vala:132
+#: Gtk/RsyncLogBox.vala:396 Gtk/RestoreBox.vala:133 Gtk/BackupBox.vala:95
+#, c-format
 msgid "Permissions"
 msgstr ""
 
-#: Core/Main.vala:248
+#: Core/Main.vala:254
 msgid "Please check if you have multiple windows open."
 msgstr ""
 
-#: Core/Main.vala:2109
+#: Core/Main.vala:2244
 msgid "Please do not interrupt the restore process!"
 msgstr ""
 
-#: Core/Main.vala:340
+#: Core/Main.vala:348
 msgid "Please install required packages and try running TimeShift again"
 msgstr ""
 
-#: Gtk/AppGtk.vala:125
+#: Gtk/AppGtk.vala:127
 msgid "Please re-run the application as admin (using 'sudo' or 'su')"
 msgstr ""
 
-#: Console/AppConsole.vala:101
+#: Console/AppConsole.vala:103
 msgid "Please run the application as admin (using 'sudo' or 'su')"
 msgstr ""
 
-#: Core/Main.vala:2059
+#: Core/Main.vala:2194
 msgid "Please save your work and close all applications."
 msgstr ""
 
-#: Gtk/MainWindow.vala:672
+#: Gtk/MainWindow.vala:695
 msgid "Please select a snapshot to view the log!"
 msgstr ""
 
-#: Gtk/RestoreDeviceBox.vala:511
+#: Gtk/RestoreDeviceBox.vala:512
 msgid "Please select the GRUB device"
 msgstr ""
 
-#: Core/Main.vala:244
+#: Core/Main.vala:250
 msgid "Please wait a few minutes and try again."
 msgstr ""
 
-#: Gtk/MainWindow.vala:740
+#: Gtk/MainWindow.vala:762
 msgid "Please wait for snapshots to be deleted."
 msgstr ""
 
-#: Gtk/RsyncLogWindow.vala:185
+#: Gtk/EstimateBox.vala:66
+msgid "Please wait..."
+msgstr ""
+
+#: Gtk/RsyncLogBox.vala:188
 msgid "Populating list..."
 msgstr ""
 
-#: Core/Main.vala:1469 Gtk/RsyncLogWindow.vala:131 Gtk/BackupBox.vala:111
-#: Gtk/RestoreBox.vala:87 Gtk/DeleteBox.vala:69
+#: Core/Main.vala:1579 Gtk/RsyncLogBox.vala:232 Gtk/DeleteBox.vala:68
+#: Gtk/RestoreBox.vala:88 Gtk/BackupBox.vala:114
 msgid "Preparing..."
 msgstr ""
 
-#: Gtk/DeleteWindow.vala:151 Gtk/SetupWizardWindow.vala:177
-#: Gtk/RestoreWindow.vala:160 Gtk/BackupWindow.vala:148
+#: Gtk/SetupWizardWindow.vala:189 Gtk/BackupWindow.vala:152
+#: Gtk/DeleteWindow.vala:154 Gtk/RestoreWindow.vala:190
 msgid "Previous"
 msgstr ""
 
-#: Gtk/AppGtk.vala:114
+#: Gtk/AppGtk.vala:116
 msgid "Print debug information"
 msgstr ""
 
-#: Core/Main.vala:3655
+#: Core/Main.vala:3794
 msgid "Query completed"
 msgstr ""
 
-#: Core/Main.vala:3638
+#: Core/Main.vala:3777
 msgid "Querying subvolume info..."
 msgstr ""
 
-#: Gtk/SnapshotBackendBox.vala:78
+#: Gtk/SnapshotBackendBox.vala:77
 msgid "RSYNC"
 msgstr ""
 
-#: Gtk/SnapshotBackendBox.vala:178
+#: Gtk/SnapshotBackendBox.vala:184
 msgid "RSYNC Snapshots"
 msgstr ""
 
-#: Gtk/BootOptionsBox.vala:138
+#: Gtk/BootOptionsBox.vala:137
 msgid ""
 "Re-generates initramfs for all installed kernels. This is generally not "
 "needed. Select this only if the restored system fails to boot."
 msgstr ""
 
-#: Console/AppConsole.vala:980
+#: Console/AppConsole.vala:982
 #, c-format
 msgid "Re-install GRUB2 bootloader?"
 msgstr ""
 
-#: Core/Main.vala:2161
+#: Core/Main.vala:2307
 msgid "Re-installing GRUB2 bootloader..."
 msgstr ""
 
-#: Gtk/BootOptionsBox.vala:121
+#: Gtk/BootOptionsBox.vala:120
 msgid "Re-installs the GRUB2 bootloader on the selected device."
 msgstr ""
 
-#: Gtk/RsyncLogWindow.vala:178
+#: Gtk/RsyncLogBox.vala:181
 #, c-format
 msgid "Read %'d of %'d lines..."
 msgstr ""
 
-#: Core/Main.vala:2254
+#: Core/Main.vala:2400
 msgid "Rebooting system..."
 msgstr ""
 
-#: Gtk/RestoreExcludeBox.vala:86 Gtk/RestoreExcludeBox.vala:116
+#: Gtk/RestoreExcludeBox.vala:61 Gtk/RestoreExcludeBox.vala:91
 #, c-format
 msgid "Recommended"
 msgstr ""
@@ -1598,16 +1665,16 @@ msgstr ""
 msgid "Refresh"
 msgstr ""
 
-#: Gtk/MainWindow.vala:355
-msgid "Refresh Snapshot List"
+#: Gtk/BackupDeviceBox.vala:106
+msgid "Remote and network locations are not supported."
 msgstr ""
 
-#: Gtk/ExcludeBox.vala:257
+#: Gtk/ExcludeBox.vala:253
 msgid "Remove"
 msgstr ""
 
-#: Core/Main.vala:1507 Core/Main.vala:1518 Core/Snapshot.vala:426
-#: Core/SnapshotRepo.vala:931
+#: Core/SnapshotRepo.vala:975 Core/Main.vala:1617 Core/Main.vala:1628
+#: Core/Main.vala:4197 Core/Snapshot.vala:509
 #, c-format
 msgid "Removed"
 msgstr ""
@@ -1616,82 +1683,93 @@ msgstr ""
 msgid "Removed cron task"
 msgstr ""
 
-#: Core/Main.vala:3443
+#: Core/Main.vala:3582
 #, c-format
 msgid "Removed mount directory: '%s'"
 msgstr ""
 
-#: Core/Snapshot.vala:469
+#: Core/Snapshot.vala:555
 msgid "Removed snapshot"
 msgstr ""
 
-#: Core/Snapshot.vala:401
+#: Core/Snapshot.vala:484
 msgid "Removing"
 msgstr ""
 
-#: Core/Snapshot.vala:438
+#: Core/Snapshot.vala:521
 msgid "Removing snapshot"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:787 Core/SnapshotRepo.vala:806
-#: Core/SnapshotRepo.vala:824 Core/SnapshotRepo.vala:838
+#: Core/SnapshotRepo.vala:831 Core/SnapshotRepo.vala:850
+#: Core/SnapshotRepo.vala:868 Core/SnapshotRepo.vala:882
 #, c-format
 msgid "Removing snapshots"
 msgstr ""
 
-#: Console/AppConsole.vala:360 Gtk/RestoreWindow.vala:101
-#: Gtk/MainWindow.vala:148 Gtk/RestoreFinishBox.vala:64
+#: Gtk/UsersBox.vala:360
+msgid ""
+"Required for displaying shared and unshared size for snapshots in the main "
+"window"
+msgstr ""
+
+#: Console/AppConsole.vala:362 Gtk/RestoreFinishBox.vala:71
+#: Gtk/RsyncLogBox.vala:377 Gtk/RsyncLogBox.vala:567 Gtk/MainWindow.vala:151
+#: Gtk/RestoreWindow.vala:125
 msgid "Restore"
 msgstr ""
 
-#: Gtk/RestoreWindow.vala:81
+#: Gtk/UsersBox.vala:329
+msgid "Restore @home subvolume"
+msgstr ""
+
+#: Gtk/RestoreWindow.vala:89
 msgid "Restore Device"
 msgstr ""
 
-#: Gtk/RestoreWindow.vala:86
+#: Gtk/RestoreWindow.vala:94
 msgid "Restore Exclude"
 msgstr ""
 
-#: Gtk/RestoreWindow.vala:63
+#: Gtk/RestoreWindow.vala:69
 msgid "Restore Snapshot"
 msgstr ""
 
-#: Core/Main.vala:2644 Core/Main.vala:2727
+#: Core/Main.vala:2809 Core/Main.vala:2851
 msgid "Restore completed"
 msgstr ""
 
-#: Gtk/MainWindow.vala:149
+#: Gtk/MainWindow.vala:152
 msgid "Restore selected snapshot"
 msgstr ""
 
-#: Console/AppConsole.vala:361
+#: Console/AppConsole.vala:363
 msgid "Restore snapshot"
 msgstr ""
 
-#: Gtk/RestoreFinishBox.vala:80
+#: Gtk/RestoreFinishBox.vala:96
 msgid "Restored subvolumes will become active after system is restarted."
 msgstr ""
 
-#: Core/Main.vala:2722
+#: Core/Subvolume.vala:206
 msgid "Restored system subvolume"
 msgstr ""
 
-#: Gtk/RestoreBox.vala:76
+#: Gtk/RestoreBox.vala:77 Gtk/RestoreBox.vala:190
 msgid "Restoring Snapshot..."
 msgstr ""
 
-#: Gtk/FinishBox.vala:84
+#: Gtk/FinishBox.vala:85
 msgid ""
 "Restoring a snapshot will replace system subvolumes, and system subvolumes "
 "currently in use will be preserved as a new snapshot. If required, this "
 "snapshot can be restored later to 'undo' the restore."
 msgstr ""
 
-#: Core/Main.vala:2616
+#: Core/Main.vala:2778
 msgid "Restoring snapshot..."
 msgstr ""
 
-#: Gtk/FinishBox.vala:87
+#: Gtk/FinishBox.vala:88
 msgid ""
 "Restoring snapshots only replaces system files and settings. Non-hidden "
 "files and directories in user home directories will not be touched. This "
@@ -1700,35 +1778,39 @@ msgid ""
 "is restored."
 msgstr ""
 
-#: Utility/Device.vala:1746
+#: Utility/Device.vala:1814
 #, c-format
 msgid "Revision"
 msgstr ""
 
-#: Gtk/RestoreDeviceBox.vala:449
+#: Gtk/RestoreDeviceBox.vala:452
 msgid "Root device not selected"
 msgstr ""
 
-#: Gtk/AppGtk.vala:117
+#: Gtk/RsyncLogWindow.vala:49
+msgid "Rsync Log Viewer"
+msgstr ""
+
+#: Gtk/AppGtk.vala:119
 #, c-format
 msgid "Run 'timeshift' for the command-line version of this tool"
 msgstr ""
 
-#: Console/AppConsole.vala:380
+#: Console/AppConsole.vala:382
 msgid "Run in non-interactive mode"
 msgstr ""
 
-#: Core/Main.vala:180
+#: Core/Main.vala:186
 msgid "Running"
 msgstr ""
 
-#: Gtk/FinishBox.vala:94
+#: Gtk/FinishBox.vala:95
 msgid ""
 "Save snapshots to an external disk instead of the system disk to guard "
 "against drive failures."
 msgstr ""
 
-#: Gtk/FinishBox.vala:96
+#: Gtk/FinishBox.vala:97
 msgid ""
 "Saving snapshots to a non-system disk allows you to format and re-install "
 "the OS on the system disk without losing snapshots stored on it. You can "
@@ -1736,50 +1818,46 @@ msgid ""
 "distribution by restoring a snapshot."
 msgstr ""
 
-#: Core/Main.vala:1193 Core/Main.vala:1345 Core/Main.vala:1347
+#: Core/Main.vala:1285 Core/Main.vala:1439 Core/Main.vala:1441
 msgid "Saving to device"
 msgstr ""
 
-#: Gtk/SettingsWindow.vala:103 Gtk/SetupWizardWindow.vala:104
+#: Gtk/SetupWizardWindow.vala:109 Gtk/SettingsWindow.vala:92
 msgid "Schedule"
 msgstr ""
 
-#: Core/Main.vala:251
+#: Core/Main.vala:257
 msgid "Scheduled snapshot in progress..."
 msgstr ""
 
-#: Core/Main.vala:1055 Gtk/ScheduleBox.vala:288 Gtk/MainWindow.vala:1037
+#: Core/Main.vala:1147 Gtk/MainWindow.vala:1067 Gtk/ScheduleBox.vala:312
 msgid "Scheduled snapshots are disabled"
 msgstr ""
 
-#: Gtk/FinishBox.vala:77
+#: Gtk/FinishBox.vala:78
 msgid "Scheduled snapshots are disabled. It's recommended to enable it."
 msgstr ""
 
-#: Gtk/ScheduleBox.vala:283
+#: Gtk/ScheduleBox.vala:305
 msgid "Scheduled snapshots are enabled"
 msgstr ""
 
-#: Gtk/FinishBox.vala:74
+#: Gtk/FinishBox.vala:75
 msgid ""
 "Scheduled snapshots are enabled. Snapshots will be created automatically for "
 "selected levels."
 msgstr ""
 
-#: Gtk/ScheduleBox.vala:149
-msgid "Scheduled task runs once every hour"
-msgstr ""
-
-#: Console/AppConsole.vala:868
+#: Console/AppConsole.vala:870
 #, c-format
 msgid "Select '%s' device (default = %s)"
 msgstr ""
 
-#: Console/AppConsole.vala:687 Core/SnapshotRepo.vala:549
+#: Console/AppConsole.vala:689 Core/SnapshotRepo.vala:593
 msgid "Select BTRFS system disk with root subvolume (@)"
 msgstr ""
 
-#: Console/AppConsole.vala:996
+#: Console/AppConsole.vala:998
 msgid "Select GRUB device"
 msgstr ""
 
@@ -1787,11 +1865,11 @@ msgstr ""
 msgid "Select Path"
 msgstr ""
 
-#: Gtk/MainWindow.vala:671
+#: Gtk/MainWindow.vala:694
 msgid "Select Snapshot"
 msgstr ""
 
-#: Gtk/ScheduleBox.vala:54
+#: Gtk/ScheduleBox.vala:57
 msgid "Select Snapshot Levels"
 msgstr ""
 
@@ -1799,11 +1877,11 @@ msgstr ""
 msgid "Select Snapshot Location"
 msgstr ""
 
-#: Gtk/SnapshotBackendBox.vala:63
+#: Gtk/SnapshotBackendBox.vala:62
 msgid "Select Snapshot Type"
 msgstr ""
 
-#: Gtk/DeleteWindow.vala:83
+#: Gtk/DeleteWindow.vala:85
 msgid "Select Snapshots"
 msgstr ""
 
@@ -1811,56 +1889,56 @@ msgstr ""
 msgid "Select Target Device"
 msgstr ""
 
-#: Gtk/BackupDeviceBox.vala:319
+#: Gtk/BackupDeviceBox.vala:392
 #, c-format
 msgid "Select a partition on this disk"
 msgstr ""
 
-#: Gtk/MainWindow.vala:777
+#: Gtk/MainWindow.vala:801
 msgid "Select a single snapshot to restore"
 msgstr ""
 
-#: Gtk/RestoreDeviceBox.vala:478
+#: Gtk/RestoreDeviceBox.vala:481
 msgid "Select another device for root file system (/)"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:588 Core/SnapshotRepo.vala:615
+#: Core/SnapshotRepo.vala:632 Core/SnapshotRepo.vala:659
 msgid "Select another device or free up some space"
 msgstr ""
 
-#: Gtk/MainWindow.vala:538 Gtk/MainWindow.vala:545
+#: Gtk/MainWindow.vala:547 Gtk/MainWindow.vala:554
 msgid "Select another device to delete snasphots"
 msgstr ""
 
-#: Gtk/MainWindow.vala:472
+#: Gtk/MainWindow.vala:481
 msgid "Select another device?"
 msgstr ""
 
-#: Gtk/RestoreExcludeBox.vala:82
+#: Gtk/RestoreExcludeBox.vala:57
 msgid "Select applications to exclude from restore"
 msgstr ""
 
-#: Console/AppConsole.vala:670
+#: Console/AppConsole.vala:672
 msgid "Select backup device"
 msgstr ""
 
-#: Gtk/ExcludeBox.vala:429
+#: Gtk/ExcludeBox.vala:433
 msgid "Select directory"
 msgstr ""
 
-#: Gtk/ExcludeBox.vala:409
+#: Gtk/ExcludeBox.vala:406
 msgid "Select file(s)"
 msgstr ""
 
-#: Console/AppConsole.vala:744
+#: Console/AppConsole.vala:746
 msgid "Select snapshot"
 msgstr ""
 
-#: Gtk/DeleteWindow.vala:332
+#: Gtk/DeleteWindow.vala:342
 msgid "Select snapshots to delete"
 msgstr ""
 
-#: Gtk/RestoreDeviceBox.vala:450
+#: Gtk/RestoreDeviceBox.vala:453
 msgid "Select the device for root file system (/)"
 msgstr ""
 
@@ -1868,27 +1946,27 @@ msgstr ""
 msgid "Select the devices where files will be restored."
 msgstr ""
 
-#: Gtk/ScheduleBox.vala:289
+#: Gtk/ScheduleBox.vala:313
 msgid "Select the intervals for creating snapshots"
 msgstr ""
 
-#: Gtk/ExcludeBox.vala:279
+#: Gtk/ExcludeBox.vala:273
 msgid "Select the items to be removed from the list"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:509
+#: Core/SnapshotRepo.vala:553
 msgid "Select the snapshot device"
 msgstr ""
 
-#: Gtk/MainWindow.vala:770
+#: Gtk/MainWindow.vala:794
 msgid "Select the snapshot to restore"
 msgstr ""
 
-#: Gtk/DeleteWindow.vala:85
+#: Gtk/DeleteWindow.vala:87
 msgid "Select the snapshots to be deleted"
 msgstr ""
 
-#: Gtk/MainWindow.vala:604
+#: Gtk/MainWindow.vala:616
 msgid "Select the snapshots to mark for deletion"
 msgstr ""
 
@@ -1896,102 +1974,99 @@ msgstr ""
 msgid "Select the target devices where system will be cloned."
 msgstr ""
 
-#: Core/Main.vala:3105
+#: Core/Main.vala:3242
 msgid "Selected default snapshot device"
 msgstr ""
 
-#: Core/Main.vala:3056 Core/Main.vala:3060
+#: Core/Main.vala:3193 Core/Main.vala:3197
 msgid "Selected default snapshot type"
 msgstr ""
 
-#: Gtk/BackupDeviceBox.vala:300
+#: Gtk/BackupDeviceBox.vala:373
 msgid "Selected device does not have BTRFS partition"
 msgstr ""
 
-#: Gtk/BackupDeviceBox.vala:298
+#: Gtk/BackupDeviceBox.vala:371
 msgid "Selected device does not have Linux partition"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:117
+#: Core/SnapshotRepo.vala:146
 msgid "Selected snapshot device"
 msgstr ""
 
-#: Console/AppConsole.vala:686 Core/SnapshotRepo.vala:548
+#: Console/AppConsole.vala:688 Core/SnapshotRepo.vala:592
 msgid "Selected snapshot device is not a system disk"
 msgstr ""
 
-#: Core/Main.vala:1901
+#: Core/Main.vala:2027
 msgid "Selected snapshot is marked for deletion"
 msgstr ""
 
-#: Gtk/MainWindow.vala:799
+#: Gtk/MainWindow.vala:825
 msgid "Selected snapshot is marked for deletion and cannot be restored"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:43
-msgid "Selected snapshot path"
-msgstr ""
-
-#: Gtk/UsersBox.vala:165
+#: Gtk/UsersBox.vala:238
 msgid ""
 "Selected user has an encrypted home directory. It's not possible to include "
 "only hidden files."
 msgstr ""
 
-#: Utility/Device.vala:1745
+#: Utility/Device.vala:1813
 #, c-format
 msgid "Serial"
 msgstr ""
 
-#: Core/Main.vala:208
+#: Core/Main.vala:214
 msgid "Session log file"
 msgstr ""
 
-#: Console/AppConsole.vala:357
+#: Console/AppConsole.vala:359
 msgid "Set snapshot description"
 msgstr ""
 
-#: Gtk/SettingsWindow.vala:55 Gtk/MainWindow.vala:178 Gtk/MainWindow.vala:179
+#: Gtk/MainWindow.vala:181 Gtk/MainWindow.vala:182 Gtk/SettingsWindow.vala:55
 msgid "Settings"
 msgstr ""
 
-#: Gtk/MainWindow.vala:189
+#: Gtk/MainWindow.vala:192
 msgid "Settings wizard"
 msgstr ""
 
-#: Gtk/FinishBox.vala:57
+#: Gtk/FinishBox.vala:58
 msgid "Setup Complete"
 msgstr ""
 
-#: Gtk/SetupWizardWindow.vala:62
+#: Gtk/SetupWizardWindow.vala:64
 msgid "Setup Wizard"
 msgstr ""
 
-#: Console/AppConsole.vala:377
+#: Console/AppConsole.vala:379
 msgid "Show additional debug messages"
 msgstr ""
 
-#: Console/AppConsole.vala:381 Gtk/AppGtk.vala:115
+#: Console/AppConsole.vala:383 Gtk/AppGtk.vala:117
 msgid "Show all options"
 msgstr ""
 
-#: Gtk/RestoreExcludeBox.vala:146
+#: Gtk/RestoreExcludeBox.vala:121
 msgid "Show more applications to exclude on the next page"
 msgstr ""
 
-#: Console/AppConsole.vala:378
+#: Console/AppConsole.vala:380
 msgid "Show rsync output (default)"
 msgstr ""
 
-#: Console/AppConsole.vala:454 Console/AppConsole.vala:493
-#: Utility/Device.vala:1748 Utility/Device.vala:1763
-#: Gtk/BackupDeviceBox.vala:185 Gtk/RsyncLogWindow.vala:306
-#: Gtk/BackupBox.vala:93 Gtk/RestoreBox.vala:130 Gtk/SnapshotListBox.vala:174
+#: Utility/Device.vala:1816 Utility/Device.vala:1831
+#: Console/AppConsole.vala:456 Console/AppConsole.vala:495
+#: Gtk/RsyncLogBox.vala:392 Gtk/RestoreBox.vala:131
+#: Gtk/BackupDeviceBox.vala:202 Gtk/BackupBox.vala:93
+#: Gtk/SnapshotListBox.vala:174
 #, c-format
 msgid "Size"
 msgstr ""
 
-#: Gtk/SnapshotBackendBox.vala:171
+#: Gtk/SnapshotBackendBox.vala:177
 msgid ""
 "Size of BTRFS snapshots are initially zero. As system files gradually change "
 "with time, data gets written to new data blocks which take up disk space "
@@ -1999,17 +2074,17 @@ msgid ""
 "blocks."
 msgstr ""
 
-#: Console/AppConsole.vala:366
+#: Console/AppConsole.vala:368
 msgid "Skip GRUB2 reinstall"
 msgstr ""
 
-#: Core/Main.vala:1906 Core/SnapshotRepo.vala:670 Core/SnapshotRepo.vala:708
+#: Core/SnapshotRepo.vala:714 Core/SnapshotRepo.vala:752 Core/Main.vala:2032
 #: Gtk/SnapshotListBox.vala:95
 #, c-format
 msgid "Snapshot"
 msgstr ""
 
-#: Gtk/MainWindow.vala:555
+#: Gtk/MainWindow.vala:564
 #, c-format
 msgid ""
 "Snapshot '%s' is being used by the system and cannot be deleted. Restart the "
@@ -2020,37 +2095,42 @@ msgstr ""
 msgid "Snapshot Created"
 msgstr ""
 
-#: Gtk/MainWindow.vala:739
+#: Gtk/SnapshotListBox.vala:296
+#, c-format
+msgid "Snapshot Levels"
+msgstr ""
+
+#: Gtk/MainWindow.vala:761
 msgid "Snapshot deletion in progress..."
 msgstr ""
 
-#: Core/SnapshotRepo.vala:426
+#: Core/SnapshotRepo.vala:470
 #, c-format
 msgid "Snapshot device"
 msgstr ""
 
-#: Console/AppConsole.vala:660 Core/SnapshotRepo.vala:515
+#: Console/AppConsole.vala:662 Core/SnapshotRepo.vala:559
 msgid "Snapshot device not available"
 msgstr ""
 
-#: Console/AppConsole.vala:656 Core/SnapshotRepo.vala:508
+#: Console/AppConsole.vala:658 Core/SnapshotRepo.vala:552
 msgid "Snapshot device not selected"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:430
+#: Core/SnapshotRepo.vala:474
 #, c-format
 msgid "Snapshot location"
 msgstr ""
 
-#: Core/Main.vala:1160
+#: Core/Main.vala:1252
 msgid "Snapshot saved successfully"
 msgstr ""
 
-#: Core/Main.vala:1896
+#: Core/Main.vala:2022
 msgid "Snapshot to restore not specified!"
 msgstr ""
 
-#: Core/Main.vala:2731
+#: Core/Main.vala:2855
 msgid "Snapshot will become active after system is rebooted."
 msgstr ""
 
@@ -2058,98 +2138,115 @@ msgstr ""
 msgid "Snapshot(s) Deleted"
 msgstr ""
 
-#: Gtk/DeleteWindow.vala:87 Gtk/MainWindow.vala:298
+#: Gtk/MainWindow.vala:310 Gtk/DeleteWindow.vala:89
 msgid "Snapshots"
 msgstr ""
 
-#: Gtk/SnapshotBackendBox.vala:163
+#: Gtk/SnapshotBackendBox.vala:169
 msgid ""
 "Snapshots are created and restored instantly. Snapshot creation is an atomic "
 "transaction at the file system level."
 msgstr ""
 
-#: Gtk/SnapshotBackendBox.vala:180
+#: Gtk/SnapshotBackendBox.vala:186
 msgid ""
 "Snapshots are created by creating copies of system files using rsync, and "
 "hard-linking unchanged files from previous snapshot."
 msgstr ""
 
-#: Gtk/SnapshotBackendBox.vala:161
+#: Gtk/SnapshotBackendBox.vala:167
 msgid ""
 "Snapshots are created using the built-in features of the BTRFS file system."
 msgstr ""
 
-#: Gtk/SnapshotBackendBox.vala:167
+#: Gtk/ScheduleBox.vala:167
+#, c-format
+msgid "Snapshots are not scheduled at fixed times."
+msgstr ""
+
+#: Gtk/SnapshotBackendBox.vala:173
 msgid ""
 "Snapshots are perfect, byte-for-byte copies of the system. Nothing is "
 "excluded."
 msgstr ""
 
-#: Gtk/SnapshotBackendBox.vala:165
+#: Gtk/SnapshotBackendBox.vala:171
 msgid ""
 "Snapshots are restored by replacing system subvolumes. Since files are never "
 "copied, deleted or overwritten, there is no risk of data loss. The existing "
 "system is preserved as a new snapshot after restore."
 msgstr ""
 
-#: Gtk/SnapshotBackendBox.vala:169
+#: Gtk/SnapshotBackendBox.vala:175
 msgid ""
 "Snapshots are saved on the same disk from which they are created (system "
 "disk). Storage on other disks is not supported. If system disk fails then "
 "snapshots stored on it will be lost along with the system."
 msgstr ""
 
-#: Gtk/MainWindow.vala:982
+#: Gtk/BackupDeviceBox.vala:107
+msgid ""
+"Snapshots are saved to /timeshift on selected partition. Other locations are "
+"not supported."
+msgstr ""
+
+#: Gtk/BackupDeviceBox.vala:99
+msgid ""
+"Snapshots are saved to /timeshift-btrfs on selected partition. Other "
+"locations are not supported."
+msgstr ""
+
+#: Gtk/MainWindow.vala:1012
 msgid "Snapshots available for restore"
 msgstr ""
 
-#: Gtk/SnapshotBackendBox.vala:184
+#: Gtk/SnapshotBackendBox.vala:190
 msgid ""
 "Snapshots can be saved to any disk formatted with a Linux file system. "
 "Saving snapshots to non-system or external disk allows the system to be "
 "restored even if system disk is damaged or re-formatted."
 msgstr ""
 
-#: Console/AppConsole.vala:281
+#: Console/AppConsole.vala:283
 msgid "Snapshots cannot be created in Live CD mode"
 msgstr ""
 
-#: Gtk/MainWindow.vala:1029
+#: Gtk/MainWindow.vala:1059
 msgid "Snapshots will be created at selected intervals"
 msgstr ""
 
-#: Gtk/ScheduleBox.vala:284
+#: Gtk/ScheduleBox.vala:306
 msgid ""
 "Snapshots will be created at selected intervals if snapshot disk has enough "
 "space (> 1 GB)"
 msgstr ""
 
-#: Gtk/MainWindow.vala:627
+#: Gtk/MainWindow.vala:642
 msgid "Snapshots will be removed during the next scheduled run"
 msgstr ""
 
-#: Console/AppConsole.vala:373
+#: Console/AppConsole.vala:375
 msgid "Specify backup device (default: config)"
 msgstr ""
 
-#: Console/AppConsole.vala:365
+#: Console/AppConsole.vala:367
 msgid "Specify device for installing GRUB2 bootloader"
 msgstr ""
 
-#: Console/AppConsole.vala:363
+#: Console/AppConsole.vala:365
 msgid "Specify snapshot to restore"
 msgstr ""
 
-#: Console/AppConsole.vala:364
+#: Console/AppConsole.vala:366
 msgid "Specify target device"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:436
+#: Core/SnapshotRepo.vala:480 Gtk/RsyncLogBox.vala:472
 #, c-format
 msgid "Status"
 msgstr ""
 
-#: Gtk/ScheduleBox.vala:162
+#: Gtk/ScheduleBox.vala:154
 msgid "Stop cron emails for scheduled tasks"
 msgstr ""
 
@@ -2157,169 +2254,180 @@ msgstr ""
 msgid "Stopped"
 msgstr ""
 
-#: Gtk/ExcludeAppsBox.vala:133 Gtk/RestoreWindow.vala:96
-#: Gtk/ExcludeBox.vala:210
+#: Core/Subvolume.vala:189
+#, c-format
+msgid "Subvolume exists at destination"
+msgstr ""
+
+#: Gtk/SnapshotListBox.vala:275
+#, c-format
+msgid "Subvolumes"
+msgstr ""
+
+#: Gtk/ExcludeAppsBox.vala:135 Gtk/ExcludeBox.vala:258
+#: Gtk/RestoreWindow.vala:120
 msgid "Summary"
 msgstr ""
 
-#: Console/AppConsole.vala:375
+#: Console/AppConsole.vala:377
 msgid "Switch to BTRFS mode (default: config)"
 msgstr ""
 
-#: Console/AppConsole.vala:376
+#: Console/AppConsole.vala:378
 msgid "Switch to RSYNC mode (default: config)"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:985
+#: Core/SnapshotRepo.vala:1029
 msgid "Symlinks updated"
 msgstr ""
 
-#: Core/Main.vala:2236
+#: Core/Main.vala:2382
 msgid "Synching file systems..."
 msgstr ""
 
-#: Core/Main.vala:1269 Core/Main.vala:2391 Core/Main.vala:2622
+#: Core/Main.vala:1361 Core/Main.vala:2544 Core/Main.vala:2785
 msgid "Synching files with rsync..."
 msgstr ""
 
-#: Gtk/AppGtk.vala:110
+#: Gtk/AppGtk.vala:112
 msgid "Syntax"
 msgstr ""
 
-#: Utility/Device.vala:1769 Gtk/SnapshotListBox.vala:127
+#: Utility/Device.vala:1837 Gtk/SnapshotListBox.vala:127
 #, c-format
 msgid "System"
 msgstr ""
 
-#: Gtk/MainWindow.vala:927
+#: Gtk/MainWindow.vala:957
 msgid "System Restore Utility"
 msgstr ""
 
-#: Gtk/FinishBox.vala:81
+#: Gtk/FinishBox.vala:82
 msgid "System can be rolled-back to a previous date by restoring a snapshot."
 msgstr ""
 
-#: Core/Main.vala:2110
+#: Core/Main.vala:2245
 msgid "System will reboot after files are restored"
 msgstr ""
 
-#: Core/Main.vala:2060
+#: Core/Main.vala:2195
 msgid "System will reboot after files are restored."
 msgstr ""
 
-#: Core/Main.vala:1129 Core/Main.vala:1170
+#: Core/Main.vala:1221 Core/Main.vala:1262
 msgid "Tagged snapshot"
 msgstr ""
 
-#: Console/AppConsole.vala:424 Gtk/SnapshotListBox.vala:151
+#: Console/AppConsole.vala:426 Gtk/SnapshotListBox.vala:151
 msgid "Tags"
 msgstr ""
 
-#: Core/Main.vala:1931
+#: Core/Main.vala:2057
 msgid "Target device is not mounted"
 msgstr ""
 
-#: Gtk/RestoreDeviceBox.vala:477
+#: Gtk/RestoreDeviceBox.vala:480
 msgid "Target device is same as system device"
 msgstr ""
 
-#: Core/Main.vala:1925
+#: Core/Main.vala:2051
 msgid "Target device not specified!"
 msgstr ""
 
-#: Gtk/SnapshotBackendBox.vala:117
+#: Gtk/SnapshotBackendBox.vala:118
 msgid ""
 "The 'btrfs' command is not available on your system. Install the 'btrfs-"
 "tools' package and try again."
 msgstr ""
 
-#: Gtk/ScheduleBox.vala:164
+#: Gtk/ScheduleBox.vala:156
 msgid ""
 "The cron service sends the output of scheduled tasks as an email to the "
 "current user. Select this option to suppress the emails for cron tasks "
 "created by Timeshift."
 msgstr ""
 
-#: Core/Main.vala:367
+#: Core/Main.vala:376
 msgid "The system partition has an unsupported subvolume layout."
 msgstr ""
 
-#: Core/Main.vala:3292
+#: Core/Main.vala:3431
 msgid "The target partition has an unsupported subvolume layout."
 msgstr ""
 
-#: Gtk/BackupDeviceBox.vala:417
+#: Gtk/BackupDeviceBox.vala:494
 #, c-format
 msgid "There are no snapshots on this device"
 msgstr ""
 
-#: Utility/Gtk/AboutWindow.vala:336
-#, c-format
-msgid "Third Party Tools"
-msgstr ""
-
-#: Utility/Device.vala:1191
+#: Utility/Device.vala:1259
 msgid "This device is not encrypted"
 msgstr ""
 
-#: Core/Main.vala:2076
+#: Core/Main.vala:2211
 msgid ""
 "This software comes without absolutely NO warranty and the author takes no "
 "responsibility for any damage arising from the use of this program."
 msgstr ""
 
-#: Gtk/MainWindow.vala:1017 Gtk/MainWindow.vala:1028
+#: Gtk/MainWindow.vala:1047 Gtk/MainWindow.vala:1058
 msgid "Timeshift is active"
 msgstr ""
 
-#: Gtk/BackupBox.vala:94 Gtk/RestoreBox.vala:131
+#: Gtk/MainWindow.vala:948
+msgid ""
+"Timeshift is powered by the following tools and components. Please visit the "
+"links for more information."
+msgstr ""
+
+#: Gtk/RsyncLogBox.vala:394 Gtk/RestoreBox.vala:132 Gtk/BackupBox.vala:94
+#, c-format
 msgid "Timestamp"
 msgstr ""
 
-#: Console/AppConsole.vala:609
+#: Console/AppConsole.vala:611
 #, c-format
 msgid "To restore with default options, press the ENTER key for all prompts!"
 msgstr ""
 
-#: Utility/Gtk/AboutWindow.vala:352
-#, c-format
-msgid "Translators"
+#: Utility/Gtk/AboutWindow.vala:441
+msgid "Translations"
 msgstr ""
 
-#: Console/AppConsole.vala:455 Console/AppConsole.vala:494
-#: Utility/Device.vala:1759 Gtk/SettingsWindow.vala:97
-#: Gtk/BackupDeviceBox.vala:173
+#: Utility/Device.vala:1827 Console/AppConsole.vala:457
+#: Console/AppConsole.vala:496 Gtk/BackupDeviceBox.vala:190
+#: Gtk/SettingsWindow.vala:86
 #, c-format
 msgid "Type"
 msgstr ""
 
-#: Utility/Device.vala:1758
+#: Utility/Device.vala:1826
 #, c-format
 msgid "UUID"
 msgstr ""
 
-#: Gtk/AppGtk.vala:97
+#: Gtk/AppGtk.vala:99
 msgid "Unknown option"
 msgstr ""
 
-#: Core/Main.vala:1111
+#: Core/Main.vala:1203
 msgid "Unknown snapshot type"
 msgstr ""
 
-#: Core/Main.vala:1456
+#: Core/Main.vala:1566
 msgid "Unknown value specified for option --tags"
 msgstr ""
 
-#: Utility/Device.vala:1202 Utility/Device.vala:1318
+#: Utility/Device.vala:1270 Utility/Device.vala:1386
 #, c-format
 msgid "Unlocked device is mapped to '%s'"
 msgstr ""
 
-#: Utility/Device.vala:1317
+#: Utility/Device.vala:1385
 msgid "Unlocked successfully"
 msgstr ""
 
-#: Utility/Device.vala:1532
+#: Utility/Device.vala:1600
 msgid "Unmounting from"
 msgstr ""
 
@@ -2327,173 +2435,173 @@ msgstr ""
 msgid "Unshared"
 msgstr ""
 
-#: Core/Main.vala:3296 Gtk/RestoreDeviceBox.vala:521
+#: Core/Main.vala:3435 Gtk/RestoreDeviceBox.vala:522
 msgid "Unsupported Subvolume Layout"
 msgstr ""
 
-#: Gtk/BootOptionsBox.vala:151
+#: Gtk/BootOptionsBox.vala:150
 msgid "Update GRUB menu"
 msgstr ""
 
-#: Gtk/BootOptionsBox.vala:136
+#: Gtk/BootOptionsBox.vala:135
 msgid "Update initramfs"
 msgstr ""
 
-#: Core/Main.vala:2566
+#: Core/Main.vala:2724
 msgid "Updated /etc/crypttab on target device"
 msgstr ""
 
-#: Core/Main.vala:2486
+#: Core/Main.vala:2644
 msgid "Updated /etc/fstab on target device"
 msgstr ""
 
-#: Gtk/BootOptionsBox.vala:153
+#: Gtk/BootOptionsBox.vala:152
 msgid ""
 "Updates the GRUB menu entries (recommended). This is safe to run and should "
 "be left selected."
 msgstr ""
 
-#: Core/Main.vala:2219
+#: Core/Main.vala:2365
 msgid "Updating GRUB menu..."
 msgstr ""
 
-#: Core/Main.vala:2410
+#: Core/Main.vala:2568
 msgid "Updating bootloader configuration..."
 msgstr ""
 
-#: Utility/Device.vala:1766
+#: Utility/Device.vala:1834
 #, c-format
 msgid "Used"
 msgstr ""
 
-#: Gtk/UsersBox.vala:98
+#: Gtk/SetupWizardWindow.vala:114 Gtk/UsersBox.vala:105
 msgid "User"
 msgstr ""
 
-#: Gtk/UsersBox.vala:58
+#: Gtk/UsersBox.vala:63
 msgid "User Home Directories"
 msgstr ""
 
-#: Utility/Device.vala:1272
+#: Utility/Device.vala:1340
 msgid "User cancelled the password prompt"
 msgstr ""
 
-#: Gtk/UsersBox.vala:65
+#: Gtk/UsersBox.vala:67
 msgid ""
 "User home directories are excluded by default unless you enable them here"
 msgstr ""
 
-#: Gtk/SettingsWindow.vala:109
+#: Gtk/SettingsWindow.vala:98
 msgid "Users"
 msgstr ""
 
-#: Utility/Device.vala:1743
+#: Gtk/RestoreWindow.vala:114
+msgid "Users Home"
+msgstr ""
+
+#: Utility/Device.vala:1811
 #, c-format
 msgid "Vendor"
 msgstr ""
 
-#: Gtk/SnapshotListBox.vala:313
-msgid "View Log for Create"
+#: Gtk/SnapshotListBox.vala:343
+msgid "View Rsync Log for Create"
 msgstr ""
 
-#: Gtk/SnapshotListBox.vala:320
-msgid "View Log for Restore"
+#: Gtk/SnapshotListBox.vala:350
+msgid "View Rsync Log for Restore"
 msgstr ""
 
-#: Gtk/MainWindow.vala:369
+#: Gtk/MainWindow.vala:378
 msgid "View TimeShift Logs"
-msgstr ""
-
-#: Gtk/RsyncLogWindow.vala:209
-msgid "View:"
 msgstr ""
 
 #: Gtk/RestoreDeviceBox.vala:101
 msgid "Volume"
 msgstr ""
 
-#: Core/Main.vala:1978 Gtk/RestoreSummaryBox.vala:53
+#: Core/Main.vala:2106 Gtk/RestoreSummaryBox.vala:53
 msgid "Warning"
 msgstr ""
 
-#: Gtk/RestoreExcludeBox.vala:86
+#: Gtk/RestoreExcludeBox.vala:61
 msgid "Web Browsers"
 msgstr ""
 
-#: Utility/Gtk/DonationWindow.vala:109
+#: Utility/Gtk/DonationWindow.vala:113
 #, c-format
 msgid "Website"
 msgstr ""
 
-#: Gtk/ScheduleBox.vala:79
+#: Gtk/ScheduleBox.vala:82 Gtk/SnapshotListBox.vala:301
 msgid "Weekly"
 msgstr ""
 
-#: Core/Main.vala:1015
+#: Core/Main.vala:1107
 msgid "Weekly snapshot failed!"
 msgstr ""
 
-#: Core/Main.vala:996
+#: Core/Main.vala:1088
 msgid "Weekly snapshots are enabled"
 msgstr ""
 
-#: Utility/Gtk/DonationWindow.vala:101
+#: Utility/Gtk/DonationWindow.vala:105
 msgid "Wiki ~ Documentation & Help"
 msgstr ""
 
-#: Gtk/DeleteFinishBox.vala:63 Gtk/BackupFinishBox.vala:63
+#: Gtk/BackupFinishBox.vala:63 Gtk/DeleteFinishBox.vala:63
 msgid "With Errors"
 msgstr ""
 
-#: Gtk/MainWindow.vala:188
+#: Gtk/MainWindow.vala:191
 msgid "Wizard"
 msgstr ""
 
-#: Utility/Device.vala:1245 Utility/Device.vala:1291
+#: Utility/Device.vala:1313 Utility/Device.vala:1359
 msgid "Wrong password"
 msgstr ""
 
-#: Utility/Gtk/CustomMessageDialog.vala:177
+#: Utility/Gtk/CustomMessageDialog.vala:176
 msgid "Yes"
 msgstr ""
 
-#: Gtk/RestoreFinishBox.vala:82
+#: Gtk/RestoreFinishBox.vala:98
 msgid ""
 "You can continue working on the current system. After restart, the current "
 "system will be visible as a new snapshot. This snapshot can be restored "
 "later if required, to 'undo' the restore."
 msgstr ""
 
-#: Gtk/RestoreDeviceBox.vala:411
+#: Gtk/RestoreDeviceBox.vala:413
 msgid ""
 "[Advanced Users Only] Change these settings only if the restored system "
 "fails to boot."
 msgstr ""
 
-#: Console/AppConsole.vala:1008
+#: Console/AppConsole.vala:1010
 #, c-format
 msgid "[ENTER = Default (%s), a = Abort]"
 msgstr ""
 
-#: Console/AppConsole.vala:879
+#: Console/AppConsole.vala:881
 #, c-format
 msgid "[ENTER = Default (%s), r = Root device, a = Abort]"
 msgstr ""
 
-#: Utility/AppLock.vala:55
+#: Utility/AppLock.vala:54
 msgid "[Warning] Deleted invalid lock"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:838
+#: Core/SnapshotRepo.vala:882
 msgid "all"
 msgstr ""
 
-#: Core/Main.vala:1384 Core/Main.vala:2714 Core/Main.vala:3716
-#: Core/Main.vala:3799 Core/Main.vala:3897 Core/Main.vala:3930
+#: Core/Subvolume.vala:201 Core/Main.vala:1494 Core/Main.vala:3862
+#: Core/Main.vala:3946 Core/Main.vala:4054 Core/Main.vala:4093
 msgid "btrfs returned an error"
 msgstr ""
 
-#: Core/Main.vala:1301 Core/Snapshot.vala:417
+#: Core/Main.vala:1393 Core/Snapshot.vala:500
 msgid "complete"
 msgstr ""
 
@@ -2505,27 +2613,28 @@ msgstr ""
 msgid "crontab file installed"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:824
+#: Core/SnapshotRepo.vala:868
 msgid "incomplete"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:806
+#: Core/SnapshotRepo.vala:850
 msgid "marked for deletion"
 msgstr ""
 
-#: Core/Main.vala:1193 Core/Main.vala:1345 Core/Main.vala:1347
+#: Core/Main.vala:1285 Core/Main.vala:1439 Core/Main.vala:1441
 msgid "mounted at path"
 msgstr ""
 
-#: Core/Main.vala:1301 Core/Snapshot.vala:418
+#: Core/Main.vala:1393 Core/Snapshot.vala:501 Gtk/DeleteBox.vala:149
+#: Gtk/RestoreBox.vala:237 Gtk/BackupBox.vala:234
 msgid "remaining"
 msgstr ""
 
-#: Core/Main.vala:1312
+#: Core/Main.vala:1404
 msgid "rsync returned an error"
 msgstr ""
 
-#: Core/SnapshotRepo.vala:670 Core/SnapshotRepo.vala:708
-#: Core/SnapshotRepo.vala:787
+#: Core/SnapshotRepo.vala:714 Core/SnapshotRepo.vala:752
+#: Core/SnapshotRepo.vala:831
 msgid "un-tagged"
 msgstr ""

--- a/src/makefile
+++ b/src/makefile
@@ -75,7 +75,7 @@ all:
 		-o ../${app_name}.pot
 
 	# translations
-	for lang in am ar az bg ca cs da de el en_GB es et eu fr he hi hr hu ia id is it ko lt nb ne nl pl pt pt_BR ro ru sk sr sv tr uk vi zh_CN; do \
+	for lang am ar az bg ca ca@valencia cs da de el en_GB es et eu fi fr he hi hr hu ia id is it ko lt nb ne nl pl pt pt_BR ro ru sk sr sv tr uk vi zh_CN zh_TW; do \
 		msgmerge --update -v ../po/${app_name}-$$lang.po ../${app_name}.pot ; \
 	done
 	
@@ -127,7 +127,7 @@ install:
 	install -m 0644 ../debian/${app_name}.appdata.xml "$(DESTDIR)$(sharedir)/metainfo"
 
 	# translations
-	for lang in am ar az bg ca cs da de el en_GB es et eu fr he hi hr hu ia id is it ko lt nb ne nl pl pt pt_BR ro ru sk sr sv tr uk vi zh_CN; do \
+	for lang in am ar az bg ca ca@valencia cs da de el en_GB es et eu fi fr he hi hr hu ia id is it ko lt nb ne nl pl pt pt_BR ro ru sk sr sv tr uk vi zh_CN zh_TW; do \
 		mkdir -p "$(DESTDIR)$(localedir)/$$lang/LC_MESSAGES"; \
 		msgfmt --check --verbose -o "$(DESTDIR)$(localedir)/$$lang/LC_MESSAGES/${app_name}.mo" ../po/${app_name}-$$lang.po ; \
 	done


### PR DESCRIPTION
@clefebvre sent me the PO files on Launchpad. I modified the merge-launchpad-translations.sh script (the original script may cause duplicate translations #208 ), merged the translations with this script, and added some new translations for zh_CN.

I hope I didn't break anything. I'm not very familiar with PO files.