### PR TITLE
Change file trash from a gvfs-trash system call to trash() from gio-2.0.

### DIFF
--- a/src/Utility/TeeJee.FileSystem.vala
+++ b/src/Utility/TeeJee.FileSystem.vala
@@ -108,7 +108,7 @@ namespace TeeJee.FileSystem{
 
 		var file = File.new_for_path (file_path);
 		if (file.query_exists ()) {
-			Posix.system("gvfs-trash '%s'".printf(escape_single_quote(file_path)));
+			file.trash();
 		}
 		return true;
 	}

--- a/src/makefile
+++ b/src/makefile
@@ -54,7 +54,7 @@ app-gtk:
 		Core/*.vala Gtk/*.vala Utility/*.vala Utility/Gtk/*.vala \
 		-o ${app_name}-gtk \
 		--pkg glib-2.0 --pkg gio-unix-2.0 --pkg posix \
-		--pkg gee-0.8 --pkg json-glib-1.0 \
+		--pkg gee-0.8 --pkg json-glib-1.0 --pkg gio-2.0 \
 		--pkg gtk+-3.0 --pkg vte-2.91 $(xapp_pkg)
 
 app-console:
@@ -65,7 +65,7 @@ app-console:
 		Core/*.vala Utility/*.vala Utility/Gtk/*.vala Console/*.vala \
 		-o ${app_name} \
 		--pkg glib-2.0 --pkg gio-unix-2.0 --pkg posix \
-		--pkg gee-0.8 --pkg json-glib-1.0 \
+		--pkg gee-0.8 --pkg json-glib-1.0 --pkg gio-2.0 \
 		--pkg gtk+-3.0 --pkg vte-2.91 $(xapp_pkg)
 
 manpage:


### PR DESCRIPTION
Closes #661

timeshift calls the deprecated gvfs-trash(1) utility.

gvfs-trash was superseded by gio(1) in 2015 and removed from upstream GNOME
in 2018. It is currently still available in the gvfs-bin package as a
Debian-specific addition, but we want to remove it before Debian 11.

The best way to send files to the trash is to use an appropriate platform
API, such as GLib's g_file_trash() or g_file_trash_async().

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=969773