### PR TITLE
Add support for dmraid

### DIFF
--- a/po/timeshift-it.po
+++ b/po/timeshift-it.po
@@ -71,6 +71,7 @@ msgstr "<b>Commenti</b> (doppio-clic per modificare)"
 msgid ""
 "A maintenance task runs once every hour and creates snapshots as needed."
 msgstr ""
+"Un comando pianificato viene eseguito ogni ora e crea uno snapshot all'occorrenza."
 
 #: Console/AppConsole.vala:698 Console/AppConsole.vala:762
 #: Console/AppConsole.vala:894 Console/AppConsole.vala:989
@@ -93,11 +94,11 @@ msgstr "Aggiungi"
 
 #: Gtk/ExcludeBox.vala:233
 msgid "Add Files"
-msgstr "Aggiungi File"
+msgstr "Aggiungi file"
 
 #: Gtk/ExcludeBox.vala:239
 msgid "Add Folders"
-msgstr "Aggiungi Cartelle"
+msgstr "Aggiungi cartelle"
 
 #: Gtk/ExcludeBox.vala:219
 msgid "Add custom pattern"
@@ -125,8 +126,7 @@ msgstr "Richiesto accesso come amministratore"
 
 #: Gtk/AppGtk.vala:126
 msgid "Admin access is required to backup and restore system files."
-msgstr ""
-"Per il salvataggio e il ripristino dei file di sistema è necessario "
+msgstr "Per il salvataggio e il ripristino dei file di sistema è necessario "
 "l'accesso come Amministratore."
 
 #: Gtk/RsyncLogBox.vala:363
@@ -271,17 +271,15 @@ msgstr "Diventa un Benefattore"
 
 #: Gtk/RestoreExcludeBox.vala:91
 msgid "Bittorrent Clients"
-msgstr "Clients Bittorrent"
+msgstr "Client Bittorrent"
 
 #: Gtk/ScheduleBox.vala:136 Gtk/SnapshotListBox.vala:298
 msgid "Boot"
-msgstr ""
-"All'avvio\n"
-"Avvio"
+msgstr "All'avvio"
 
 #: Gtk/RestoreDeviceBox.vala:499
 msgid "Boot device not selected"
-msgstr "Dispositivo di Avvio non selezionato"
+msgstr "Dispositivo di avvio non selezionato"
 
 #: Core/Main.vala:1017
 msgid "Boot snapshot failed!"
@@ -296,15 +294,15 @@ msgstr ""
 
 #: Core/Main.vala:998
 msgid "Boot snapshots are enabled"
-msgstr "Le Istantanee di avvio sono abilitate"
+msgstr "Le istantanee all'avvio sono abilitate"
 
 #: Gtk/BootOptionsWindow.vala:49
 msgid "Bootloader Options"
-msgstr "Opzioni del Bootloader"
+msgstr "Opzioni del bootloader"
 
 #: Gtk/RestoreDeviceBox.vala:411
 msgid "Bootloader Options (Advanced)"
-msgstr "Opzioni del Bootloader (Esperti)"
+msgstr "Opzioni del bootloader (Esperti)"
 
 #: Gtk/MainWindow.vala:171
 msgid "Browse"
@@ -312,7 +310,7 @@ msgstr "Esplora"
 
 #: Gtk/SnapshotListBox.vala:336
 msgid "Browse Files"
-msgstr "Sfoglia i File"
+msgstr "Sfoglia i file"
 
 #: Gtk/MainWindow.vala:172
 msgid "Browse selected snapshot"
@@ -348,7 +346,7 @@ msgstr ""
 
 #: Gtk/MainWindow.vala:563
 msgid "Cannot Delete Live Snapshot"
-msgstr "Impossibile Eliminare Live Snapshot"
+msgstr "Impossibile eliminare snapshot in uso"
 
 #: Gtk/RsyncLogBox.vala:380 Gtk/RsyncLogBox.vala:383 Gtk/RsyncLogBox.vala:567
 #: Gtk/RsyncLogBox.vala:588 Gtk/RestoreBox.vala:125 Gtk/BackupBox.vala:87
@@ -361,7 +359,7 @@ msgstr "Elementi modificati:"
 
 #: Gtk/RestoreWindow.vala:104
 msgid "Checking Restore Actions (Dry Run)"
-msgstr ""
+msgstr "Verifica ripristino (simulazione)"
 
 #: Core/Main.vala:2732
 msgid "Checking file systems for errors..."
@@ -378,16 +376,15 @@ msgstr "Pulizia in corso..."
 
 #: Gtk/UsersBox.vala:92 Gtk/ExcludeBox.vala:84
 msgid "Click to edit. Drag and drop to re-order."
-msgstr "Clicca per modificare. Trascina e rilascia per riordinare."
+msgstr "Clicca per modificare. Trascina per riordinare."
 
 #: Gtk/ExcludeBox.vala:59
-#, fuzzy
 msgid "Click to edit. Drag-drop to re-order."
