### PR TITLE
fix: add which to dependencies

### DIFF
--- a/src/Core/Main.vala
+++ b/src/Core/Main.vala
@@ -338,7 +338,7 @@ public class Main : GLib.Object{
 
 		log_debug("Main: check_dependencies()");
 		
-		string[] dependencies = { "rsync","/sbin/blkid","df","mount","umount","fuser","crontab","cp","rm","touch","ln","sync"}; //"shutdown","chroot",
+		string[] dependencies = { "rsync","/sbin/blkid","df","mount","umount","fuser","crontab","cp","rm","touch","ln","sync","which"}; //"shutdown","chroot",
 
 		string path;
 		foreach(string cmd_tool in dependencies){


### PR DESCRIPTION
`Process::get_cmd_path` requires `which`: https://github.com/teejee2008/timeshift/blob/08d0e5912b617009f2f0fdb61fb4173cb3576ed4/src/Utility/TeeJee.Process.vala#L257-L272
<!--
```vala
	// dep: which
	public string get_cmd_path (string cmd_tool){


		/* Returns the full path to a command */


		try {
			int exitCode;
			string stdout, stderr;
			Process.spawn_command_line_sync("which " + cmd_tool, out stdout, out stderr, out exitCode);
	        return stdout;
		}
		catch (Error e){
	        log_error (e.message);
	        return "";
	    }
	}
```
-->
which, `which` is not checked:
https://github.com/teejee2008/timeshift/blob/08d0e5912b617009f2f0fdb61fb4173cb3576ed4/src/Core/Main.vala#L341
<!--
```vala
	public bool check_dependencies(out string msg){
		
		msg = "";


		log_debug("Main: check_dependencies()");
		
		string[] dependencies = { "rsync","/sbin/blkid","df","mount","umount","fuser","crontab","cp","rm","touch","ln","sync"}; //"shutdown","chroot",


		string path;
		foreach(string cmd_tool in dependencies){
			path = get_cmd_path (cmd_tool);
			if ((path == null) || (path.length == 0)){
				msg += " * " + cmd_tool + "\n";
			}
		}


		if (msg.length > 0){
			msg = _("Commands listed below are not available on this system") + ":\n\n" + msg + "\n";
			msg += _("Please install required packages and try running TimeShift again");
			log_error(msg);
			return false;
		}
		else{
			return true;
		}
	}
```
-->
which, caused this bug: https://github.com/teejee2008/timeshift/issues/736
```terminal
...E: failed to execute child process "which" (No such file or directory)
```

which, could be fixed by this pull request.

---
GitHub Magic Phrase: this pull request fixes #736.