### PR TITLE
fix(timeshift-de.po): correct typo

### DIFF
--- a/po/timeshift-de.po
+++ b/po/timeshift-de.po
@@ -427,7 +427,7 @@ msgstr "Kommentare"
 
 #: Gtk/RestoreBox.vala:74 Gtk/RestoreBox.vala:187 Core/Main.vala:2793
 msgid "Comparing Files (Dry Run)..."
-msgstr "Dateien vergleichen (Probleauf)"
+msgstr "Dateien vergleichen (Probelauf)"
 
 #: Core/Main.vala:2559
 msgid "Comparing files with rsync..."


### PR DESCRIPTION
issue: #511 and #488

Fix typo "Probleauf" to "Probelauf" 