### PR TITLE
timeshift-pt_BR.po: Fix newlines

### DIFF
--- a/po/timeshift-pt_BR.po
+++ b/po/timeshift-pt_BR.po
@@ -265,7 +265,7 @@ msgstr ""
 "Os backups do BTRFS são salvos no mesmo disco do qual ele é criado. Se o "
 "disco do sistema falhar, os backups serão perdidos juntamente com o sistema. "
 "Salve os backups em um disco externo, que não seja de sistema, no modo RSYNC "
-"para proteger contra falhas de disco.\n"
+"para proteger contra falhas de disco."
 
 #: Utility/Gtk/AboutWindow.vala:349 Utility/Gtk/AboutWindow.vala:381
 msgid "Back"
@@ -548,7 +548,7 @@ msgid ""
 "system"
 msgstr ""
 "Crie backups manualmente ou ative backups agendados para proteger o seu "
-"sistema\n"
+"sistema"
 
 #: Gtk/SnapshotBackendBox.vala:95
 #, fuzzy
@@ -1217,7 +1217,7 @@ msgid ""
 "install Timeshift, and try restoring another snapshot."
 msgstr ""
 "Se o sistema restaurado falhar ao inicializar, inicie o sistema pelo CD/USB, "
-"instale o Timeshift e tente restaurar outro backup.\n"
+"instale o Timeshift e tente restaurar outro backup."
 
 #: Core/Main.vala:2230
 msgid ""
@@ -1237,7 +1237,7 @@ msgstr ""
 
 #: Gtk/ExcludeBox.vala:54
 msgid "Include / Exclude Patterns"
-msgstr "Parâmetros de inclusão / exclusão\n"
+msgstr "Parâmetros de inclusão / exclusão"
 
 #: Gtk/UsersBox.vala:340
 msgid "Include @home subvolume in backups"
@@ -1322,11 +1322,11 @@ msgstr "Último backup da inicialização é de %d horas atrás\n"
 msgid "Last boot snapshot is older than system start time"
 msgstr ""
 "Último backup da inicialização é mais antigo do que a hora de início do "
-"sistema\n"
+"sistema"
 
 #: Core/Main.vala:1014
 msgid "Last boot snapshot not found"
-msgstr "Último backup de inicialização não foi encontrado\n"
+msgstr "Último backup de inicialização não foi encontrado"
 
 #: Core/Main.vala:1085
 #, fuzzy, c-format
@@ -1335,7 +1335,7 @@ msgstr "Último backup diário é de %d horas atrás\n"
 
 #: Core/Main.vala:1080
 msgid "Last daily snapshot is more than 1 day old"
-msgstr "Último backup diário foi feito há mais de 1 dia\n"
+msgstr "Último backup diário foi feito há mais de 1 dia"
 
 #: Core/Main.vala:1076
 msgid "Last daily snapshot not found"
@@ -1348,11 +1348,11 @@ msgstr "Último backup foi a %d minutos atrás\n"
 
 #: Core/Main.vala:1049
 msgid "Last hourly snapshot is more than 1 hour old"
-msgstr "Último backup é de mais de 1 hora atrás\n"
+msgstr "Último backup é de mais de 1 hora atrás"
 
 #: Core/Main.vala:1045
 msgid "Last hourly snapshot not found"
-msgstr "Backup da última hora não encontrado\n"
+msgstr "Backup da última hora não encontrado"
 
 #: Core/Main.vala:1147
 #, fuzzy, c-format
@@ -1361,7 +1361,7 @@ msgstr "Último backup mensal é de %d dias atrás\n"
 
 #: Core/Main.vala:1142
 msgid "Last monthly snapshot is more than 1 month old"
-msgstr "Último backup mensal foi efetuado há mais de 1 mês\n"
+msgstr "Último backup mensal foi efetuado há mais de 1 mês"
 
 #: Core/Main.vala:1138
 msgid "Last monthly snapshot not found"
@@ -1383,7 +1383,7 @@ msgstr "Último backup semanal não encontrado"
 #: Gtk/MainWindow.vala:1033
 #, c-format
 msgid "Latest snapshot"
-msgstr "Backup mais recente\n"
+msgstr "Backup mais recente"
 
 #: Utility/Gtk/AboutWindow.vala:316 Utility/Gtk/AboutWindow.vala:356
 msgid "License"
@@ -1467,7 +1467,7 @@ msgstr "Backups Mensal estão habilitados"
 
 #: Core/Main.vala:1154
 msgid "Monthly snapshot failed!"
-msgstr "Backup mensal falhou!\n"
+msgstr "Backup mensal falhou!"
 
 #: Core/Main.vala:2131 Core/Main.vala:2164
 msgid "Mount"
@@ -1505,7 +1505,7 @@ msgstr "Nenhum Backup Selecionado"
 
 #: Gtk/MainWindow.vala:1057
 msgid "No snapshots available"
-msgstr "Nenhum backup disponível\n"
+msgstr "Nenhum backup disponível"
 
 #: Gtk/MainWindow.vala:1001 Console/AppConsole.vala:321
 #: Core/SnapshotRepo.vala:914
@@ -1514,7 +1514,7 @@ msgstr "Nenhum backup encontrado"
 
 #: Console/AppConsole.vala:742
 msgid "No snapshots found on device"
