### PR TITLE
Correction of a typo - Polish translation

### DIFF
--- a/po/timeshift-pl.po
+++ b/po/timeshift-pl.po
@@ -2301,8 +2301,8 @@ msgid ""
 "Snapshots are saved to /timeshift on selected partition. Other locations are "
 "not supported."
 msgstr ""
-"Migawki są zapisywane w /timeshift na wybranej partycji. Inne lokalizacje są "
-"niewpierane."
+"Migawki są zapisywane w /timeshift na wybranej partycji. Inne lokalizacje nie "
+"są wspierane."
 
 #: Gtk/BackupDeviceBox.vala:99
 msgid ""
@@ -2310,7 +2310,7 @@ msgid ""
 "locations are not supported."
 msgstr ""
 "Migawki są zapisywane w /timeshift-btrfs na wybranej partycji. Inne "
-"lokalizacje są niewpierane."
+"lokalizacje nie są wspierane."
 
 #: Gtk/MainWindow.vala:996
 msgid "Snapshots available for restore"


### PR DESCRIPTION
Correction of a typo: "wpierane" to "wspierane", 2 occurrences.