### PR TITLE
Fix #454

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Packages are available in the Launchpad PPA for supported Ubuntu releases.
 Run the following commands in a terminal window:  
 
 ```sh
-sudo add-apt-repository -y ppa:teejee2008/ppa
+sudo add-apt-repository -y ppa:teejee2008/timeshift
 sudo apt-get update
 sudo apt-get install timeshift
 ```


### PR DESCRIPTION
Changed Ubuntu installation instruction from pointing to legacy development ppa. Newly it should be correctly pointing to new release ppa (did I understand correctly please?).