-msgstr "Clicca per modificare. Trascina e rilascia per riordinare."
+msgstr "Clicca per modificare. Trascina per riordinare."
 
 #: Gtk/RestoreWindow.vala:69
 msgid "Clone System"
-msgstr "Clona Sistema"
+msgstr "Clona sistema"
 
 #: Console/AppConsole.vala:364
 msgid "Clone current system"
@@ -427,7 +424,7 @@ msgstr "Commenti"
 
 #: Core/Main.vala:2775 Gtk/RestoreBox.vala:74 Gtk/RestoreBox.vala:187
 msgid "Comparing Files (Dry Run)..."
-msgstr ""
+msgstr "Comparazione file (simulazione)..."
 
 #: Core/Main.vala:2541
 msgid "Comparing files with rsync..."
@@ -444,7 +441,7 @@ msgstr "Completato Con Errori"
 
 #: Gtk/RsyncLogBox.vala:87 Gtk/RestoreWindow.vala:109
 msgid "Confirm Actions"
-msgstr ""
+msgstr "Conferma azioni"
 
 #: Console/AppConsole.vala:1068
 #, c-format
@@ -470,9 +467,8 @@ msgstr "Impossibile trovare il sottovolume di sistema"
 
 #: Core/Main.vala:2974
 msgid "Could not find system subvolumes for creating pre-restore snapshot"
-msgstr ""
-"Impossibile trovare i sottovolumi di sistema per la creazione di snapshot di "
-"preripristino"
+msgstr "Impossibile trovare i sottovolumi di sistema per la creazione di snapshot di "
+"pre-ripristino"
 
 #: Gtk/RsyncLogBox.vala:366 Gtk/RsyncLogBox.vala:571 Gtk/MainWindow.vala:141
 #, c-format
@@ -481,7 +477,7 @@ msgstr "Crea"
 
 #: Gtk/BackupWindow.vala:61
 msgid "Create Snapshot"
-msgstr "Crea Immagine"
+msgstr "Crea istananea"
 
 #: Gtk/ScheduleBox.vala:136
 msgid "Create one per boot"
@@ -524,9 +520,8 @@ msgstr ""
 "proteggere il sistema"
 
 #: Gtk/SnapshotBackendBox.vala:95
-#, fuzzy
 msgid "Create snapshots using BTRFS"
-msgstr "Creare l'immagine usando RSYNC"
+msgstr "Crea istantanee usando BTRFS"
 
 #: Gtk/SnapshotBackendBox.vala:78
 msgid "Create snapshots using RSYNC tool and hard-links"
@@ -580,15 +575,15 @@ msgstr "Errore Critico"
 
 #: Utility/CronTab.vala:136
 msgid "Cron job added"
-msgstr "Cron Job aggiunto"
+msgstr "Operazione schedulata aggiunta"
 
 #: Utility/CronTab.vala:217
 msgid "Cron job removed"
-msgstr "Cron Job rimosso"
+msgstr "Operazione schedulata rimossa"
 
 #: Utility/CronTab.vala:304
 msgid "Cron task exists"
-msgstr "Il task di cron esiste"
+msgstr "L'operazione schedulata esiste"
 
 #: Gtk/ScheduleBox.vala:100 Gtk/SnapshotListBox.vala:300
 msgid "Daily"
@@ -615,7 +610,7 @@ msgstr "Elimina"
 
 #: Gtk/DeleteWindow.vala:62
 msgid "Delete Snapshots"
-msgstr "Elimina Istantanee"
+msgstr "Elimina istantanee"
 
 #: Console/AppConsole.vala:372
 msgid "Delete all snapshots"
@@ -646,7 +641,7 @@ msgstr "Il sottovolume è stato cancellato"
 
 #: Gtk/DeleteBox.vala:58
 msgid "Deleting Snapshots..."
-msgstr "Eliminazione Istantanee..."
+msgstr "Eliminazione istantanee..."
 
 #: Core/Subvolume.vala:141
 #, c-format
@@ -704,8 +699,7 @@ msgstr "Dispositivi con file system Linux"
 
 #: Gtk/RestoreDeviceBox.vala:84
 msgid "Devices from which snapshot was created are pre-selected."
-msgstr ""
-"I dispositivi da cui è stata creata l'istantanea sono stati preselezionati."
+msgstr "I dispositivi da cui è stata creata l'istantanea sono stati preselezionati."
 
 #: Console/AppConsole.vala:326
 msgid "Devices with Linux file systems"
@@ -713,7 +707,7 @@ msgstr "Dispositivi con file system Linux"
 
 #: Gtk/BackupDeviceBox.vala:105
 msgid "Devices with Windows file systems are not supported (NTFS, FAT, etc)."
-msgstr ""
+msgstr "Dispositivi con file system Windows non sono supportati (NTFS, FAT, ecc.)"
 
 #: Utility/Gtk/DonationWindow.vala:61
 msgid ""
@@ -798,7 +792,7 @@ msgstr "Donazioni"
 
 #: Gtk/UsersBox.vala:357
 msgid "Enable BTRFS qgroups (recommended)"
