### PR TITLE
Support labeled filesystems when specified in /etc/fstab

### DIFF
--- a/src/Utility/FsTabEntry.vala
+++ b/src/Utility/FsTabEntry.vala
@@ -182,7 +182,7 @@ public class FsTabEntry : GLib.Object{
 			|| mount_point.has_prefix("/media")
 			|| (mount_point == "none")
 			|| !mount_point.has_prefix("/")
-			|| (!device_string.has_prefix("/dev/") && !device_string.down().has_prefix("uuid="))){
+			|| (!device_string.has_prefix("/dev/") && !device_string.down().has_prefix("uuid=") && !device_string.down().has_prefix("label=") )){
 			
 			return false;
 		}


### PR DESCRIPTION
I usually label my filesystems, so a line like:
```UUID=00000000-0000-0000-0000-000000000000 / btrfs defaults,ssd,noatime,subvol=@ 0 1```
would become:
```LABEL=SOME_LABEL_FOR_MY_FILESYSTEM / btrfs defaults,ssd,noatime,subvol=@ 0 1```

This commit makes sure that timeshift will still create snapshots of my btrfs.