### PR TITLE
Force rsync to output decimals in C locale

### DIFF
--- a/src/Utility/RsyncTask.vala
+++ b/src/Utility/RsyncTask.vala
@@ -174,7 +174,7 @@ public class RsyncTask : AsyncTask{
 
 	private string build_script() {
 		
-		var cmd = "";
+		var cmd = "export LC_ALL=C.UTF-8\n";
 
 		if (io_nice){
 			//cmd += "ionice -c2 -n7 ";


### PR DESCRIPTION
Based on the changelog of rsync 3.2.4 - https://download.samba.org/pub/rsync/NEWS#3.2.4

> A long-standing bug was preventing rsync from figuring out the current locale's decimal point character, which made rsync always output numbers using the "C" locale. Since this is now fixed in 3.2.4, a script that parses rsync's decimal numbers (e.g. from the verbose footer) may want to setup the environment in a way that the output continues to be in the C locale. For instance, one of the following should work fine:
```
    export LC_ALL=C.UTF-8
```

Closes #891 