### PR TITLE
Main: Update snapshot list after each snapshot is taken (fixes double/nested snapshots)

### DIFF
--- a/src/Core/Main.vala
+++ b/src/Core/Main.vala
@@ -1019,6 +1019,7 @@ public class Main : GLib.Object{
 						}
 						else{
 							update_symlinks = true;
+							repo.load_snapshots();
 						}
 					}
 				}
@@ -1049,6 +1050,7 @@ public class Main : GLib.Object{
 						}
 						else{
 							update_symlinks = true;
+							repo.load_snapshots();
 						}
 					}
 				}
@@ -1079,6 +1081,7 @@ public class Main : GLib.Object{
 						}
 						else{
 							update_symlinks = true;
+							repo.load_snapshots();
 						}
 					}
 				}
@@ -1109,6 +1112,7 @@ public class Main : GLib.Object{
 						}
 						else{
 							update_symlinks = true;
+							repo.load_snapshots();
 						}
 					}
 				}
@@ -1139,6 +1143,7 @@ public class Main : GLib.Object{
 						}
 						else{
 							update_symlinks = true;
+							repo.load_snapshots();
 						}
 					}
 				}


### PR DESCRIPTION
This should fix the issue in #141  (at least for my case)

When automatic snapshots are taken for daily, weekly, monthly, etc. there are cases when a snapshot at a single point in time should be tagged with multiple (D, W, M). As it is now, if multiple snapshot types are scheduled for creation on the same run of `timeshift --check`, it will try to create 2 snapshots, resulting in nested snapshots.

This fix makes sure the repo snapshot list is updated immediately after a snapshot is taken (e.g., Daily), so that the next case down (e.g. Weekly) only adds the appropriate tag instead of trying to create a new snapshot.