-msgstr ""
+msgstr "Abilita qgroup BTRFS (raccomandato)"
 
 #: Gtk/MainWindow.vala:1068
 msgid "Enable scheduled snapshots to protect your system"
@@ -838,12 +832,11 @@ msgstr "Inserisci il percorso o cerca la cartella"
 #: Console/AppConsole.vala:754
 #, c-format
 msgid "Enter snapshot number (a=Abort, p=Previous, n=Next)"
-msgstr ""
-"Inserisci il numero dell'instantanea (a=Annulla, p=Precedente, n=Succesivo)"
+msgstr "Inserisci il numero dell'instantanea (a=Annulla, p=Precedente, n=Successivo)"
 
 #: Gtk/ExcludeBox.vala:225
 msgid "Enter the pattern to exclude (Ex: *.mp3, *.bak)"
-msgstr "Inserisci lo schema di esclusione (es.: *.mp3, *.bak)"
+msgstr "Inserisci la maschera di esclusione (es.: *.mp3, *.bak)"
 
 #: Utility/GtkHelper.vala:18 Gtk/RestoreDeviceBox.vala:534
 msgid "Error"
@@ -851,7 +844,7 @@ msgstr "Errore"
 
 #: Gtk/RestoreWindow.vala:488
 msgid "Error running Rsync"
-msgstr ""
+msgstr "Errore nell'esecuzione di Rsync"
 
 #: Gtk/SetupWizardWindow.vala:99 Gtk/BackupWindow.vala:81
 msgid "Estimate"
@@ -871,25 +864,23 @@ msgstr "Esempi"
 
 #: Gtk/UsersBox.vala:136
 msgid "Exclude All"
-msgstr "Escludi Applicazioni"
+msgstr "Escludi tutto"
 
 #: Gtk/ExcludeAppsBox.vala:51 Gtk/RestoreExcludeBox.vala:55
 msgid "Exclude Application Settings"
-msgstr "Escludi Impostazioni Applicazione"
+msgstr "Escludi impostazioni applicazioni"
 
 #: Gtk/RestoreWindow.vala:99
 msgid "Exclude Apps"
-msgstr "Escludi Applicazioni"
+msgstr "Escludi applicazioni"
 
 #: Gtk/ExcludeMessageWindow.vala:70
 msgid "Exclude List"
-msgstr "Lista Esclusione"
+msgstr "Lista esclusioni"
 
 #: Gtk/ExcludeListSummaryWindow.vala:49
 msgid "Exclude List Summary"
-msgstr ""
-"Riepilogo Lista Esclusioni\n"
-"Sommario Lista Esclusioni"
+msgstr "Riepilogo lista esclusioni"
 
 #: Gtk/ExcludeBox.vala:224
 msgid "Exclude Pattern"
@@ -991,8 +982,7 @@ msgstr "Impossibile spostare il file"
 
 #: Core/Main.vala:2961
 msgid "Failed to move system subvolume to snapshot directory"
-msgstr ""
-"Impossibile spostare il sottovolume di sistema nella cartella degli snapshot"
+msgstr "Impossibile spostare il sottovolume di sistema nella cartella degli snapshot"
 
 #: Core/Main.vala:3863
 msgid "Failed to query subvolume list"
@@ -1045,9 +1035,7 @@ msgstr "Impossibile smontare"
 
 #: Core/Main.vala:3519
 msgid "Failed to unmount device!"
-msgstr ""
-"Impossibile smontare il dispositivo!\n"
-"Impossibile montare il dispositivo!"
+msgstr "Impossibile smontare il dispositivo!"
 
 #: Utility/TeeJee.FileSystem.vala:175
 msgid "Failed to write file"
@@ -1097,9 +1085,7 @@ msgstr "Conteggio file e cartelle:"
 
 #: Gtk/ExcludeMessageWindow.vala:76
 msgid "Files matching the following patterns will be excluded"
-msgstr ""
-"Saranno esclusi i file corrispondenti alle maschere seguenti\n"
-"Saranno esclusi i file corrispondenti ai seguenti modelli"
+msgstr "Saranno esclusi i file corrispondenti alle maschere seguenti"
 
 #: Utility/Device.vala:1828
 #, c-format
@@ -1133,7 +1119,7 @@ msgstr "La prima istantanea richiede:"
 
 #: Core/Main.vala:2894
 msgid "Found existing pre-restore snapshot"
-msgstr "Trovato snapshot pre-ripristino esistente"
+msgstr "Trovato uno snapshot pre-ripristino"
 
 #: Gtk/BackupDeviceBox.vala:215
 msgid "Free"
@@ -1141,9 +1127,7 @@ msgstr "Disponibile"
 
 #: Core/SnapshotRepo.vala:77 Core/SnapshotRepo.vala:147
 msgid "Free space"
-msgstr ""
-"Spazio disponibile\n"
-"Spazio libero"
+msgstr "Spazio disponibile"
 
 #: Console/AppConsole.vala:1042
 msgid "GRUB Device"
@@ -1212,7 +1196,7 @@ msgstr "Istantanee orarie abilitate"
 
 #: Utility/Gtk/AboutWindow.vala:457
 msgid "Icon Themes & Utilities"
