### PR TITLE
Update timeshift-es.po

### DIFF
--- a/po/timeshift-es.po
+++ b/po/timeshift-es.po
@@ -861,7 +861,7 @@ msgstr "Ejemplos"
 
 #: Gtk/UsersBox.vala:136
 msgid "Exclude All"
-msgstr "Excluir aplicaciones"
+msgstr "Excluir todo"
 
 #: Gtk/ExcludeAppsBox.vala:51 Gtk/RestoreExcludeBox.vala:55
 msgid "Exclude Application Settings"
@@ -1218,7 +1218,7 @@ msgstr "Incluir subvolumen @home en las copias"
 
 #: Gtk/UsersBox.vala:266
 msgid "Include All"
-msgstr "Excluir aplicaciones"
+msgstr "Incluir todo"
 
 #: Gtk/UsersBox.vala:194
 msgid "Include Hidden"


### PR DESCRIPTION
Changed strings affected with issue #275 
Some translations on timeshift-es.po are wrong
Line 864
msgstr "Excluir aplicaciones"
has to be
msgstr "Excluir todo"
Aplicaciones is spanish for applications not a trasnlation of All
Line 1221
msgstr "Excluir aplicaciones"
has to be
msgstr "Incluir todo"
The message string is totally wrong signifies the contrary of the english string "Include All"