### PR TITLE
Added support for writable loop devices and LVM

### DIFF
--- a/src/Core/Main.vala
+++ b/src/Core/Main.vala
@@ -3328,12 +3328,29 @@ public class Main : GLib.Object{
 		sys_home = null;
 
 		foreach(var pi in partitions){
+			if ((app_mode == "")||(LOG_DEBUG)){
+				log_debug("Partition \"%s\" on device \"%s\" : read-only = %s.".printf(
+					pi.name,
+					pi.device, 
+					pi.read_only.to_string()
+				));
+			}
+
+			if ( pi.read_only ) { 
+				continue;
+			}
 			
 			foreach(var mp in pi.mount_points){
 				
 				// skip loop devices - Fedora Live uses loop devices containing ext4-formatted lvm volumes
 				if ((pi.type == "loop") || (pi.has_parent() && (pi.parent.type == "loop"))){
-					continue;
+					if ((app_mode == "")||(LOG_DEBUG)){
+						log_debug("Mount point \"%s\" : read-only = %s.".printf(mp.mount_point, mp.read_only.to_string()));
+					}
+
+					if ( mp.read_only ) { 
+						continue;
+					}
 				}
 
 				if (mp.mount_point == "/"){

--- a/src/Gtk/SettingsWindow.vala
+++ b/src/Gtk/SettingsWindow.vala
@@ -45,7 +45,7 @@ class SettingsWindow : Gtk.Window{
 	private UsersBox users_box;
 
 	private uint tmr_init;
-	private int def_width = 500;
+	private int def_width = 640;
 	private int def_height = 500;
 	
 	public SettingsWindow() {

--- a/src/Utility/Device.vala
+++ b/src/Utility/Device.vala
@@ -380,6 +380,7 @@ public class Device : GLib.Object{
 		test_lsblk_version();
 
 		var list = new Gee.ArrayList<Device>();
+		var knames_check_list = new Gee.HashSet<string>();
 
 		string std_out;
 		string std_err;
@@ -441,6 +442,19 @@ public class Device : GLib.Object{
 					
 					pi.name = match.fetch(++pos).strip();
 					pi.kname = match.fetch(++pos).strip();
+
+					if ( knames_check_list.contains(pi.kname) ) {
+						if (LOG_DEBUG) {
+							log_debug("Device \"%s\" with same kname \"%s\" already added.".printf(
+								pi.name,
+								pi.kname
+							));
+						}
+
+						continue;
+					} else {
+						knames_check_list.add(pi.kname);
+					}
 					
 					pi.label = match.fetch(++pos); // don't strip; labels can have leading or trailing spaces
 					pi.uuid = match.fetch(++pos).strip();

--- a/src/Utility/MountEntry.vala
+++ b/src/Utility/MountEntry.vala
@@ -12,11 +12,24 @@ public class MountEntry : GLib.Object{
 	public Device device = null;
 	public string mount_point = "";
 	public string mount_options = "";
+	public bool read_only = false;
 	
 	public MountEntry(Device? device, string mount_point, string mount_options){
 		this.device = device;
 		this.mount_point = mount_point;
 		this.mount_options = mount_options;
+
+		foreach (string option in mount_options.split(",")) {
+			option = option.strip();
+
+			if ("ro" == option) {
+				this.read_only = true;
+				break;
+			} else if ("rw" == option) {
+				this.read_only = false;
+				break;
+			} 
+		}
 	}
 
 	public string subvolume_name(){


### PR DESCRIPTION
Hi, I am the author of the project [Buddy Linux](https://github.com/antonio-petricca/buddy-linux) which allows to install Linux on  **loopback LVM writable** devices, storing the boot partition on a removable USB device.

I observed that Timeshift (in my case):
- Starts in restore/only mode, but this is wrong because my distribution is a true linux with writable partitions.
- Does not recognize LVM volumes.

For that reason I have extended it to support that features with the intention to contibute to your excellent tools.

Here the full **changelog**:

- **BackupDeviceBox.vala**
  - Allowed discovery of LVM partitions.
  - Replaced disk label shown as 'disk size' with 'partition name'. The size is already shown in another column.
  - Added UUID column.
- **Device.vala**
  - LVM partitions, splitted among multiple devices, are no more added multiple times.
- **Main.vala**
  - Allowed writable loopback devices.
- **MountEntry.vala**
  - Added _read_only_ property.
- **SettingsWindow.vala**
  - Extended width to 640px to fit with the added UUID column.

Regards,
Antonio  Petricca