### PR TITLE
Fix missing hourly backups; issues #497 & #467

### DIFF
--- a/src/Core/Main.vala
+++ b/src/Core/Main.vala
@@ -1215,7 +1215,7 @@ public class Main : GLib.Object{
 					case "daily":
 					case "weekly":
 					case "monthly":
-						dt_filter = now.add_hours(-1);
+						dt_filter = now.add_hours(-1).add_seconds(59);
 						break;
 					default:
 						log_error(_("Unknown snapshot type") + ": %s".printf(tag));


### PR DESCRIPTION
The code should be changed so that choosing a snapshot to tag follows timing similar to determining if a snapshot for a tag is needed. That is, allow for the possibility that not all runs of cron start right on the same second. A safe change to do this would be to change the timestamp comparison to account for extra seconds.