### PR TITLE
Fix null string causing GLib-GIO-CRITICAL (fixes #745)

### DIFF
--- a/src/Utility/IconManager.vala
+++ b/src/Utility/IconManager.vala
@@ -75,13 +75,16 @@ public class IconManager : GLib.Object {
 		}
 
 		// check relative location
-		string base_path = file_parent(file_parent(file_parent(binpath)));
+		string base_path = file_parent(file_parent(binpath));
 		if (base_path != "/"){
-			log_debug("base_path: %s".printf(base_path));
-			path = path_combine(base_path, path);
-			if (dir_exists(path)){
-				search_paths.add(path);
-				log_debug("found images directory: %s".printf(path));
+			base_path = file_parent(base_path);
+			if (base_path != "/"){
+				log_debug("base_path: %s".printf(base_path));
+				path = path_combine(base_path, path);
+				if (dir_exists(path)){
+					search_paths.add(path);
+					log_debug("found images directory: %s".printf(path));
+				}
 			}
 		}
 


### PR DESCRIPTION
Quick fix for #745

Fixes cases when called from cron, due to `PATH` order:
https://github.com/teejee2008/timeshift/blob/efed1177e3951e333ad3f30a86612b39b6a27ce3/src/Utility/CronTab.vala#L296

cron path order should probably be fixed, but this PR still fixes cases where someone wants to run `/bin/timeshift`, etc. manually