-msgstr ""
+msgstr "Temi delle icone e programmi di supporto"
 
 #: Gtk/RestoreFinishBox.vala:102
 msgid ""
@@ -1232,7 +1216,7 @@ msgstr ""
 
 #: Gtk/ExcludeBox.vala:54
 msgid "Include / Exclude Patterns"
-msgstr "Maschere di Inclusione / esclusione"
+msgstr "Maschere di inclusione/esclusione"
 
 #: Gtk/UsersBox.vala:340
 msgid "Include @home subvolume in backups"
@@ -1240,7 +1224,7 @@ msgstr "Includi il sottovolume @home nei backup"
 
 #: Gtk/UsersBox.vala:266
 msgid "Include All"
-msgstr "Escludi Applicazioni"
+msgstr "Includi tutto"
 
 #: Gtk/UsersBox.vala:194
 msgid "Include Hidden"
@@ -1248,7 +1232,7 @@ msgstr "Includi elementi nascosti"
 
 #: Core/Main.vala:2026
 msgid "Invalid Snapshot"
-msgstr "Immagine non valida"
+msgstr "Istantanea non valida"
 
 #: Console/AppConsole.vala:251
 #, c-format
@@ -1257,11 +1241,11 @@ msgstr "Argomenti linea di comando non validi"
 
 #: Gtk/MainWindow.vala:824
 msgid "Invalid snapshot"
-msgstr "Immagine non valida"
+msgstr "Istantanea non valida"
 
 #: Utility/Gtk/DonationWindow.vala:97
 msgid "Issue Tracker ~ Report Issues, Request Features, Ask Questions"
-msgstr "Issue Tracker ~ Segnala Problemi, Richiedi Funzionalità, Fai Domande"
+msgstr "Issue Tracker ~ Segnala problemi, richiedi funzionalità, fai domande"
 
 #: Gtk/ExcludeBox.vala:272
 msgid "Items Not Selected"
@@ -1292,7 +1276,7 @@ msgstr ""
 
 #: Gtk/RestoreDeviceBox.vala:244
 msgid "Keep on Root Device"
-msgstr "Prosegui sul dispositivo di Root"
+msgstr "Prosegui sul dispositivo di root"
 
 #: Gtk/RestoreDeviceBox.vala:229
 msgid "Keep this mount path on the root filesystem"
@@ -1315,8 +1299,7 @@ msgstr "L'ultima istantanea di avvio è vecchia di %d ore"
 
 #: Core/Main.vala:1005
 msgid "Last boot snapshot is older than system start time"
-msgstr ""
-"L'ultima istantanea di avvio è più vecchia della data di avvio del sistema"
+msgstr "L'ultima istantanea di avvio è più vecchia della data di avvio del sistema"
 
 #: Core/Main.vala:1001
 msgid "Last boot snapshot not found"
@@ -1329,7 +1312,7 @@ msgstr "L'ultima istantanea giornaliera è vecchia di %d ore"
 
 #: Core/Main.vala:1065
 msgid "Last daily snapshot is more than 1 day old"
-msgstr "L'ultima istantanea giornaliera è più vecchia di 1 giorno"
+msgstr "L'ultima istantanea giornaliera è più vecchia di un giorno"
 
 #: Core/Main.vala:1061
 msgid "Last daily snapshot not found"
@@ -1342,7 +1325,7 @@ msgstr "L'ultima istantanea oraria è vecchia di %d ore"
 
 #: Core/Main.vala:1035
 msgid "Last hourly snapshot is more than 1 hour old"
-msgstr "L'ultima istantanea oraria è più vecchia di 1 ora"
+msgstr "L'ultima istantanea oraria è più vecchia di un'ora"
 
 #: Core/Main.vala:1031
 msgid "Last hourly snapshot not found"
@@ -1355,7 +1338,7 @@ msgstr "L'ultima istantanea mensile è vecchia di %d giorni"
 
 #: Core/Main.vala:1125
 msgid "Last monthly snapshot is more than 1 month old"
-msgstr "L'ultima istantanea mensile è più vecchia di 1 mese"
+msgstr "L'ultima istantanea mensile è più vecchia di un mese"
 
 #: Core/Main.vala:1121
 msgid "Last monthly snapshot not found"
@@ -1368,7 +1351,7 @@ msgstr "L'ultima istantanea settimanale è vecchia di %d giorni"
 
 #: Core/Main.vala:1095
 msgid "Last weekly snapshot is more than 1 week old"
-msgstr "L'ultima istantanea settimanale è più vecchia di 1 settimana"
+msgstr "L'ultima istantanea settimanale è più vecchia di una settimana"
 
 #: Core/Main.vala:1091
 msgid "Last weekly snapshot not found"
@@ -1381,12 +1364,12 @@ msgstr "Ultima istantanea"
 
 #: Utility/Gtk/AboutWindow.vala:316 Utility/Gtk/AboutWindow.vala:356
 msgid "License"