-msgstr "Nenhum backup encontrado no dispositivo\n"
+msgstr "Nenhum backup encontrado no dispositivo"
 
 #: Gtk/MainWindow.vala:546
 msgid "No snapshots on device"
@@ -1592,7 +1592,7 @@ msgstr "Arquivos de log mais antigos removidos"
 
 #: Gtk/MainWindow.vala:1035
 msgid "Oldest snapshot"
-msgstr "Backup mais antigo\n"
+msgstr "Backup mais antigo"
 
 #: Gtk/SnapshotListBox.vala:297
 msgid "On demand (manual)"
@@ -1938,7 +1938,7 @@ msgid ""
 "against drive failures."
 msgstr ""
 "Salve backups em um disco externo em vez do disco do sistema, para protegê-"
-"los de falhas na unidade.\n"
+"los de falhas na unidade."
 
 #: Gtk/FinishBox.vala:97
 msgid ""
@@ -1966,7 +1966,7 @@ msgstr "Backup agendado em curso..."
 
 #: Gtk/MainWindow.vala:1051 Gtk/ScheduleBox.vala:312 Core/Main.vala:1165
 msgid "Scheduled snapshots are disabled"
-msgstr "Backups agendados estão desativados\n"
+msgstr "Backups agendados estão desativados"
 
 #: Gtk/FinishBox.vala:78
 msgid "Scheduled snapshots are disabled. It's recommended to enable it."
@@ -1974,7 +1974,7 @@ msgstr "Os backups agendados estão desativados. Recomenda-se ativá-los."
 
 #: Gtk/ScheduleBox.vala:305
 msgid "Scheduled snapshots are enabled"
-msgstr "Backups agendados estão ativados\n"
+msgstr "Backups agendados estão ativados"
 
 #: Gtk/FinishBox.vala:75
 msgid ""
@@ -2100,7 +2100,7 @@ msgstr "Selecionar o backup para restaurar"
 
 #: Gtk/DeleteWindow.vala:87
 msgid "Select the snapshots to be deleted"
-msgstr "Selecionar o backup a ser apagado\n"
+msgstr "Selecionar o backup a ser apagado"
 
 #: Gtk/MainWindow.vala:609
 msgid "Select the snapshots to mark for deletion"
@@ -2269,7 +2269,7 @@ msgstr "Localização do backup"
 
 #: Core/Main.vala:1270
 msgid "Snapshot saved successfully"
-msgstr "Backup efetuado com sucesso\n"
+msgstr "Backup efetuado com sucesso"
 
 #: Core/Main.vala:2040
 msgid "Snapshot to restore not specified!"
@@ -2362,7 +2362,7 @@ msgstr ""
 
 #: Gtk/MainWindow.vala:996
 msgid "Snapshots available for restore"
-msgstr "Backups disponíveis para ser restaurados\n"
+msgstr "Backups disponíveis para ser restaurados"
 
 #: Gtk/SnapshotBackendBox.vala:190
 msgid ""


### PR DESCRIPTION
../po/timeshift-pt_BR.po:264: 'msgid' and 'msgstr' entries do not both end with '\n'
../po/timeshift-pt_BR.po:549: 'msgid' and 'msgstr' entries do not both end with '\n'
../po/timeshift-pt_BR.po:1218: 'msgid' and 'msgstr' entries do not both end with '\n'
../po/timeshift-pt_BR.po:1240: 'msgid' and 'msgstr' entries do not both end with '\n'
../po/timeshift-pt_BR.po:1323: 'msgid' and 'msgstr' entries do not both end with '\n'
../po/timeshift-pt_BR.po:1329: 'msgid' and 'msgstr' entries do not both end with '\n'
../po/timeshift-pt_BR.po:1338: 'msgid' and 'msgstr' entries do not both end with '\n'
../po/timeshift-pt_BR.po:1351: 'msgid' and 'msgstr' entries do not both end with '\n'
../po/timeshift-pt_BR.po:1355: 'msgid' and 'msgstr' entries do not both end with '\n'
../po/timeshift-pt_BR.po:1364: 'msgid' and 'msgstr' entries do not both end with '\n'
../po/timeshift-pt_BR.po:1386: 'msgid' and 'msgstr' entries do not both end with '\n'
../po/timeshift-pt_BR.po:1470: 'msgid' and 'msgstr' entries do not both end with '\n'
../po/timeshift-pt_BR.po:1508: 'msgid' and 'msgstr' entries do not both end with '\n'
../po/timeshift-pt_BR.po:1517: 'msgid' and 'msgstr' entries do not both end with '\n'
../po/timeshift-pt_BR.po:1594: 'msgid' and 'msgstr' entries do not both end with '\n'
../po/timeshift-pt_BR.po:1938: 'msgid' and 'msgstr' entries do not both end with '\n'
../po/timeshift-pt_BR.po:1968: 'msgid' and 'msgstr' entries do not both end with '\n'
../po/timeshift-pt_BR.po:1976: 'msgid' and 'msgstr' entries do not both end with '\n'
../po/timeshift-pt_BR.po:2102: 'msgid' and 'msgstr' entries do not both end with '\n'
../po/timeshift-pt_BR.po:2270: 'msgid' and 'msgstr' entries do not both end with '\n'
../po/timeshift-pt_BR.po:2363: 'msgid' and 'msgstr' entries do not both end with '\n'
msgfmt: found 21 fatal errors