### PR TITLE
Gnome notifications fix

### DIFF
--- a/src/Utility/OSDNotify.vala
+++ b/src/Utility/OSDNotify.vala
@@ -63,8 +63,11 @@ public class OSDNotify : GLib.Object {
 			
 			if (cmd_exists("notify-send")){
 				
-				string s = "notify-send -t %d -u %s -i %s \"%s\" \"%s\"".printf(
-					durationMillis, urgency, "gtk-dialog-" + dialog_type, title, message);
+				string desktop_entry = "timeshift-gtk";
+				string hint = "string:desktop-entry:%s".printf(desktop_entry);
+
+				string s = "notify-send -t %d -u %s -i %s \"%s\" \"%s\" -h %s".printf(
+					durationMillis, urgency, "gtk-dialog-" + dialog_type, title, message, hint);
 					
 				retVal = exec_sync (s, null, null);
 				

--- a/src/timeshift-gtk.desktop
+++ b/src/timeshift-gtk.desktop
@@ -19,3 +19,4 @@ Comment[lt]=Sistemos atkūrimo paslaugų programa
 Comment[ru]=Программа для восстановления системы
 X-KDE-StartupNotify=false
 Categories=System;
+X-GNOME-UsesNotifications=true


### PR DESCRIPTION
Due to Gnome Guidelines https://wiki.gnome.org/Initiatives/GnomeGoals/NotificationSource

Now, due to the absence of these parameters, notifications from the timeshift are displayed as "Others"