-msgstr ""
+msgstr "Licenza"
 
 #: Core/Main.vala:1344
 #, c-format
 msgid "Linking from snapshot"
-msgstr "Mi sto collegando dallo snapshot"
+msgstr "Collegamento dallo snapshot"
 
 #: Console/AppConsole.vala:352
 msgid "List"
@@ -1402,7 +1385,7 @@ msgstr "Elenco instantanee"
 
 #: Gtk/MainWindow.vala:1000
 msgid "Live USB Mode (Restore Only)"
-msgstr "Modalità Live USB (Solo Ripristino)"
+msgstr "Modalità Live USB (solo ripristino)"
 
 #: Gtk/SetupWizardWindow.vala:104 Gtk/BackupWindow.vala:86
 #: Gtk/SettingsWindow.vala:89
@@ -1431,11 +1414,11 @@ msgstr "Menu"
 
 #: Gtk/UsersBox.vala:354
 msgid "Miscellaneous"
-msgstr ""
+msgstr "Altro"
 
 #: Core/Main.vala:235
 msgid "Missing Dependencies"
-msgstr "Dipendenze Mancanti"
+msgstr "Dipendenze mancanti"
 
 #: Core/SnapshotRepo.vala:689
 #, c-format
@@ -1465,12 +1448,11 @@ msgstr "Monta"
 
 #: Core/Main.vala:2968
 msgid "Moved system subvolume to snapshot directory"
-msgstr ""
-"È stato spostato il sottovolume di sistema nella cartella degli snapshot"
+msgstr "Sottovolume di sistema spostato nella cartella degli snapshot"
 
 #: Gtk/MainWindow.vala:800
 msgid "Multiple snapshots selected"
-msgstr "Istantanee multiple selezionate"
+msgstr "Più istantanee selezionate"
 
 #: Console/AppConsole.vala:425 Gtk/RsyncLogBox.vala:492
 #: Gtk/BackupDeviceBox.vala:235
@@ -1492,7 +1474,7 @@ msgstr "Nessuna modifica"
 
 #: Gtk/MainWindow.vala:615 Gtk/DeleteWindow.vala:341
 msgid "No Snapshots Selected"
-msgstr "Nessuna Istantanea selezionata"
+msgstr "Nessuna istantanea selezionata"
 
 #: Gtk/MainWindow.vala:1073
 msgid "No snapshots available"
@@ -1509,7 +1491,7 @@ msgstr "Nessuna instantanea trovata sul dispositivo"
 
 #: Gtk/MainWindow.vala:553
 msgid "No snapshots on device"
-msgstr "Nessun istantanea sul dispositivo"
+msgstr "Nessuna istantanea sul dispositivo"
 
 #: Core/SnapshotRepo.vala:665
 msgid "No snapshots on this device"
@@ -1521,10 +1503,10 @@ msgstr "Nessuna istantanea selezionata"
 
 #: Gtk/MainWindow.vala:1050 Gtk/MainWindow.vala:1052
 msgid "None"
-msgstr "Niente"
+msgstr "Nessuna"
 
 #: Core/Subvolume.vala:184
-#, fuzzy, c-format
+#, c-format
 msgid "Not Found"
 msgstr "Cartella non trovata"
 
@@ -1587,7 +1569,7 @@ msgstr "Istantanea più vecchia"
 
 #: Gtk/SnapshotListBox.vala:297
 msgid "On demand (manual)"
-msgstr ""
+msgstr "Su richiesta (manuale)"
 
 #: Core/Main.vala:377 Core/Main.vala:3432 Gtk/RestoreDeviceBox.vala:525
 msgid ""
@@ -1624,11 +1606,11 @@ msgstr "Proprietario"
 #: Utility/Device.vala:1824
 #, c-format
 msgid "Parent Device"
-msgstr "Dispositivo Superiore"
+msgstr "Dispositivo contenitore"
 
 #: Core/Main.vala:2469 Core/Main.vala:2560 Gtk/RsyncLogBox.vala:222
 msgid "Parsing log file..."
-msgstr "Lettura file log..."
+msgstr "Lettura file di log..."
 
 #: Gtk/RestoreDeviceBox.vala:524
 msgid "Partition has an unsupported subvolume layout."
@@ -1662,8 +1644,7 @@ msgstr "Installare i pacchetti richiesti ed eseguire nuovamente TimeShift"
 
 #: Gtk/AppGtk.vala:127
 msgid "Please re-run the application as admin (using 'sudo' or 'su')"
-msgstr ""
-"Per favore riesegui l'applicazione come amministratore (usando 'sudo' o 'su')"
+msgstr "Riesegui l'applicazione come amministratore (usando 'sudo' o 'su')"
 
 #: Console/AppConsole.vala:103
 msgid "Please run the application as admin (using 'sudo' or 'su')"
@@ -1691,11 +1672,11 @@ msgstr "Attendere che le istantanee vengano eliminate."
 
 #: Gtk/EstimateBox.vala:66
 msgid "Please wait..."
-msgstr ""
+msgstr "Attendere prego..."
 
 #: Gtk/RsyncLogBox.vala:188
 msgid "Populating list..."
