### PR TITLE
throttle io usage with ionice

### DIFF
--- a/src/Core/Main.vala
+++ b/src/Core/Main.vala
@@ -338,7 +338,7 @@ public class Main : GLib.Object{
 
 		log_debug("Main: check_dependencies()");
 		
-		string[] dependencies = { "rsync","/sbin/blkid","df","mount","umount","fuser","crontab","cp","rm","touch","ln","sync"}; //"shutdown","chroot",
+		string[] dependencies = { "rsync","/sbin/blkid","df","mount","umount","fuser","crontab","cp","rm","touch","ln","sync","ionice"}; //"shutdown","chroot",
 
 		string path;
 		foreach(string cmd_tool in dependencies){
@@ -2269,7 +2269,7 @@ public class Main : GLib.Object{
 
 		// run rsync ---------------------------------------
 
-		sh += "rsync -avir --force --delete --delete-after";
+		sh += "ionice -c idle rsync -avir --force --delete --delete-after";
 
 		if (dry_run){
 			sh += " --dry-run";
@@ -3742,7 +3742,7 @@ public class Main : GLib.Object{
 
 			save_exclude_list_for_backup(TEMP_DIR);
 			
-			cmd  = "LC_ALL=C ; rsync -ai --delete --numeric-ids --relative --stats --dry-run --delete-excluded --exclude-from='%s' /. '%s' &> '%s'".printf(file_exclude_list, dir_empty, file_log);
+			cmd  = "LC_ALL=C ; ionice -c idle rsync -ai --delete --numeric-ids --relative --stats --dry-run --delete-excluded --exclude-from='%s' /. '%s' &> '%s'".printf(file_exclude_list, dir_empty, file_log);
 
 			log_debug(cmd);
 			ret_val = exec_script_sync(cmd, out std_out, out std_err);

--- a/src/Core/SnapshotRepo.vala
+++ b/src/Core/SnapshotRepo.vala
@@ -947,7 +947,7 @@ public class SnapshotRepo : GLib.Object{
 		try{
 			var f = File.new_for_path(thr_args1);
 			if(f.query_exists()){
-				cmd = "rm -rf \"%s\"".printf(thr_args1);
+				cmd = "ionice -c idle rm -rf \"%s\"".printf(thr_args1);
 
 				if (LOG_COMMANDS) { log_debug(cmd); }
 
@@ -1027,7 +1027,7 @@ public class SnapshotRepo : GLib.Object{
 			string path = "%s-%s".printf(snapshots_path, tag);
 			var f = File.new_for_path(path);
 			if (f.query_exists()){
-				cmd = "rm -rf \"%s\"".printf(path + "/");
+				cmd = "ionice -c idle rm -rf \"%s\"".printf(path + "/");
 
 				if (LOG_COMMANDS) { log_debug(cmd); }
 

--- a/src/Utility/AsyncTask.vala
+++ b/src/Utility/AsyncTask.vala
@@ -480,7 +480,7 @@ public class RsyncTask : AsyncTask{
 	private string build_script() {
 		var script = new StringBuilder();
 
-		var cmd = "rsync -ai";
+		var cmd = "ionice -c idle rsync -ai";
 
 		if (verbose){
 			cmd += " --verbose";

--- a/src/Utility/DeleteFileTask.vala
+++ b/src/Utility/DeleteFileTask.vala
@@ -90,7 +90,7 @@ public class DeleteFileTask : AsyncTask{
 
 		if (use_rsync){
 
-			cmd += "rsync -aii";
+			cmd += "ionice -c idle rsync -aii";
 
 			if (verbose){
 				cmd += " --verbose";

--- a/src/Utility/RsyncTask.vala
+++ b/src/Utility/RsyncTask.vala
@@ -180,7 +180,7 @@ public class RsyncTask : AsyncTask{
 			//cmd += "ionice -c2 -n7 ";
 		}
 
-		cmd += "rsync -aii";
+		cmd += "ionice -c idle rsync -aii";
 
 		//if (!dry_run){
 		//	cmd += "i";

--- a/src/Utility/TeeJee.FileSystem.vala
+++ b/src/Utility/TeeJee.FileSystem.vala
@@ -354,7 +354,7 @@ namespace TeeJee.FileSystem{
 			return true;
 		}
 		
-		string cmd = "rm -rf '%s'".printf(escape_single_quote(dir_path));
+		string cmd = "ionice -c idle rm -rf '%s'".printf(escape_single_quote(dir_path));
 		
 		log_debug(cmd);
 		
@@ -579,7 +579,7 @@ namespace TeeJee.FileSystem{
 
 		/* Sync files with rsync */
 
-		string cmd = "rsync -avh";
+		string cmd = "ionice -c idle rsync -avh";
 		cmd += updateExisting ? "" : " --ignore-existing";
 		cmd += deleteExtra ? " --delete" : "";
 		cmd += " '%s'".printf(escape_single_quote(sourceDirectory) + "//");


### PR DESCRIPTION
when timeshift is performing a backup, it saturates my nvme drives to the point that other applications lock up. if we prepend the `rm` and `rsync` commands with `ionice`, this gives a better user experience.

resolves #475 
resolves #146