### PR TITLE
Improve clarity of column headers

### DIFF
--- a/src/Gtk/UsersBox.vala
+++ b/src/Gtk/UsersBox.vala
@@ -133,7 +133,7 @@ class UsersBox : Gtk.Box{
 		// column -------------------------------------------------
 		
 		col = new TreeViewColumn();
-		col.title = _("Exclude All");
+		col.title = _("Exclude All Files");
 		treeview.append_column(col);
 		
 		// radio_exclude
@@ -191,7 +191,7 @@ class UsersBox : Gtk.Box{
 		// column -------------------------------------------------
 		
 		col = new TreeViewColumn();
-		col.title = _("Include Hidden");
+		col.title = _("Include Only Hidden Files");
 		treeview.append_column(col);
 		
 		// radio_include
@@ -263,7 +263,7 @@ class UsersBox : Gtk.Box{
 		// column --------------------------------------------
 		
 		col = new TreeViewColumn();
-		col.title = _("Include All");
+		col.title = _("Include All Files");
 		treeview.append_column(col);
 
 		// radio_exclude


### PR DESCRIPTION
I recently discovered that timeshift had only been backing up hidden files, and not all files as I believed, despite my having used the configuration dialog several times.

The column header "Include Hidden" suggested to me that hidden files would be included *in addition to* regular files, the same way the `ls` command shows hidden files in addition to regular files with the `-a` flag and the same way GNOME's file manager shows hidden files in addition to regular files when the appropriate checkbox is enabled.

I have consequently found myself in a recovery situation, and have discovered that I have permanently lost files of sentimental value. Hopefully this improved verbiage will make it clear to users that timeshift does not follow the same conventions that other tools do.