-msgstr "Riempimento della lista..."
+msgstr "Creazione della lista..."
 
 #: Core/Main.vala:1579 Gtk/RsyncLogBox.vala:232 Gtk/DeleteBox.vala:68
 #: Gtk/RestoreBox.vala:88 Gtk/BackupBox.vala:114
@@ -1709,7 +1690,7 @@ msgstr "Indietro"
 
 #: Gtk/AppGtk.vala:116
 msgid "Print debug information"
-msgstr "Stampa le informazioni di debug"
+msgstr "Stampa i messaggi di debug"
 
 #: Core/Main.vala:3794
 msgid "Query completed"
@@ -1717,7 +1698,7 @@ msgstr "Richiesta completata"
 
 #: Core/Main.vala:3777
 msgid "Querying subvolume info..."
-msgstr "Richiesta in corso delle informazioni del sottovolume..."
+msgstr "Richiesta delle informazioni del sottovolume in corso..."
 
 #: Gtk/SnapshotBackendBox.vala:77
 msgid "RSYNC"
@@ -1812,6 +1793,8 @@ msgid ""
 "Required for displaying shared and unshared size for snapshots in the main "
 "window"
 msgstr ""
+"Richiesto per visualizzare le dimensioni condivise e non per gli snapshot nella"
+"pagina principale"
 
 #: Console/AppConsole.vala:362 Gtk/RestoreFinishBox.vala:71
 #: Gtk/RsyncLogBox.vala:377 Gtk/RsyncLogBox.vala:567 Gtk/MainWindow.vala:151
@@ -1820,21 +1803,20 @@ msgid "Restore"
 msgstr "Ripristina"
 
 #: Gtk/UsersBox.vala:329
-#, fuzzy
 msgid "Restore @home subvolume"
-msgstr "Sottovolume di sistema ripristinato"
+msgstr "Ripristina sottovolume @home"
 
 #: Gtk/RestoreWindow.vala:89
 msgid "Restore Device"
-msgstr "Ripristino del dispositivo"
+msgstr "Ripristina dispositivo"
 
 #: Gtk/RestoreWindow.vala:94
 msgid "Restore Exclude"
-msgstr "Ripristina Escludi"
+msgstr "Esclusioni ripristino"
 
 #: Gtk/RestoreWindow.vala:69
 msgid "Restore Snapshot"
-msgstr "Ripristina Istantanea"
+msgstr "Ripristina istantanea"
 
 #: Core/Main.vala:2809 Core/Main.vala:2851
 msgid "Restore completed"
@@ -1850,8 +1832,7 @@ msgstr "Ripristina instantanea"
 
 #: Gtk/RestoreFinishBox.vala:96
 msgid "Restored subvolumes will become active after system is restarted."
-msgstr ""
-"I sottovolumi ripristinati diventeranno attivi dopo il riavvio del sistema."
+msgstr "I sottovolumi ripristinati diventeranno attivi dopo il riavvio del sistema."
 
 #: Core/Subvolume.vala:206
 msgid "Restored system subvolume"
@@ -1902,13 +1883,12 @@ msgstr "Dispositivo root non selezionato"
 
 #: Gtk/RsyncLogWindow.vala:49
 msgid "Rsync Log Viewer"
-msgstr ""
+msgstr "Visualizzatore log Rsync"
 
 #: Gtk/AppGtk.vala:119
 #, c-format
 msgid "Run 'timeshift' for the command-line version of this tool"
-msgstr ""
-"Esegui 'timeshift' per la versione da riga di comando di questo strumento"
+msgstr "Esegui 'timeshift' per la versione da riga di comando di questo strumento"
 
 #: Console/AppConsole.vala:382
 msgid "Run in non-interactive mode"
@@ -1956,8 +1936,7 @@ msgstr "Le istantanee pianificate sono disabilitate"
 
 #: Gtk/FinishBox.vala:78
 msgid "Scheduled snapshots are disabled. It's recommended to enable it."
-msgstr ""
-"Le istantanee pianificate sono disabilitate. Si consiglia di abilitarle."
+msgstr "Le istantanee pianificate sono disabilitate. Si consiglia di abilitarle."
 
 #: Gtk/ScheduleBox.vala:305
 msgid "Scheduled snapshots are enabled"
@@ -1986,27 +1965,27 @@ msgstr "Seleziona il dispositivo GRUB"
 
 #: Utility/GtkHelper.vala:815
 msgid "Select Path"
-msgstr "Seleziona Percorso"
+msgstr "Seleziona percorso"
 
 #: Gtk/MainWindow.vala:694
 msgid "Select Snapshot"
-msgstr "Seleziona Istantanea"
+msgstr "Seleziona istantanea"
 
 #: Gtk/ScheduleBox.vala:57
 msgid "Select Snapshot Levels"
-msgstr "Seleziona Cadenza Istantanee"
+msgstr "Seleziona cadenza istantanee"
 
 #: Gtk/BackupDeviceBox.vala:56
 msgid "Select Snapshot Location"
