### PR TITLE
Update AsyncTask.vala

### DIFF
--- a/src/Utility/AsyncTask.vala
+++ b/src/Utility/AsyncTask.vala
@@ -73,7 +73,7 @@ public abstract class AsyncTask : GLib.Object{
 	public signal void stderr_line_read(string line);
 	public signal void task_complete();
 
-	public AsyncTask(){
+	protected AsyncTask(){
 		working_dir = TEMP_DIR + "/" + timestamp_for_path();
 		script_file = path_combine(working_dir, "script.sh");
 		log_file = path_combine(working_dir, "task.log");


### PR DESCRIPTION
Fix error when building from source
```
Utility/AsyncTask.vala:76.2-76.17: error: Creation method of abstract class cannot be public.
public AsyncTask(){
^^^^^^^^^^^^^^^^
```