### PR TITLE
Fix po/timeshift-nl.po

### DIFF
--- a/po/timeshift-nl.po
+++ b/po/timeshift-nl.po
@@ -1778,7 +1778,7 @@ msgstr "Momentopnamen verwijderen"
 msgid ""
 "Required for displaying shared and unshared size for snapshots in the main "
 "window"
-msgstr " "Vereist voor het weergeven van gedeelde en niet-gedeelde grootte voor snapshots in het hoofdmenu "
+msgstr "Vereist voor het weergeven van gedeelde en niet-gedeelde grootte voor snapshots in het hoofdmenu "
 "venster"
 
 #: Console/AppConsole.vala:362 Gtk/RestoreFinishBox.vala:71


### PR DESCRIPTION
It was wrongly formatted and thus was excluded from the build, leading to no Dutch translations at runtime.