### PR TITLE
Recognize "zfs_member" as a linux filesystem

### DIFF
--- a/src/Utility/Device.vala
+++ b/src/Utility/Device.vala
@@ -184,6 +184,7 @@ public class Device : GLib.Object{
 			case "xfs":
 			case "jfs":
 			case "zfs":
+			case "zfs_member":
 			case "btrfs":
 			case "lvm":
 			case "lvm2":


### PR DESCRIPTION
You added "zfs" with https://github.com/teejee2008/timeshift/commit/600d014930468c172dd96b1895e5f9e688c58dc6 but a ZFS pool has fstype "zfs_member".