-msgstr "Seleziona Posizione Istantanee"
+msgstr "Seleziona posizione istantanee"
 
 #: Gtk/SnapshotBackendBox.vala:62
 msgid "Select Snapshot Type"
-msgstr "Seleziona Tipo Istantanea"
+msgstr "Seleziona tipo istantanea"
 
 #: Gtk/DeleteWindow.vala:85
 msgid "Select Snapshots"
-msgstr "Seleziona Istantanee"
+msgstr "Seleziona istantanee"
 
 #: Gtk/RestoreDeviceBox.vala:61
 msgid "Select Target Device"
@@ -2095,8 +2074,7 @@ msgstr "Selezionare le istantanee da segnare per l'eliminazione"
 
 #: Gtk/RestoreDeviceBox.vala:79
 msgid "Select the target devices where system will be cloned."
-msgstr ""
-"Seleziona i dispositivi di destinazione in cui il sistema verrà clonato."
+msgstr "Seleziona i dispositivi di destinazione in cui il sistema verrà clonato."
 
 #: Core/Main.vala:3242
 msgid "Selected default snapshot device"
@@ -2128,8 +2106,7 @@ msgstr "L'istantanea selezionata è segnata per l'eliminazione"
 
 #: Gtk/MainWindow.vala:825
 msgid "Selected snapshot is marked for deletion and cannot be restored"
-msgstr ""
-"L'istantanea selezionata è segnata per l'eliminazione e non può essere "
+msgstr "L'istantanea selezionata è segnata per l'eliminazione e non può essere "
 "ripristinata"
 
 #: Gtk/UsersBox.vala:238
@@ -2341,12 +2318,16 @@ msgid ""
 "Snapshots are saved to /timeshift on selected partition. Other locations are "
 "not supported."
 msgstr ""
+"Le istantanee vengono salvate nella cartella /timeshift sulla partizione selezionata."
+"Altre posizioni non sono supportate."
 
 #: Gtk/BackupDeviceBox.vala:99
 msgid ""
 "Snapshots are saved to /timeshift-btrfs on selected partition. Other "
 "locations are not supported."
 msgstr ""
+"Le istantanee vengono salvate nella cartella /timeshift-btrfs sulla partizione"
+"selezionata. Altre posizioni non sono supportate."
 
 #: Gtk/MainWindow.vala:1012
 msgid "Snapshots available for restore"
@@ -2381,8 +2362,7 @@ msgstr ""
 
 #: Gtk/MainWindow.vala:642
 msgid "Snapshots will be removed during the next scheduled run"
-msgstr ""
-"Le istantanee saranno rimosse durante la successiva esecuzione pianificata"
+msgstr "Le istantanee saranno rimosse durante la successiva esecuzione pianificata"
 
 #: Console/AppConsole.vala:375
 msgid "Specify backup device (default: config)"
@@ -2416,12 +2396,12 @@ msgstr "Fermato"
 #: Core/Subvolume.vala:189
 #, c-format
 msgid "Subvolume exists at destination"
-msgstr ""
+msgstr "La destinazione presenta un sottovolume"
 
 #: Gtk/SnapshotListBox.vala:275
-#, fuzzy, c-format
+#, c-format
 msgid "Subvolumes"
-msgstr "Volume"
+msgstr "Sottovolumi"
 
 #: Gtk/ExcludeAppsBox.vala:135 Gtk/ExcludeBox.vala:258
 #: Gtk/RestoreWindow.vala:120
@@ -2463,8 +2443,7 @@ msgstr "Utilità per il ripristino del sistema"
 
 #: Gtk/FinishBox.vala:82
 msgid "System can be rolled-back to a previous date by restoring a snapshot."
-msgstr ""
-"Il sistema può essere ripristinato a una data precedente ripristinando uno "
+msgstr "Il sistema può essere ripristinato a una data precedente ripristinando uno "
 "snapshot."
 
 #: Core/Main.vala:2245
@@ -2515,13 +2494,11 @@ msgstr ""
 
 #: Core/Main.vala:376
 msgid "The system partition has an unsupported subvolume layout."
-msgstr ""
-"La partizione di sistema ha un layout di volume secondario non supportato."
+msgstr "La partizione di sistema ha un layout di volume secondario non supportato."
 
 #: Core/Main.vala:3431
 msgid "The target partition has an unsupported subvolume layout."
-msgstr ""
-"La partizione di destinazione ha un layout di volume secondario non "
+msgstr "La partizione di destinazione ha un layout di volume secondario non "
 "supportato."
 
 #: Gtk/BackupDeviceBox.vala:494
@@ -2550,17 +2527,18 @@ msgid ""
 "Timeshift is powered by the following tools and components. Please visit the "
 "links for more information."
 msgstr ""
+"Timeshift si basa sui dispositivi e componenti di seguito. Visita i link "
+"per avere più informazioni"
 
 #: Gtk/RsyncLogBox.vala:394 Gtk/RestoreBox.vala:132 Gtk/BackupBox.vala:94
 #, c-format
 msgid "Timestamp"
