### PR TITLE
Exclude /snap by default

### DIFF
--- a/src/Core/Main.vala
+++ b/src/Core/Main.vala
@@ -555,6 +555,7 @@ public class Main : GLib.Object{
 		exclude_list_default.add("/var/log/timeshift/*");
 		exclude_list_default.add("/var/log/timeshift-btrfs/*");
 		exclude_list_default.add("/swapfile");
+		exclude_list_default.add("/snap");
 
 		foreach(var entry in FsTabEntry.read_file("/etc/fstab")){
 


### PR DESCRIPTION
Closes gh-345

If I understand the code correctly this should do the trick. I don't know Vala code so I'd appreciate your feedback if I did something completely silly.