### PR TITLE
Add makepot file

### DIFF
--- a/makepot
+++ b/makepot
@@ -1,0 +1,6 @@
+find . -name "*.vala" > POTFILES
+
+xgettext --language=Vala --keyword=_ --output=timeshift.pot --files-from=POTFILES
+xgettext --output=timeshift.pot --join-existing src/share/polkit-1/actions/*.policy
+
+rm POTFILES


### PR DESCRIPTION
This script creates the translation template `timeshift.pot`

It catches all `.vala` files and the translation string from the `.policy` file, which are currently missing.
After merging this, you'll need to run this script to update the template.
I didn't do this, because I don't want to bloat the pull request.