### PR TITLE
Simplify launch via pkexec

### DIFF
--- a/src/timeshift-launcher
+++ b/src/timeshift-launcher
@@ -18,7 +18,7 @@ else
 			xhost -SI:localuser:root
 			xhost
 		elif command -v pkexec >/dev/null 2>&1; then
-			pkexec env DISPLAY=$DISPLAY XAUTHORITY=$XAUTHORITY ${app_command}
+			pkexec ${app_command}
 		elif command -v sudo >/dev/null 2>&1; then
 			x-terminal-emulator -e "sudo ${app_command}"
 		elif command -v su >/dev/null 2>&1; then


### PR DESCRIPTION
- remove usage of env: when timeshift is being launched via pkexec, envs like
  DISPLAY and XAUTHORITY are inherited from the current envoronment
- when they are set explicitly via the binary /usr/bin/env, X server does not permit access,
  the old method of launching did not work on ROSA KDE 4:
  > Could not connect to display
- when /usr/bin/env is launched, the graphical policykit agent dialog shows that /usr/bin/env is being
  launched and does not show TimeShift's icon

There is no reason to use env, I believe. This patch fixes launching on ROSA.

Before (and failed to run):
![DeepinScreenshot_выберите-область_20200317110344](https://user-images.githubusercontent.com/15802528/76835290-d260a980-683f-11ea-87e1-111f3c2c9ff5.png)

After (shows a good icon and does work):
![DeepinScreenshot_выберите-область_20200317110546](https://user-images.githubusercontent.com/15802528/76835307-dd1b3e80-683f-11ea-9e94-04f043a9fe26.png)