-msgstr "Marcatura oraria"
+msgstr "Orario"
 
 #: Console/AppConsole.vala:611
 #, c-format
 msgid "To restore with default options, press the ENTER key for all prompts!"
-msgstr ""
-"Per ripristinare con le opzioni predefinite, premi il tasto INVIO per tutte "
+msgstr "Per ripristinare con le opzioni predefinite, premi il tasto INVIO per tutte "
 "le richieste!"
 
 #: Utility/Gtk/AboutWindow.vala:441
@@ -2633,7 +2611,7 @@ msgid ""
 "Updates the GRUB menu entries (recommended). This is safe to run and should "
 "be left selected."
 msgstr ""
-"Aggiorna le voci del menu di GRUB (consigliato). Questo è sicuro da eseguire "
+"Aggiorna le voci del menu di GRUB (consigliato). È sicuro da eseguire "
 "e dovrebbe essere lasciato selezionato."
 
 #: Core/Main.vala:2365
@@ -2655,7 +2633,7 @@ msgstr "Utente"
 
 #: Gtk/UsersBox.vala:63
 msgid "User Home Directories"
-msgstr "Cartelle Home Utenti"
+msgstr "Cartelle file personali"
 
 #: Utility/Device.vala:1340
 msgid "User cancelled the password prompt"
@@ -2665,7 +2643,7 @@ msgstr "L'utente ha annullato la richiesta della password"
 msgid ""
 "User home directories are excluded by default unless you enable them here"
 msgstr ""
-"Le cartelle Home degli utenti sono escluse per impostazione predefinita se "
+"Le cartelle personali degli utenti sono escluse per impostazione predefinita se "
 "non le abiliti qui"
 
 #: Gtk/SettingsWindow.vala:98
@@ -2673,9 +2651,8 @@ msgid "Users"
 msgstr "Utenti"
 
 #: Gtk/RestoreWindow.vala:114
-#, fuzzy
 msgid "Users Home"
-msgstr "Utenti"
+msgstr "Cartelle personali"
 
 #: Utility/Device.vala:1811
 #, c-format
@@ -2684,15 +2661,15 @@ msgstr "Produttore"
 
 #: Gtk/SnapshotListBox.vala:343
 msgid "View Rsync Log for Create"
-msgstr ""
+msgstr "Visualizza i log di Rsync per la creazione"
 
 #: Gtk/SnapshotListBox.vala:350
 msgid "View Rsync Log for Restore"
-msgstr ""
+msgstr "Visualizza i log di Rsync per il ripristino"
 
 #: Gtk/MainWindow.vala:378
 msgid "View TimeShift Logs"
-msgstr "Visualizza Log Timeshift"
+msgstr "Visualizza log Timeshift"
 
 #: Gtk/RestoreDeviceBox.vala:101
 msgid "Volume"
@@ -2729,11 +2706,11 @@ msgstr "Wiki ~ Documentazione e Aiuto"
 
 #: Gtk/BackupFinishBox.vala:63 Gtk/DeleteFinishBox.vala:63
 msgid "With Errors"
-msgstr "Con Errori"
+msgstr "Con errori"
 
 #: Gtk/MainWindow.vala:191
 msgid "Wizard"
-msgstr "Configurazione Guidata"
+msgstr "Configurazione guidata"
 
 #: Utility/Device.vala:1313 Utility/Device.vala:1359
 msgid "Wrong password"
@@ -2741,7 +2718,7 @@ msgstr "Password errata"
 
 #: Utility/Gtk/CustomMessageDialog.vala:176
 msgid "Yes"
-msgstr "Si"
+msgstr "Sì"
 
 #: Gtk/RestoreFinishBox.vala:98
 msgid ""
@@ -2759,7 +2736,7 @@ msgid ""
 "[Advanced Users Only] Change these settings only if the restored system "
 "fails to boot."
 msgstr ""
-"[Solo Utenti Esperti] Cambia queste impostazioni solo se il sistema "
+"[Solo utenti esperti] Cambia queste impostazioni solo se il sistema "
 "ripristinato non si avvia."
 
 #: Console/AppConsole.vala:1010
@@ -2770,7 +2747,7 @@ msgstr "[INVIO = Predefinito (%s), a = Annulla]"
 #: Console/AppConsole.vala:881
 #, c-format
 msgid "[ENTER = Default (%s), r = Root device, a = Abort]"
-msgstr "[Invio = Predefinito (%s), r = Dispositivo di Root, a = Annulla]"
+msgstr "[Invio = Predefinito (%s), r = Dispositivo di root, a = Annulla]"
 
 #: Utility/AppLock.vala:54
 msgid "[Warning] Deleted invalid lock"


### PR DESCRIPTION
I added some code to fix the partitions list when dmraid is used. The dmraid device is presented as a disk and its partitions as possible snapshot containers; the single member disks are removed.

I tested it by taking a base snapshot and an incremental one, seems to work. Note: I can only test the raid-1 case, but it should not be different with other raid levels.

I also updated the italian translations. Some were completely wrong, like "include" for "exclude" and so on.